### PR TITLE
String escape performances

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -205,6 +205,17 @@ Object.defineProperty(
 // 34 and 92 happens all the time, so we
 // have a fast case for them
 function escape (s) {
+  var point = 255
+  for (var i = 0, l = s.length; i < l && point > 31; i++) {
+    point = s.charCodeAt(i)
+    if (point === 34 || point === 92) {
+      s = s.slice(0, i) + '\\' + s.slice(i++)
+      l++
+    }
+  }
+  return point < 32 ? JSON.stringify(s) : '"' + s + '"'
+}
+/* function escape (s) {
   var str = s.toString()
   var result = ''
   var last = 0
@@ -223,7 +234,7 @@ function escape (s) {
     result += str.slice(last)
   }
   return point < 32 ? JSON.stringify(str) : '"' + result + '"'
-}
+} */
 
 Pino.prototype.asJson = function asJson (obj, msg, num) {
   if (!msg && obj instanceof Error) {


### PR DESCRIPTION
I've made some experiments with the string stringify to find the fast way to manage unicode characters.
I wrote a benchmark that tests `JSON.stringify` as is, `escape` and `asStr` (the function that I wrote).
Comparing my results with the Matteo's one, we found some differences.

Here is the result of mine benchmarks:

``` bash
short 33
long 541
freakingLong 541000

long-stringify: 2.625ms
long-asString: 2.460ms
long-asStr: 2.166ms

short-stringify: 0.006ms
short-asString: 0.050ms
short-asStr: 0.010ms

JSON.stringify - freaking long x 524 ops/sec ±1.07% (88 runs sampled)
asStringSmall - freaking long x 506 ops/sec ±1.05% (84 runs sampled)
asStr - freaking long x 509 ops/sec ±1.03% (89 runs sampled)

JSON.stringify - long x 433,415 ops/sec ±1.01% (91 runs sampled)
asStringSmall - long x 437,293 ops/sec ±1.03% (86 runs sampled)
asStr - long x 441,310 ops/sec ±1.02% (87 runs sampled)

JSON.stringify - short x 3,546,163 ops/sec ±0.95% (90 runs sampled)
asStringSmall - short x 2,312,364 ops/sec ±0.85% (91 runs sampled)
asStr - short x 1,914,376 ops/sec ±0.90% (91 runs sampled)
```

Here there are the gist of the two [escape functions](https://gist.github.com/delvedor/7d747487dc18ad3e52feb555969ee97a) and the [benchmark](https://gist.github.com/delvedor/23111168392d83a4f994a26bdf7822b6).
As you can see `JSON.stringify` is faster in the _freaking long_ and _short_ strings, while is slower in the _long_ case.
If you run the pino bench with `asStr` pino is slower, but in the raw bench `asStr` is faster than `escape`.
Am I missing something?

`asStr` code:

``` js
function asStr (str) {
  var point = 255
  for (var i = 0, l = str.length; i < l && point > 31; i++) {
    point = str.charCodeAt(i)
    if (point === 34 || point === 92) {
      str = str.slice(0, i) + '\\' + str.slice(i++)
      l++
    }
  }
  return point < 32 ? JSON.stringify(str) : '"' + str + '"'
}
```

Related: 
https://github.com/mcollina/fast-json-stringify/pull/14
