### PR TITLE
addLevel bugfixes

### DIFF
--- a/test/addlevel.test.js
+++ b/test/addlevel.test.js
@@ -23,9 +23,9 @@ test('can add a custom level to a prior instance', function (t) {
     t.is(chunk.msg, 'bar')
   }))
 
-  log.addLevel('foo', 35)
-  t.is(typeof log.foo, 'function')
-  log.foo('bar')
+  log.addLevel('foo2', 35)
+  t.is(typeof log.foo2, 'function')
+  log.foo2('bar')
 })
 
 test('custom levels encompass higher levels', function (t) {

--- a/test/addlevel.test.js
+++ b/test/addlevel.test.js
@@ -37,6 +37,17 @@ test('custom level via constructor does not affect other instances', function (t
   t.is(typeof other.foo3, 'undefined')
 })
 
+test('custom level on one instance does not affect other instances', function (t) {
+  t.plan(2)
+
+  var log = pino()
+  log.addLevel('foo4', 37)
+  var other = pino()
+  log.addLevel('foo5', 38)
+  t.is(typeof other.foo4, 'undefined')
+  t.is(typeof other.foo5, 'undefined')
+})
+
 test('custom levels encompass higher levels', function (t) {
   t.plan(1)
 
@@ -70,6 +81,19 @@ test('children can be set to custom level', function (t) {
     t.is(chunk.child, 'yes')
     cb()
   }))
+  var child = parent.child({child: 'yes'})
+  child.foo('bar')
+})
+
+test('custom levels exists on children', function (t) {
+  t.plan(2)
+
+  var parent = pino({}, sink(function (chunk, enc, cb) {
+    t.is(chunk.msg, 'bar')
+    t.is(chunk.child, 'yes')
+    cb()
+  }))
+  parent.addLevel('foo', 35)
   var child = parent.child({child: 'yes'})
   child.foo('bar')
 })

--- a/test/addlevel.test.js
+++ b/test/addlevel.test.js
@@ -28,6 +28,15 @@ test('can add a custom level to a prior instance', function (t) {
   log.foo2('bar')
 })
 
+test('custom level via constructor does not affect other instances', function (t) {
+  t.plan(2)
+
+  var log = pino({level: 'foo3', levelVal: 36})
+  var other = pino()
+  t.is(typeof log.foo3, 'function')
+  t.is(typeof other.foo3, 'undefined')
+})
+
 test('custom levels encompass higher levels', function (t) {
   t.plan(1)
 


### PR DESCRIPTION
This PR fixes #167

I've split it into three commits.

- a18f09244a28af865bdda1c96f501812b5504f3e Modifies the existing test to show that the current code fails
- dbdd81956087a54a2efbc3f203f16ea7bff1ea10 Adds a new test, that fails, to show that levels created via the constructor exists on other instances as well
- 886be9cce333ec8f230673bc456317cac379d05b Fixes the problems by not sharing levels and lscache between instances.


## Solution
Default `levels` and `_lscache` properties have been added to `Pino.prototype`. These are used when no custom levels have been added. 

##### addLevel()
The first time `addLevel()` is called on a `Pino` instance, new copies of `levels` and `_lscache` are created on the instance and these are then modified to include the new level.


##### Children of parents with custom levels
If a logger instance has custom levels, these are copied over to children as well, when `child()` is called. 

#### NOTE: Parent and children share `levels` and `_lscache`
The objects in `levels` and `_lscache` are shared between the parent and children. This means that if `addLevel` is called on one instance, all others `levels` and `_lscache` properties will contain the new level as well.

I choose to do it like this, in order to not make copies for every child. I think this is a fair tradeoff. 
Custom levels should be added to the first logger instance, before any child logs have been created, and no new levels should be added after that. `API.md` should probably include a comment about this.