### PR TITLE
Add new err-serializer that serializes all error properties

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -364,11 +364,17 @@ function asResValue (res) {
 }
 
 function asErrValue (err) {
-  return {
+  var obj = {
     type: err.constructor.name,
     message: err.message,
     stack: err.stack
   }
+  for (var key in err) {
+    if (obj[key] === undefined) {
+      obj[key] = err[key]
+    }
+  }
+  return obj
 }
 
 function countInterp (s, i) {


### PR DESCRIPTION
This replaces the core serializer with the one I made in https://github.com/IndigoUnited/pino-err-serializer.

Before merging, I need to port the tests to this repo. Any guidance to were these should be added?

There's https://github.com/pinojs/pino/blob/master/test/serializers.test.js but it doesn't actually test the core serializers.