### PR TITLE
Make silent level a noop function

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -110,6 +110,7 @@ Pino.prototype.warn = tools.genLog(levels.levels.warn)
 Pino.prototype.info = tools.genLog(levels.levels.info)
 Pino.prototype.debug = tools.genLog(levels.levels.debug)
 Pino.prototype.trace = tools.genLog(levels.levels.trace)
+Pino.prototype.silent = tools.noop
 
 Object.defineProperty(Pino.prototype, 'levelVal', {
   get: function getLevelVal () {

--- a/test/levels.test.js
+++ b/test/levels.test.js
@@ -146,6 +146,35 @@ test('silent level', function (t) {
   t.end()
 })
 
+test('silent is a noop', function (t) {
+  var instance = pino({
+    level: 'silent'
+  }, sink(function (chunk, enc, cb) {
+    t.fail('no data should be logged')
+  }))
+
+  instance['silent']('hello world')
+  t.end()
+})
+
+test('silent stays a noop after level changes', function (t) {
+  var noop = require('../lib/tools').noop
+  var instance = pino({
+    level: 'silent'
+  }, sink(function (chunk, enc, cb) {
+    t.fail('no data should be logged')
+  }))
+
+  instance.level = 'trace'
+  t.notEqual(instance[instance.level], noop)
+
+  instance.level = 'silent'
+  instance['silent']('hello world')
+  t.is(instance[instance.level], noop)
+
+  t.end()
+})
+
 test('exposed levels', function (t) {
   t.plan(1)
   t.deepEqual(Object.keys(pino.levels.values), [


### PR DESCRIPTION
This PR is an implementation of @davidmarkclements proposal in https://github.com/pinojs/express-pino-logger/issues/9

Basically, the "silent" level is now a no operation function so that invocations of it behave the way people think it would.