### PR TITLE
Add a ready event for extreme mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ This has a couple of important caveats:
   * For instance, a powercut will mean up to 4KB of buffered logs will be lost
   * A sigkill (or other untrappable signal) will probably result in the same
   * If writing to a stream other than `process.stdout` or `process.stderr`, there is a slight possibility of lost logs or even partially written logs if the OS buffers don't have enough space, or something else is being written to the stream (or maybe some other reason we've not thought of)
-* If you supply an alternate stream to the constructor, then that stream must support synchronous writes so that it can be properly flushed on exit. This means the stream must expose its file descriptor via `stream.fd` or `stream._handle.fd`. Usually they have to be native (from core) stream, meaning a TCP/unix socket, a file, or stdout/sderr. If your stream is invalid an `error` event will be emitted on the returned logger, e.g.:
+* If you supply an alternate stream to the constructor, then that stream must support synchronous writes so that it can be properly flushed on exit. This means the stream must expose its file descriptor via `stream.fd` or `stream._handle.fd`. Usually they have to be native (from core) stream, meaning a TCP/unix socket, a file, or stdout/sderr. If your stream is invalid an `error` event will be emitted on the returned logger, otherwise the `ready` event will be emitted. For example:
 
   ```js
   var stream = require('stream')
@@ -617,9 +617,15 @@ This has a couple of important caveats:
   var logger = pino({extreme: true}, new stream.Writable({write: function (chunk) {
     // do something with chunk
   }}))
+
   logger.on('error', function (err) {
     console.error('pino logger cannot flush on exit due to provided output stream')
     process.exit(1)
+  })
+
+  logger.on('ready', function (_logger) {
+    // _logger === logger
+    logger.info('pino extreme mode is ready to be used')
   })
   ```
 

--- a/pino.js
+++ b/pino.js
@@ -110,13 +110,18 @@ function pino (opts, stream) {
     // but setTimeout isn't *shrug*
     setTimeout(function () {
       if (!streamIsBlockable(istream)) {
-        logger.emit('error', new Error('stream must have a file descriptor in extreme mode'))
+        return logger.emit('error', new Error('stream must have a file descriptor in extreme mode'))
       }
+      logger.emit('ready', logger)
     }, 100)
 
     onExit(function (code, evt) {
       var buf = iopts.cache.buf
       if (buf) {
+        // If the user failed to listen for the `error` event then we have
+        // to pretend like they don't care about the rest of the buffer.
+        if (!streamIsBlockable(istream)) return
+
         // We need to block the process exit long enough to flush the buffer
         // to the destination stream. We do that by forcing a synchronous
         // write directly to the stream's file descriptor.

--- a/test/extreme.test.js
+++ b/test/extreme.test.js
@@ -143,3 +143,15 @@ test('flush does nothing without stream mode', function (t) {
   instance.flush()
   t.end()
 })
+
+test('emits ready event with valid stream', function (t) {
+  delete require.cache[require.resolve('../')]
+  var pino = require('../')
+  var dest = fs.createWriteStream('/dev/null')
+  var extreme = pino({extreme: true}, dest)
+
+  extreme.on('ready', function (logger) {
+    t.is(logger, extreme)
+    t.end()
+  })
+})


### PR DESCRIPTION
This is to make #131 less of an issue. We can't really fail gracefully at that point due to the asynchronous nature of waiting for file descriptors to settle. So the next best thing is to give the extreme mode user a `ready` event so that they know when the logger is fully vetted and ready to go. But they *really* need to listen for the `error` event to know if the stream they have supplied is valid.