### PR TITLE
Refactor internal Pino to use an options object

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -4,6 +4,7 @@ var stringifySafe = require('fast-safe-stringify')
 var format = require('quick-format')
 var EventEmitter = require('events').EventEmitter
 var os = require('os')
+var fs = require('fs')
 var flatstr = require('flatstr')
 var once = require('once')
 var pid = process.pid
@@ -104,7 +105,7 @@ function pino (opts, stream) {
         // to the destination stream. We do that by forcing a synchronous
         // write directly to the stream's file descriptor.
         var fd = (istream.fd) ? istream.fd : istream._handle.fd
-        require('fs').writeSync(fd, buf)
+        fs.writeSync(fd, buf)
       }
       if (!process._events[evt] || process._events[evt].length < 2 || !process._events[evt].filter(function (f) {
         return f + '' !== onExit.passCode + '' && f + '' !== onExit.insertCode + ''


### PR DESCRIPTION
In order to solve #124 I intend to associate the levels with the actual `Pino` instance returned by `pino`. To do that, I will need to add another parameter to the `Pino` constructor. I think the constructor already has way too many parameters, so I refactored it to accept only two such that the signature is `Pino(opts, stream)`.

Running the basic benchmark on the master branch and this branch 3 times each and averaging the results, I get:

+ refactored bench average: 235.316333
+ master bench average: 237.611667

Thus, this refactor is equally performant.