### PR TITLE
Err serializer tests

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -364,11 +364,17 @@ function asResValue (res) {
 }
 
 function asErrValue (err) {
-  return {
+  var obj = {
     type: err.constructor.name,
     message: err.message,
     stack: err.stack
   }
+  for (var key in err) {
+    if (obj[key] === undefined) {
+      obj[key] = err[key]
+    }
+  }
+  return obj
 }
 
 function countInterp (s, i) {

--- a/pino.js
+++ b/pino.js
@@ -157,7 +157,6 @@ function Pino (opts, stream) {
     if (levelIsStandard === false && valIsStandard === false) this.addLevel(opts.level, opts.levelVal)
   }
   this._setLevel(opts.level)
-
   this._baseLog = flatstr(baseLog +
     (this.name === undefined ? '' : '"name":' + this.stringify(this.name) + ','))
 
@@ -241,14 +240,13 @@ Pino.prototype.asJson = function asJson (obj, msg, num) {
   if (obj) {
     if (obj.stack) {
       data += ',"type":"Error","stack":' + this.stringify(obj.stack)
-    } else {
-      for (var key in obj) {
-        value = obj[key]
-        if (obj.hasOwnProperty(key) && value !== undefined) {
-          value = this.stringify(this.serializers[key] ? this.serializers[key](value) : value)
-          if (value !== undefined) {
-            data += ',"' + key + '":' + value
-          }
+    }
+    for (var key in obj) {
+      value = obj[key]
+      if (obj.hasOwnProperty(key) && value !== undefined) {
+        value = this.stringify(this.serializers[key] ? this.serializers[key](value) : value)
+        if (value !== undefined) {
+          data += ',"' + key + '":' + value
         }
       }
     }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -67,28 +67,6 @@ function levelTest (name, level) {
     instance[name]('hello %d', 42)
   })
 
-  test('passing error at level ' + name, function (t) {
-    t.plan(2)
-    var err = new Error('myerror')
-    var instance = pino(sink(function (chunk, enc, cb) {
-      t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
-      delete chunk.time
-      t.deepEqual(chunk, {
-        pid: pid,
-        hostname: hostname,
-        level: level,
-        type: 'Error',
-        msg: err.message,
-        stack: err.stack,
-        v: 1
-      })
-      cb()
-    }))
-
-    instance.level = name
-    instance[name](err)
-  })
-
   test('passing error with a serializer at level ' + name, function (t) {
     t.plan(2)
     var err = new Error('myerror')

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -1,0 +1,78 @@
+'use strict'
+var test = require('tap').test
+var pino = require('../')
+var sink = require('./helper').sink
+
+var os = require('os')
+var pid = process.pid
+var hostname = os.hostname()
+var level = 50
+var name = 'error'
+
+test('err is serialized with additional properties set on the Error object', function (t) {
+  t.plan(2)
+  var err = Object.assign(new Error('myerror'), {foo: 'bar'})
+  var instance = pino(sink(function (chunk, enc, cb) {
+    t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
+    delete chunk.time
+    t.deepEqual(chunk, {
+      pid: pid,
+      hostname: hostname,
+      level: level,
+      type: 'Error',
+      msg: err.message,
+      stack: err.stack,
+      foo: err.foo,
+      v: 1
+    })
+    cb()
+  }))
+
+  instance.level = name
+  instance[name](err)
+})
+
+test('type should be retained, even if type is a property', function (t) {
+  t.plan(2)
+  var err = Object.assign(new Error('myerror'), {type: 'bar'})
+  var instance = pino(sink(function (chunk, enc, cb) {
+    t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
+    delete chunk.time
+    t.deepEqual(chunk, {
+      pid: pid,
+      hostname: hostname,
+      level: level,
+      type: 'bar',
+      msg: err.message,
+      stack: err.stack,
+      v: 1
+    })
+    cb()
+  }))
+
+  instance.level = name
+  instance[name](err)
+})
+
+test('type, message and stack should be first level properties', function (t) {
+  t.plan(2)
+  var err = Object.assign(new Error('foo'), { foo: 'bar' })
+  var instance = pino(sink(function (chunk, enc, cb) {
+    t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
+    delete chunk.time
+    t.deepEqual(chunk, {
+      pid: pid,
+      hostname: hostname,
+      level: level,
+      type: 'Error',
+      msg: err.message,
+      stack: err.stack,
+      foo: err.foo,
+      v: 1
+    })
+    cb()
+  }))
+
+  instance.level = name
+  instance[name](err)
+})


### PR DESCRIPTION
I've ported across the tests for err-serializer.

Not sure if you'd prefer it in a separate branch or within the other PR. I can work in a fork of the PR if that makes more sense. 

I had to make a change to pino.js to remove the else in the if(obj.stack) check on line 244, not sure if that was the right approach?