### PR TITLE
#135 - child logger names

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -272,8 +272,8 @@ Pino.prototype.child = function child (bindings) {
   if (!bindings) {
     throw new Error('missing bindings for child Pino')
   }
-  
-  if (bindings.name && 'string' !== typeof bindings.name) {
+
+  if (bindings.name && typeof bindings.name !== 'string') {
     throw new Error('when provided, bindings.name must be a string for child Pino')
   }
 

--- a/pino.js
+++ b/pino.js
@@ -272,6 +272,10 @@ Pino.prototype.child = function child (bindings) {
   if (!bindings) {
     throw new Error('missing bindings for child Pino')
   }
+  
+  if (bindings.name && 'string' !== typeof bindings.name) {
+    throw new Error('when provided, bindings.name must be a string for child Pino')
+  }
 
   var data = ','
   var value
@@ -291,7 +295,7 @@ Pino.prototype.child = function child (bindings) {
     serializers: bindings.hasOwnProperty('serializers') ? Object.assign(this.serializers, bindings.serializers) : this.serializers,
     stringify: this.stringify,
     end: this.end,
-    name: this.name,
+    name: bindings.name || this.name,
     timestamp: this.timestamp,
     slowtime: this.slowtime,
     chindings: data,


### PR DESCRIPTION
This does the trick.

I also thought about fixing the name in the chindings if it's found there - just because in this case we may be able to prevent this duplication from resulting strings.

But - I could not find a robust and high performing way that that in case there are nested objects with name property - will replace the right name attribute ... 😛 

solves #135 