### PR TITLE
Reorganize code for legibility

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -1,0 +1,26 @@
+'use strict'
+
+var once = require('once')
+
+function onExit (fn) {
+  var oneFn = once(fn)
+  process.on('beforeExit', handle('beforeExit'))
+  process.on('exit', handle('exit'))
+  process.on('uncaughtException', handle('uncaughtException', 1))
+  process.on('SIGHUP', handle('SIGHUP', 129))
+  process.on('SIGINT', handle('SIGINT', 130))
+  process.on('SIGQUIT', handle('SIGQUIT', 131))
+  process.on('SIGTERM', handle('SIGTERM', 143))
+  function handle (evt, code) {
+    onExit.passCode = function (code) {
+      if (oneFn.value) { oneFn = once(fn) }
+      oneFn(code, evt)
+    }
+    onExit.insertCode = function () {
+      if (oneFn.value) { oneFn = once(fn) }
+      oneFn(code, evt)
+    }
+    return (code === undefined) ? onExit.passCode : onExit.insertCode
+  }
+}
+module.exports.onExit = onExit

--- a/lib/events.js
+++ b/lib/events.js
@@ -23,4 +23,7 @@ function onExit (fn) {
     return (code === undefined) ? onExit.passCode : onExit.insertCode
   }
 }
-module.exports.onExit = onExit
+
+module.exports = {
+  onExit: onExit
+}

--- a/lib/levels.js
+++ b/lib/levels.js
@@ -1,0 +1,49 @@
+'use strict'
+
+var flatstr = require('flatstr')
+
+var levels = {
+  fatal: 60,
+  error: 50,
+  warn: 40,
+  info: 30,
+  debug: 20,
+  trace: 10
+}
+module.exports.levels = levels
+
+var nums = Object.keys(levels).reduce(function (o, k) {
+  o[levels[k]] = k
+  return o
+}, {})
+module.exports.nums = nums
+
+// level string cache
+var lscache = Object.keys(nums).reduce(function (o, k) {
+  o[k] = flatstr('"level":' + Number(k))
+  return o
+}, {})
+module.exports.lscache = lscache
+
+// IIFE so the keys are cached at module load
+var isStandardLevel = (function () {
+  var keys = Object.keys(levels)
+  return function (level) {
+    if (Infinity === level) {
+      return true
+    }
+    return keys.indexOf(level) > -1
+  }
+}())
+module.exports.isStandardLevel = isStandardLevel
+
+var isStandardLevelVal = (function () {
+  var keys = Object.keys(nums)
+  return function (val) {
+    if (!isFinite(val)) {
+      return true
+    }
+    return keys.indexOf(val + '') > -1
+  }
+}())
+module.exports.isStandardLevelVal = isStandardLevelVal

--- a/lib/levels.js
+++ b/lib/levels.js
@@ -10,20 +10,17 @@ var levels = {
   debug: 20,
   trace: 10
 }
-module.exports.levels = levels
 
 var nums = Object.keys(levels).reduce(function (o, k) {
   o[levels[k]] = k
   return o
 }, {})
-module.exports.nums = nums
 
 // level string cache
 var lscache = Object.keys(nums).reduce(function (o, k) {
   o[k] = flatstr('"level":' + Number(k))
   return o
 }, {})
