### PR TITLE
Fix prettifier crashing when receiving the line: `null`

### DIFF
--- a/pretty.js
+++ b/pretty.js
@@ -47,6 +47,7 @@ function filter (value) {
 }
 
 function isPinoLine (line) {
+  if (line === null || line === undefined) return false
   return line.hasOwnProperty('hostname') && line.hasOwnProperty('pid') && (line.hasOwnProperty('v') && line.v === 1)
 }
 

--- a/pretty.js
+++ b/pretty.js
@@ -47,7 +47,7 @@ function filter (value) {
 }
 
 function isPinoLine (line) {
-  if (line === null || line === undefined) return false
+  if (line === null) return false
   return line.hasOwnProperty('hostname') && line.hasOwnProperty('pid') && (line.hasOwnProperty('v') && line.v === 1)
 }
 

--- a/pretty.js
+++ b/pretty.js
@@ -47,8 +47,10 @@ function filter (value) {
 }
 
 function isPinoLine (line) {
-  if (line === null) return false
-  return line.hasOwnProperty('hostname') && line.hasOwnProperty('pid') && (line.hasOwnProperty('v') && line.v === 1)
+  return line &&
+    line.hasOwnProperty('hostname') &&
+    line.hasOwnProperty('pid') &&
+    (line.hasOwnProperty('v') && line.v === 1)
 }
 
 function pretty (opts) {

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -139,3 +139,25 @@ test('pino transform treats the name with care', function (t) {
 
   instance.info('hello world')
 })
+
+test('handles `null` input', function (t) {
+  t.plan(1)
+  var pretty = pino.pretty()
+  pretty.pipe(split(function (line) {
+    t.is(line, 'null')
+    return line
+  }))
+  pretty.write('null')
+  pretty.end()
+})
+
+test('handles `undefined` input', function (t) {
+  t.plan(1)
+  var pretty = pino.pretty()
+  pretty.pipe(split(function (line) {
+    t.is(line, 'undefined')
+    return line
+  }))
+  pretty.write('undefined')
+  pretty.end()
+})

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -161,3 +161,14 @@ test('handles `undefined` input', function (t) {
   pretty.write('undefined')
   pretty.end()
 })
+
+test('handles `true` input', function (t) {
+  t.plan(1)
+  var pretty = pino.pretty()
+  pretty.pipe(split(function (line) {
+    t.is(line, 'true')
+    return line
+  }))
+  pretty.write('true')
+  pretty.end()
+})


### PR DESCRIPTION
Issue #154 shows that if the prettifier receives a line value that is the literal text `null\n`, then `isPinoLine` will fail. The issue is that the spec (https://tools.ietf.org/html/rfc7159#section-3) allows literal values `null`, `true`, and `false` as valid JSON in addition to `[]` and `{}`. But `null` is not an object, so it doesn't have the `hasOwnProperty` method; thus the crash.