### PR TITLE
Add formatter option for `pino.pretty()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,8 @@ Options:
 
 * `timeTransOnly`, if set to `true`, it will only covert the unix timestamp to
   ISO 8601 date format, and reserialize the JSON (equivalent to `pino -t`).
+* `formatter`, a custom function to format the line, is passed the JSON
+  object as an argument and should return a string value
 
 You can use the pretty transformer internally, like so:
 
@@ -785,12 +787,12 @@ pino.info({
     to: {key: 'sensitive', another: 'thing'}
   },
   more: 'stuff'
-}) 
+})
 
 // {"pid":7306,"hostname":"x","level":30,"time":1475519922198,"key":"[Redacted]","path":{"to":{"key":"[Redacted]","another":"thing"}},"more":"stuff","v":1}
 ```
 
-If you have other serializers simply extend: 
+If you have other serializers simply extend:
 
 ```js
 var noir = require('pino-noir')

--- a/pretty.js
+++ b/pretty.js
@@ -52,6 +52,7 @@ function isPinoLine (line) {
 
 function pretty (opts) {
   var timeTransOnly = opts && opts.timeTransOnly
+  var formatter = opts && opts.formatter
   var levelFirst = opts && opts.levelFirst
 
   var stream = split(mapLine)
@@ -86,6 +87,10 @@ function pretty (opts) {
     if (parsed.err || !isPinoLine(value)) {
       // pass through
       return line + '\n'
+    }
+
+    if (formatter) {
+      return opts.formatter(parsed.value) + '\n'
     }
 
     if (timeTransOnly) {

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -49,6 +49,20 @@ test('pino transform can just parse the dates', function (t) {
   instance.info('hello world')
 })
 
+test('pino transform can format with a custom function', function (t) {
+  t.plan(1)
+  var pretty = pino.pretty({ formatter: function (line) {
+    return 'msg: ' + line.msg + ', foo: ' + line.foo
+  } })
+  pretty.pipe(split(function (line) {
+    t.ok(line === 'msg: hello world, foo: bar', 'line matches')
+    return line
+  }))
+  var instance = pino(pretty)
+
+  instance.info({foo: 'bar'}, 'hello world')
+})
+
 test('pino transform prettifies Error', function (t) {
   var pretty = pino.pretty()
   var err = new Error('hello world')


### PR DESCRIPTION
Allows the application to define its own formatter for the `pino.pretty()` transform stream.

resolves #120