-module.exports.lscache = lscache
 
 // IIFE so the keys are cached at module load
 var isStandardLevel = (function () {
@@ -35,7 +32,6 @@ var isStandardLevel = (function () {
     return keys.indexOf(level) > -1
   }
 }())
-module.exports.isStandardLevel = isStandardLevel
 
 var isStandardLevelVal = (function () {
   var keys = Object.keys(nums)
@@ -46,4 +42,11 @@ var isStandardLevelVal = (function () {
     return keys.indexOf(val + '') > -1
   }
 }())
-module.exports.isStandardLevelVal = isStandardLevelVal
+
+module.exports = {
+  levels: levels,
+  nums: nums,
+  lscache: lscache,
+  isStandardLevel: isStandardLevel,
+  isStandardLevelVal: isStandardLevelVal
+}

--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -9,7 +9,6 @@ function asReqValue (req) {
     remotePort: req.connection.remotePort
   }
 }
-module.exports.asReqValue = asReqValue
 
 function asResValue (res) {
   return {
@@ -17,21 +16,18 @@ function asResValue (res) {
     header: res._header
   }
 }
-module.exports.asResValue = asResValue
 
 function mapHttpRequest (req) {
   return {
     req: asReqValue(req)
   }
 }
-module.exports.mapHttpRequest = mapHttpRequest
 
 function mapHttpResponse (res) {
   return {
     res: asResValue(res)
   }
 }
-module.exports.mapHttpResponse = mapHttpResponse
 
 function asErrValue (err) {
   var obj = {
@@ -46,4 +42,11 @@ function asErrValue (err) {
   }
   return obj
 }
-module.exports.asErrValue = asErrValue
+
+module.exports = {
+  asReqValue: asReqValue,
+  asResValue: asResValue,
+  mapHttpRequest: mapHttpRequest,
+  mapHttpResponse: mapHttpResponse,
+  asErrValue: asErrValue
+}

--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -1,0 +1,49 @@
+'use strict'
+
+function asReqValue (req) {
+  return {
+    method: req.method,
+    url: req.url,
+    headers: req.headers,
+    remoteAddress: req.connection.remoteAddress,
+    remotePort: req.connection.remotePort
+  }
+}
+module.exports.asReqValue = asReqValue
+
+function asResValue (res) {
+  return {
+    statusCode: res.statusCode,
+    header: res._header
+  }
+}
+module.exports.asResValue = asResValue
+
+function mapHttpRequest (req) {
+  return {
+    req: asReqValue(req)
+  }
+}
+module.exports.mapHttpRequest = mapHttpRequest
+
+function mapHttpResponse (res) {
+  return {
+    res: asResValue(res)
+  }
+}
+module.exports.mapHttpResponse = mapHttpResponse
+
+function asErrValue (err) {
+  var obj = {
+    type: err.constructor.name,
+    message: err.message,
+    stack: err.stack
+  }
+  for (var key in err) {
+    if (obj[key] === undefined) {
+      obj[key] = err[key]
+    }
+  }
+  return obj
+}
+module.exports.asErrValue = asErrValue

--- a/lib/time.js
+++ b/lib/time.js
@@ -12,6 +12,8 @@ function getSlowTime () {
   return ',"time":"' + (new Date()).toISOString() + '"'
 }
 
-module.exports.getNoTime = getNoTime
-module.exports.getTime = getTime
-module.exports.getSlowTime = getSlowTime
+module.exports = {
+  getNoTime: getNoTime,
+  getTime: getTime,
+  getSlowTime: getSlowTime
+}

--- a/lib/time.js
+++ b/lib/time.js
@@ -1,0 +1,17 @@
+'use strict'
+
+function getNoTime () {
+  return ''
+}
+
+function getTime () {
+  return ',"time":' + Date.now()
+}
+
+function getSlowTime () {
+  return ',"time":"' + (new Date()).toISOString() + '"'
+}
+
+module.exports.getNoTime = getNoTime
+module.exports.getTime = getTime
+module.exports.getSlowTime = getSlowTime

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,0 +1,124 @@
+'use strict'
+
+var flatstr = require('flatstr')
+var format = require('quick-format-unescaped')
+var util = require('util')
+var pid = process.pid
+var os = require('os')
+var hostname = os.hostname()
+var baseLog = flatstr('{"pid":' + pid + ',"hostname":"' + hostname + '",')
+var levels = require(require.resolve('./levels'))
+var serializers = require(require.resolve('./serializers'))
+var time = require(require.resolve('./time'))
+
+function noop () {}
+module.exports.noop = noop
+
+function copy (a, b) {
+  for (var k in b) { a[k] = b[k] }
+  return a
+}
+module.exports.copy = copy
+
+// Must be invoked via .call() to retain speed of inlining into the
+// Pino constructor.
+function applyOptions (opts) {
+  this.serializers = opts.serializers
+  this.stringify = opts.stringify
+  this.end = opts.end
+  this.name = opts.name
+  this.timestamp = opts.timestamp
+  this.slowtime = opts.slowtime
+  this.chindings = opts.chindings
+  this.cache = opts.cache
+  this.formatOpts = opts.formatOpts
+
+  if (opts.level && opts.levelVal) {
+    var levelIsStandard = levels.isStandardLevel(opts.level)
+    var valIsStandard = levels.isStandardLevelVal(opts.levelVal)
+    if (valIsStandard) throw Error('level value is already used: ' + opts.levelVal)
+    if (levelIsStandard === false && valIsStandard === false) this.addLevel(opts.level, opts.levelVal)
+  }
+  this._setLevel(opts.level)
+  this._baseLog = flatstr(baseLog +
+    (this.name === undefined ? '' : '"name":' + this.stringify(this.name) + ','))
+
+  if (opts.timestamp === false) {
+    this.time = time.getNoTime
+  } else if (opts.slowtime) {
+    this.time = time.getSlowTime
+  } else {
+    this.time = time.getTime
+  }
+}
+module.exports.applyOptions = applyOptions
+
+function defineLevelsProperty (onObject) {
+  Object.defineProperty(onObject, 'levels', {
+    value: {
+      values: copy({}, levels.levels),
+      labels: copy({}, levels.nums)
+    },
+    enumerable: true
+  })
+  Object.defineProperty(onObject.levels.values, 'silent', {value: Infinity})
+  Object.defineProperty(onObject.levels.labels, Infinity, {value: 'silent'})
+}
+module.exports.defineLevelsProperty = defineLevelsProperty
+
+function streamIsBlockable (s) {
+  if (s.hasOwnProperty('_handle') && s._handle.hasOwnProperty('fd') && s._handle.fd) return true
+  if (s.hasOwnProperty('fd') && s.fd) return true
+  return false
+}
+module.exports.streamIsBlockable = streamIsBlockable
+
+function countInterp (s, i) {
+  var n = 0
+  var pos = 0
+  while (true) {
+    pos = s.indexOf(i, pos)
+    if (pos >= 0) {
+      ++n
+      pos += 2
+    } else break
+  }
+  return n
+}
+
+function genLog (z) {
+  return function LOG (a, b, c, d, e, f, g, h, i, j, k) {
+    var l = 0
+    var m = null
+    var n = null
+    var o
+    var p
+    if (typeof a === 'object' && a !== null) {
+      m = a
+      n = [b, c, d, e, f, g, h, i, j, k]
+      l = 1
+
+      if (m.method && m.headers && m.socket) {
+        m = serializers.mapHttpRequest(m)
+      } else if (typeof m.setHeader === 'function') {
+        m = serializers.mapHttpResponse(m)
+      }
+    } else {
+      n = [a, b, c, d, e, f, g, h, i, j, k]
+    }
+    p = n.length = arguments.length - l
+    if (p > 1) {
+      l = typeof a === 'string' ? countInterp(a, '%j') : 0
+      if (l) {
+        n.length = l + countInterp(a, '%d') + countInterp(a, '%s') + 1
+        o = `${util.format.apply(null, n)}`
+      } else {
+        o = format(n, this.formatOpts)
+      }
+    } else if (p) {
+      o = n[0]
+    }
+    this.write(m, o, z)
+  }
+}
+module.exports.genLog = genLog

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -12,13 +12,11 @@ var serializers = require(require.resolve('./serializers'))
 var time = require(require.resolve('./time'))
 
 function noop () {}
-module.exports.noop = noop
 
 function copy (a, b) {
   for (var k in b) { a[k] = b[k] }
   return a
 }
-module.exports.copy = copy
 
 // Must be invoked via .call() to retain speed of inlining into the
 // Pino constructor.
@@ -51,7 +49,6 @@ function applyOptions (opts) {
     this.time = time.getTime
   }
 }
-module.exports.applyOptions = applyOptions
 
 function defineLevelsProperty (onObject) {
   Object.defineProperty(onObject, 'levels', {
@@ -64,14 +61,12 @@ function defineLevelsProperty (onObject) {
   Object.defineProperty(onObject.levels.values, 'silent', {value: Infinity})
   Object.defineProperty(onObject.levels.labels, Infinity, {value: 'silent'})
 }
-module.exports.defineLevelsProperty = defineLevelsProperty
 
 function streamIsBlockable (s) {
   if (s.hasOwnProperty('_handle') && s._handle.hasOwnProperty('fd') && s._handle.fd) return true
   if (s.hasOwnProperty('fd') && s.fd) return true
   return false
 }
-module.exports.streamIsBlockable = streamIsBlockable
 
 function countInterp (s, i) {
   var n = 0
@@ -121,4 +116,12 @@ function genLog (z) {
     this.write(m, o, z)
   }
 }
-module.exports.genLog = genLog
+
+module.exports = {
+  noop: noop,
+  copy: copy,
+  applyOptions: applyOptions,
+  defineLevelsProperty: defineLevelsProperty,
+  streamIsBlockable: streamIsBlockable,
+  genLog: genLog
+}

--- a/pino.js
+++ b/pino.js
@@ -1,16 +1,13 @@
 'use strict'
 
 var stringifySafe = require('fast-safe-stringify')
-var format = require('quick-format-unescaped')
 var EventEmitter = require('events').EventEmitter
-var os = require('os')
 var fs = require('fs')
 var flatstr = require('flatstr')
-var once = require('once')
-var util = require('util')
-var pid = process.pid
-var hostname = os.hostname()
-var baseLog = flatstr('{"pid":' + pid + ',"hostname":"' + hostname + '",')
+var events = require('./lib/events')
+var levels = require('./lib/levels')
+var tools = require('./lib/tools')
+var serializers = require('./lib/serializers')
 
 var LOG_VERSION = 1
 
@@ -24,65 +21,6 @@ var defaultOptions = {
   level: 'info',
   levelVal: undefined,
   enabled: true
-}
-
-var levels = {
-  fatal: 60,
-  error: 50,
-  warn: 40,
-  info: 30,
-  debug: 20,
-  trace: 10
-}
-
-var nums = Object.keys(levels).reduce(function (o, k) {
-  o[levels[k]] = k
-  return o
-}, {})
-
-function defineLevelsProperty (onObject) {
-  Object.defineProperty(onObject, 'levels', {
-    value: {
-      values: copy({}, levels),
-      labels: copy({}, nums)
-    },
-    enumerable: true
-  })
-  Object.defineProperty(onObject.levels.values, 'silent', {value: Infinity})
-  Object.defineProperty(onObject.levels.labels, Infinity, {value: 'silent'})
-}
-
-// IIFE so the keys are cached at module load
-var isStandardLevel = (function () {
-  var keys = Object.keys(levels)
-  return function (level) {
-    if (Infinity === level) {
-      return true
-    }
-    return keys.indexOf(level) > -1
-  }
-}())
-
-var isStandardLevelVal = (function () {
-  var keys = Object.keys(nums)
-  return function (val) {
-    if (!isFinite(val)) {
-      return true
-    }
-    return keys.indexOf(val + '') > -1
-  }
-}())
-
-// level string cache
-var lscache = Object.keys(nums).reduce(function (o, k) {
-  o[k] = flatstr('"level":' + Number(k))
-  return o
-}, {})
-
-function streamIsBlockable (s) {
-  if (s.hasOwnProperty('_handle') && s._handle.hasOwnProperty('fd') && s._handle.fd) return true
-  if (s.hasOwnProperty('fd') && s.fd) return true
-  return false
 }
 
 function pino (opts, stream) {
@@ -115,12 +53,12 @@ function pino (opts, stream) {
     //    Assertion failed: (cb_v->IsFunction()), function MakeCallback...
     // but setTimeout isn't *shrug*
     setTimeout(function () {
-      if (!streamIsBlockable(istream)) {
+      if (!tools.streamIsBlockable(istream)) {
         logger.emit('error', new Error('stream must have a file descriptor in extreme mode'))
       }
     }, 100)
 
-    onExit(function (code, evt) {
+    events.onExit(function (code, evt) {
       var buf = iopts.cache.buf
       if (buf) {
         // We need to block the process exit long enough to flush the buffer
@@ -130,7 +68,7 @@ function pino (opts, stream) {
         fs.writeSync(fd, buf)
       }
       if (!process._events[evt] || process._events[evt].length < 2 || !process._events[evt].filter(function (f) {
-        return f + '' !== onExit.passCode + '' && f + '' !== onExit.insertCode + ''
+        return f + '' !== events.onExit.passCode + '' && f + '' !== events.onExit.insertCode + ''
       }).length) {
         process.exit(code)
       } else {
@@ -142,56 +80,24 @@ function pino (opts, stream) {
   return logger
 }
 
-defineLevelsProperty(pino)
-
-// Must be invoked via .call() to retain speed of inlining into the
-// Pino constructor.
-function applyOptions (opts) {
-  this.serializers = opts.serializers
-  this.stringify = opts.stringify
-  this.end = opts.end
-  this.name = opts.name
-  this.timestamp = opts.timestamp
-  this.slowtime = opts.slowtime
-  this.chindings = opts.chindings
-  this.cache = opts.cache
-  this.formatOpts = opts.formatOpts
-
-  if (opts.level && opts.levelVal) {
-    var levelIsStandard = isStandardLevel(opts.level)
-    var valIsStandard = isStandardLevelVal(opts.levelVal)
-    if (valIsStandard) throw new Error('level value is already used: ' + opts.levelVal)
-    if (levelIsStandard === false && valIsStandard === false) this.addLevel(opts.level, opts.levelVal)
-  }
-  this._setLevel(opts.level)
-  this._baseLog = flatstr(baseLog +
-    (this.name === undefined ? '' : '"name":' + this.stringify(this.name) + ','))
-
-  if (opts.timestamp === false) {
-    this.time = getNoTime
-  } else if (opts.slowtime) {
-    this.time = getSlowTime
-  } else {
-    this.time = getTime
-  }
-}
+tools.defineLevelsProperty(pino)
 
 function Pino (opts, stream) {
   // We define the levels property at construction so that state does
   // not get shared between instances.
-  defineLevelsProperty(this)
+  tools.defineLevelsProperty(this)
   this.stream = stream
-  applyOptions.call(this, opts)
+  tools.applyOptions.call(this, opts)
 }
 
 Pino.prototype = new EventEmitter()
 
-Pino.prototype.fatal = genLog(levels.fatal)
-Pino.prototype.error = genLog(levels.error)
-Pino.prototype.warn = genLog(levels.warn)
-Pino.prototype.info = genLog(levels.info)
-Pino.prototype.debug = genLog(levels.debug)
-Pino.prototype.trace = genLog(levels.trace)
+Pino.prototype.fatal = tools.genLog(levels.levels.fatal)
+Pino.prototype.error = tools.genLog(levels.levels.error)
+Pino.prototype.warn = tools.genLog(levels.levels.warn)
+Pino.prototype.info = tools.genLog(levels.levels.info)
+Pino.prototype.debug = tools.genLog(levels.levels.debug)
+Pino.prototype.trace = tools.genLog(levels.levels.trace)
 
 Object.defineProperty(Pino.prototype, 'levelVal', {
   get: function getLevelVal () {
@@ -208,10 +114,10 @@ Object.defineProperty(Pino.prototype, 'levelVal', {
 
     for (var key in this.levels.values) {
       if (num > this.levels.values[key]) {
-        this[key] = noop
+        this[key] = tools.noop
         continue
       }
-      this[key] = isStandardLevel(key) ? Pino.prototype[key] : genLog(this.levels.values[key])
+      this[key] = levels.isStandardLevel(key) ? Pino.prototype[key] : tools.genLog(this.levels.values[key])
     }
   }
 })
@@ -240,7 +146,7 @@ Object.defineProperty(Pino.prototype, 'level', {
 })
 
 Object.defineProperty(Pino.prototype, '_lscache', {
-  value: copy({}, lscache)
+  value: tools.copy({}, levels.lscache)
 })
 
 Object.defineProperty(
@@ -277,18 +183,6 @@ Pino.prototype.asJson = function asJson (obj, msg, num) {
   return data + this.chindings + this.end
 }
 
-function getNoTime () {
-  return ''
-}
-
-function getTime () {
-  return ',"time":' + Date.now()
-}
-
-function getSlowTime () {
-  return ',"time":"' + (new Date()).toISOString() + '"'
-}
-
 Pino.prototype.child = function child (bindings) {
   if (!bindings) {
     throw Error('missing bindings for child Pino')
@@ -308,7 +202,7 @@ Pino.prototype.child = function child (bindings) {
 
   var opts = {
     level: bindings.level || this.level,
-    levelVal: isStandardLevelVal(this.levelVal) ? undefined : this.levelVal,
+    levelVal: levels.isStandardLevelVal(this.levelVal) ? undefined : this.levelVal,
     serializers: bindings.hasOwnProperty('serializers') ? Object.assign(this.serializers, bindings.serializers) : this.serializers,
     stringify: this.stringify,
     end: this.end,
@@ -322,7 +216,7 @@ Pino.prototype.child = function child (bindings) {
 
   var _child = Object.create(this)
   _child.stream = this.stream
-  applyOptions.call(_child, opts)
+  tools.applyOptions.call(_child, opts)
   return _child
 }
 
@@ -355,136 +249,15 @@ Pino.prototype.addLevel = function addLevel (name, lvl) {
   this.levels.values[name] = lvl
   this.levels.labels[lvl] = name
   this._lscache[lvl] = flatstr('"level":' + Number(lvl))
-  this[name] = genLog(lvl)
+  this[name] = tools.genLog(lvl)
   return true
 }
 
-function mapHttpRequest (req) {
-  return {
-    req: asReqValue(req)
-  }
-}
-
-function mapHttpResponse (res) {
-  return {
-    res: asResValue(res)
-  }
-}
-
-function asReqValue (req) {
-  return {
-    method: req.method,
-    url: req.url,
-    headers: req.headers,
-    remoteAddress: req.connection.remoteAddress,
-    remotePort: req.connection.remotePort
-  }
-}
-
-function asResValue (res) {
-  return {
-    statusCode: res.statusCode,
-    header: res._header
-  }
-}
-
-function asErrValue (err) {
-  var obj = {
-    type: err.constructor.name,
-    message: err.message,
-    stack: err.stack
-  }
-  for (var key in err) {
-    if (obj[key] === undefined) {
-      obj[key] = err[key]
-    }
-  }
-  return obj
-}
-
-function countInterp (s, i) {
-  var n = 0
-  var pos = 0
-  while (true) {
-    pos = s.indexOf(i, pos)
-    if (pos >= 0) {
-      ++n
-      pos += 2
-    } else break
-  }
-  return n
-}
-
-function genLog (z) {
-  return function LOG (a, b, c, d, e, f, g, h, i, j, k) {
-    var l = 0
-    var m = null
-    var n = null
-    var o
-    var p
-    if (typeof a === 'object' && a !== null) {
-      m = a
-      n = [b, c, d, e, f, g, h, i, j, k]
-      l = 1
-
-      if (m.method && m.headers && m.socket) {
-        m = mapHttpRequest(m)
-      } else if (typeof m.setHeader === 'function') {
-        m = mapHttpResponse(m)
-      }
-    } else {
-      n = [a, b, c, d, e, f, g, h, i, j, k]
-    }
-    p = n.length = arguments.length - l
-    if (p > 1) {
-      l = typeof a === 'string' ? countInterp(a, '%j') : 0
-      if (l) {
-        n.length = l + countInterp(a, '%d') + countInterp(a, '%s') + 1
-        o = `${util.format.apply(null, n)}`
-      } else {
-        o = format(n, this.formatOpts)
-      }
-    } else if (p) {
-      o = n[0]
-    }
-    this.write(m, o, z)
-  }
-}
-
-function copy (a, b) {
-  for (var k in b) { a[k] = b[k] }
-  return a
-}
-
-function onExit (fn) {
-  var oneFn = once(fn)
-  process.on('beforeExit', handle('beforeExit'))
-  process.on('exit', handle('exit'))
-  process.on('uncaughtException', handle('uncaughtException', 1))
-  process.on('SIGHUP', handle('SIGHUP', 129))
-  process.on('SIGINT', handle('SIGINT', 130))
-  process.on('SIGQUIT', handle('SIGQUIT', 131))
-  process.on('SIGTERM', handle('SIGTERM', 143))
-  function handle (evt, code) {
-    onExit.passCode = function (code) {
-      if (oneFn.value) { oneFn = once(fn) }
-      oneFn(code, evt)
-    }
-    onExit.insertCode = function () {
-      if (oneFn.value) { oneFn = once(fn) }
-      oneFn(code, evt)
-    }
-    return (code === undefined) ? onExit.passCode : onExit.insertCode
-  }
-}
-
-function noop () {}
-
 module.exports = pino
 module.exports.stdSerializers = {
-  req: asReqValue,
-  res: asResValue,
-  err: asErrValue
+  req: serializers.asReqValue,
+  res: serializers.asResValue,
+  err: serializers.asErrValue
 }
 module.exports.pretty = require('./pretty')
 Object.defineProperty(


### PR DESCRIPTION
This PR splits up the one massive `index.js` into multiple source files. Over time, the `index.js` has had new features and fixes tacked on in seemingly arbitrary locations (I know we all choose what we think makes sense). The result is a mess of code that is difficult to navigate when working through issues or trying to add a feature.

I have run all of the benchmarks and do not see any real difference between this and the master branch. I am attaching outputs from three runs of `bench-all` on each branch so you can decide for yourself (or show me that I missed something).

[pino-reorg.bench.txt](https://github.com/pinojs/pino/files/729785/pino-reorg.bench.txt)
[pino-master.bench.txt](https://github.com/pinojs/pino/files/729784/pino-master.bench.txt)

