### PR TITLE
Fix http response filtering

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -388,14 +388,6 @@ function countInterp (s, i) {
   return n
 }
 
-function isHttpRequest (m) {
-  return m.method && m.headers && m.socket
-}
-
-function isHttpResponse (m) {
-  return typeof m.setHeader === 'function'
-}
-
 function genLog (z) {
   return function LOG (a, b, c, d, e, f, g, h, i, j, k) {
     var l = 0
@@ -408,9 +400,9 @@ function genLog (z) {
       n = [b, c, d, e, f, g, h, i, j, k]
       l = 1
 
-      if (isHttpRequest(m)) {
+      if (m.method && m.headers && m.socket) {
         m = mapHttpRequest(m)
-      } else if (isHttpResponse(m)) {
+      } else if (typeof m.setHeader === 'function') {
         m = mapHttpResponse(m)
       }
     } else {

--- a/pino.js
+++ b/pino.js
@@ -388,6 +388,14 @@ function countInterp (s, i) {
   return n
 }
 
+function isHttpRequest (m) {
+  return m.method && m.headers && m.socket
+}
+
+function isHttpResponse (m) {
+  return typeof m.setHeader === 'function'
+}
+
 function genLog (z) {
   return function LOG (a, b, c, d, e, f, g, h, i, j, k) {
     var l = 0
@@ -400,9 +408,9 @@ function genLog (z) {
       n = [b, c, d, e, f, g, h, i, j, k]
       l = 1
 
-      if (m.method && m.headers && m.socket) {
+      if (isHttpRequest(m)) {
         m = mapHttpRequest(m)
-      } else if (m.statusCode) {
+      } else if (isHttpResponse(m)) {
         m = mapHttpResponse(m)
       }
     } else {

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -105,3 +105,26 @@ test('err serializer', function (t) {
   instance.level = name
   instance[name]({ err })
 })
+
+test('an error with statusCode property is not confused for a http response', function (t) {
+  t.plan(2)
+  var err = Object.assign(new Error('StatusCodeErr'), { statusCode: 500 })
+  var instance = pino(sink(function (chunk, enc, cb) {
+    t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
+    delete chunk.time
+    t.deepEqual(chunk, {
+      pid: pid,
+      hostname: hostname,
+      level: level,
+      type: 'Error',
+      msg: err.message,
+      stack: err.stack,
+      statusCode: err.statusCode,
+      v: 1
+    })
+    cb()
+  }))
+
+  instance.level = name
+  instance[name](err)
+})


### PR DESCRIPTION
@mcollina In order to distinguish http response I have also tried to use `instanceof`. I decided to go for `setHeader` as you suggested because it seems slightly faster.

I would be happy to improve the PR and integrate your comments.

Fixes https://github.com/pinojs/pino/issues/175