### PR TITLE
Refactor construction to avoid `new`

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -30,6 +30,199 @@ var defaultOptions = {
   enabled: true
 }
 
+var pinoPrototype = Object.create(EventEmitter.prototype, {
+  silent: {
+    value: tools.noop,
+    enumerable: true
+  },
+  stream: {
+    value: process.stdout,
+    writable: true
+  }
+})
+
+var levelMethods = ['fatal', 'error', 'warn', 'info', 'debug', 'trace']
+levelMethods.forEach(function (m) {
+  Object.defineProperty(pinoPrototype, m, {
+    value: tools.genLog(levels.levels[m]),
+    enumerable: true,
+    writable: true
+  })
+})
+
+Object.defineProperty(pinoPrototype, 'levelVal', {
+  get: function getLevelVal () {
+    return this._levelVal
+  },
+  set: function setLevelVal (num) {
+    if (typeof num === 'string') { return this._setLevel(num) }
+
+    if (this.emit) {
+      this.emit('level-change', this.levels.labels[num], num, this.levels.labels[this._levelVal], this._levelVal)
+    }
+
+    this._levelVal = num
+
+    for (var key in this.levels.values) {
+      if (num > this.levels.values[key]) {
+        this[key] = tools.noop
+        continue
+      }
+      this[key] = levels.isStandardLevel(key) ? pinoPrototype[key] : tools.genLog(this.levels.values[key])
+    }
+  }
+})
+
+Object.defineProperty(pinoPrototype, '_setLevel', {
+  value: function _setLevel (level) {
+    if (typeof level === 'number') {
+      if (!isFinite(level)) {
+        throw Error('unknown level ' + level)
+      }
+      level = this.levels.labels[level]
+    }
+
+    if (!this.levels.values[level]) {
+      throw Error('unknown level ' + level)
+    }
+    this.levelVal = this.levels.values[level]
+  }
+})
+
+Object.defineProperty(pinoPrototype, '_getLevel', {
+  value: function _getLevel (level) {
+    return this.levels.labels[this.levelVal]
+  }
+})
+
+Object.defineProperty(pinoPrototype, 'level', {
+  get: pinoPrototype._getLevel,
+  set: pinoPrototype._setLevel
+})
+
+Object.defineProperty(pinoPrototype, '_lscache', {
+  value: tools.copy({}, levels.lscache)
+})
+
+Object.defineProperty(
+  pinoPrototype,
+  'LOG_VERSION',
+  {value: LOG_VERSION}
+)
+
+Object.defineProperty(pinoPrototype, 'asJson', {
+  enumerable: true,
+  value: function asJson (obj, msg, num) {
+    if (!msg && obj instanceof Error) {
+      msg = obj.message
+    }
+    var data = this._baseLog + this._lscache[num] + this.time()
+    // to catch both null and undefined
+    /* eslint-disable eqeqeq */
+    if (msg != undefined) {
+      data += ',"msg":' + JSON.stringify('' + msg)
+    }
+    var value
+    if (obj) {
+      if (obj.stack) {
+        data += ',"type":"Error","stack":' + this.stringify(obj.stack)
+      }
+      for (var key in obj) {
+        value = obj[key]
+        if ((!obj.hasOwnProperty || obj.hasOwnProperty(key)) && value !== undefined) {
+          value = this.stringify(this.serializers[key] ? this.serializers[key](value) : value)
+          if (value !== undefined) {
+            data += ',"' + key + '":' + value
+          }
+        }
+      }
+    }
+    return data + this.chindings + this.end
+  }
+})
+
+Object.defineProperty(pinoPrototype, 'child', {
+  enumerable: true,
+  value: function child (bindings) {
+    if (!bindings) {
+      throw Error('missing bindings for child Pino')
+    }
+
+    var data = ','
+    var value
+    var key
+    for (key in bindings) {
+      value = bindings[key]
+      if (key !== 'level' && key !== 'serializers' && bindings.hasOwnProperty(key) && value !== undefined) {
+        value = this.serializers[key] ? this.serializers[key](value) : value
+        data += '"' + key + '":' + this.stringify(value) + ','
+      }
+    }
+    data = this.chindings + data.substr(0, data.length - 1)
+
+    var opts = {
+      level: bindings.level || this.level,
+      levelVal: levels.isStandardLevelVal(this.levelVal) ? undefined : this.levelVal,
+      serializers: bindings.hasOwnProperty('serializers') ? Object.assign({}, this.serializers, bindings.serializers) : this.serializers,
+      stringify: this.stringify,
+      end: this.end,
+      name: this.name,
+      timestamp: this.timestamp,
+      slowtime: this.slowtime,
+      chindings: data,
+      cache: this.cache,
+      formatOpts: this.formatOpts
+    }
+
+    var _child = Object.create(this)
+    _child.stream = this.stream
+    tools.applyOptions.call(_child, opts)
+    return _child
+  }
+})
+
+// should this be enumerable?
+Object.defineProperty(pinoPrototype, 'write', {
+  value: function (obj, msg, num) {
+    var s = this.asJson(obj, msg, num)
+    if (!this.cache) {
+      this.stream.write(flatstr(s))
+      return
+    }
+
+    this.cache.buf += s
+    if (this.cache.buf.length > this.cache.size) {
+      this.stream.write(flatstr(this.cache.buf))
+      this.cache.buf = ''
+    }
+  }
+})
+
+Object.defineProperty(pinoPrototype, 'flush', {
+  enumerable: true,
+  value: function () {
+    if (!this.cache) {
+      return
+    }
+
+    this.stream.write(flatstr(this.cache.buf))
+    this.cache.buf = ''
+  }
+})
+
+Object.defineProperty(pinoPrototype, 'addLevel', {
+  enumerable: true,
+  value: function addLevel (name, lvl) {
+    if (this.levels.values.hasOwnProperty(name)) return false
+    if (this.levels.labels.hasOwnProperty(lvl)) return false
+    this.levels.values[name] = lvl
+    this.levels.labels[lvl] = name
+    this._lscache[lvl] = flatstr('"level":' + Number(lvl))
+    this[name] = tools.genLog(lvl)
+    return true
+  }
+})
+
 function pino (opts, stream) {
   var iopts = opts
   var istream = stream
@@ -44,7 +237,7 @@ function pino (opts, stream) {
     var pstream = pretty(iopts.prettyPrint)
     var origStream = istream
     pump(pstream, origStream, function (err) {
-      if (err) logger.emit('error', err)
+      if (err) instance.emit('error', err)
     })
     istream = pstream
   }
@@ -63,13 +256,19 @@ function pino (opts, stream) {
     iopts.level = 'silent'
   }
 
+  var instance = Object.create(pinoPrototype)
+  instance.stream = istream
+  tools.defineLevelsProperty(instance)
+  tools.applyOptions.call(instance, iopts)
+  if (iopts.cache) setTimeout(waitForFDSettle, 100)
+
   var settleTries = 0
   function waitForFDSettle () {
     var isBlockable = tools.streamIsBlockable(istream)
     if (isBlockable === false && settleTries > 10) {
-      return logger.emit('error', Error('stream must have a file descriptor in extreme mode'))
+      return instance.emit('error', Error('stream must have a file descriptor in extreme mode'))
     } else if (isBlockable === true) {
-      return events(logger, extremeModeExitHandler)
+      return events(instance, extremeModeExitHandler)
     }
     settleTries += 1
     setTimeout(waitForFDSettle, 100)
@@ -86,185 +285,10 @@ function pino (opts, stream) {
     }
   }
 
-  var logger = new Pino(iopts, istream)
-  if (iopts.cache) setTimeout(waitForFDSettle, 100)
-
-  return logger
+  return instance
 }
 
 tools.defineLevelsProperty(pino)
-
-function Pino (opts, stream) {
-  // We define the levels property at construction so that state does
-  // not get shared between instances.
-  tools.defineLevelsProperty(this)
-  this.stream = stream
-  tools.applyOptions.call(this, opts)
-}
-
-Pino.prototype = Object.create(EventEmitter.prototype)
-
-Pino.prototype.fatal = tools.genLog(levels.levels.fatal)
-Pino.prototype.error = tools.genLog(levels.levels.error)
-Pino.prototype.warn = tools.genLog(levels.levels.warn)
-Pino.prototype.info = tools.genLog(levels.levels.info)
-Pino.prototype.debug = tools.genLog(levels.levels.debug)
-Pino.prototype.trace = tools.genLog(levels.levels.trace)
-Pino.prototype.silent = tools.noop
-
-Object.defineProperty(Pino.prototype, 'levelVal', {
-  get: function getLevelVal () {
-    return this._levelVal
-  },
-  set: function setLevelVal (num) {
-    if (typeof num === 'string') { return this._setLevel(num) }
-
-    if (this.emit) {
-      this.emit('level-change', this.levels.labels[num], num, this.levels.labels[this._levelVal], this._levelVal)
-    }
-
-    this._levelVal = num
-
-    for (var key in this.levels.values) {
-      if (num > this.levels.values[key]) {
-        this[key] = tools.noop
-        continue
-      }
-      this[key] = levels.isStandardLevel(key) ? Pino.prototype[key] : tools.genLog(this.levels.values[key])
-    }
-  }
-})
-
-Pino.prototype._setLevel = function _setLevel (level) {
-  if (typeof level === 'number') {
-    if (!isFinite(level)) {
-      throw Error('unknown level ' + level)
-    }
-    level = this.levels.labels[level]
-  }
-
-  if (!this.levels.values[level]) {
-    throw Error('unknown level ' + level)
-  }
-  this.levelVal = this.levels.values[level]
-}
-
-Pino.prototype._getLevel = function _getLevel (level) {
-  return this.levels.labels[this.levelVal]
-}
-
-Object.defineProperty(Pino.prototype, 'level', {
-  get: Pino.prototype._getLevel,
-  set: Pino.prototype._setLevel
-})
-
-Object.defineProperty(Pino.prototype, '_lscache', {
-  value: tools.copy({}, levels.lscache)
-})
-
-Object.defineProperty(
-  Pino.prototype,
-  'LOG_VERSION',
-  {value: LOG_VERSION}
-)
-
-Pino.prototype.asJson = function asJson (obj, msg, num) {
-  if (!msg && obj instanceof Error) {
-    msg = obj.message
-  }
-  var data = this._baseLog + this._lscache[num] + this.time()
-  // to catch both null and undefined
-  /* eslint-disable eqeqeq */
-  if (msg != undefined) {
-    data += ',"msg":' + JSON.stringify('' + msg)
-  }
-  var value
-  if (obj) {
-    if (obj.stack) {
-      data += ',"type":"Error","stack":' + this.stringify(obj.stack)
-    }
-    for (var key in obj) {
-      value = obj[key]
-      if ((!obj.hasOwnProperty || obj.hasOwnProperty(key)) && value !== undefined) {
-        value = this.stringify(this.serializers[key] ? this.serializers[key](value) : value)
-        if (value !== undefined) {
-          data += ',"' + key + '":' + value
-        }
-      }
-    }
-  }
-  return data + this.chindings + this.end
-}
-
-Pino.prototype.child = function child (bindings) {
-  if (!bindings) {
-    throw Error('missing bindings for child Pino')
-  }
-
-  var data = ','
-  var value
-  var key
-  for (key in bindings) {
-    value = bindings[key]
-    if (key !== 'level' && key !== 'serializers' && bindings.hasOwnProperty(key) && value !== undefined) {
-      value = this.serializers[key] ? this.serializers[key](value) : value
-      data += '"' + key + '":' + this.stringify(value) + ','
-    }
-  }
-  data = this.chindings + data.substr(0, data.length - 1)
-
-  var opts = {
-    level: bindings.level || this.level,
-    levelVal: levels.isStandardLevelVal(this.levelVal) ? undefined : this.levelVal,
-    serializers: bindings.hasOwnProperty('serializers') ? Object.assign({}, this.serializers, bindings.serializers) : this.serializers,
-    stringify: this.stringify,
-    end: this.end,
-    name: this.name,
-    timestamp: this.timestamp,
-    slowtime: this.slowtime,
-    chindings: data,
-    cache: this.cache,
-    formatOpts: this.formatOpts
-  }
-
-  var _child = Object.create(this)
-  _child.stream = this.stream
-  tools.applyOptions.call(_child, opts)
-  return _child
-}
-
-Pino.prototype.write = function (obj, msg, num) {
-  var s = this.asJson(obj, msg, num)
-  if (!this.cache) {
-    this.stream.write(flatstr(s))
-    return
-  }
-
-  this.cache.buf += s
-  if (this.cache.buf.length > this.cache.size) {
-    this.stream.write(flatstr(this.cache.buf))
-    this.cache.buf = ''
-  }
-}
-
-Pino.prototype.flush = function () {
-  if (!this.cache) {
-    return
-  }
-
-  this.stream.write(flatstr(this.cache.buf))
-  this.cache.buf = ''
-}
-
-Pino.prototype.addLevel = function addLevel (name, lvl) {
-  if (this.levels.values.hasOwnProperty(name)) return false
-  if (this.levels.labels.hasOwnProperty(lvl)) return false
-  this.levels.values[name] = lvl
-  this.levels.labels[lvl] = name
-  this._lscache[lvl] = flatstr('"level":' + Number(lvl))
-  this[name] = tools.genLog(lvl)
-  return true
-}
 
 module.exports = pino
 module.exports.stdSerializers = {
@@ -277,12 +301,4 @@ Object.defineProperty(
   module.exports,
   'LOG_VERSION',
   {value: LOG_VERSION, enumerable: true}
-)
-
-// This is an internal API. It can change at any time, including semver-minor.
-// Use it at your own risk.
-Object.defineProperty(
-  module.exports,
-  '_Pino',
-  {value: Pino}
 )

--- a/pino.js
+++ b/pino.js
@@ -102,7 +102,7 @@ function Pino (opts, stream) {
   tools.applyOptions.call(this, opts)
 }
 
-Pino.prototype = new EventEmitter()
+Pino.prototype = Object.create(EventEmitter.prototype)
 
 Pino.prototype.fatal = tools.genLog(levels.levels.fatal)
 Pino.prototype.error = tools.genLog(levels.levels.error)

--- a/test/levels.test.js
+++ b/test/levels.test.js
@@ -119,6 +119,40 @@ test('set the level via constructor', function (t) {
   instance.fatal('this is fatal')
 })
 
+test('level-change event', function (t) {
+  var instance = pino()
+  var handle = function (lvl, val, prevLvl, prevVal) {
+    t.is(lvl, 'trace')
+    t.is(val, 10)
+    t.is(prevLvl, 'info')
+    t.is(prevVal, 30)
+  }
+  instance.on('level-change', handle)
+  instance.level = 'trace'
+  instance.removeListener('level-change', handle)
+  instance.level = 'info'
+
+  var count = 0
+
+  var l1 = function () { count += 1 }
+  var l2 = function () { count += 1 }
+  var l3 = function () { count += 1 }
+  instance.on('level-change', l1)
+  instance.on('level-change', l2)
+  instance.on('level-change', l3)
+
+  instance.level = 'trace'
+  instance.removeListener('level-change', l3)
+  instance.level = 'fatal'
+  instance.removeListener('level-change', l1)
+  instance.level = 'debug'
+  instance.removeListener('level-change', l2)
+  instance.level = 'info'
+
+  t.is(count, 6)
+  t.end()
+})
+
 test('enable', function (t) {
   var instance = pino({
     level: 'trace',
@@ -218,38 +252,4 @@ test('setting level in child', function (t) {
   instance.info('hello world')
   instance.error('this is an error')
   instance.fatal('this is fatal')
-})
-
-test('level-change event', function (t) {
-  var instance = pino()
-  var handle = function (lvl, val, prevLvl, prevVal) {
-    t.is(lvl, 'trace')
-    t.is(val, 10)
-    t.is(prevLvl, 'info')
-    t.is(prevVal, 30)
-  }
-  instance.on('level-change', handle)
-  instance.level = 'trace'
-  instance.removeListener('level-change', handle)
-  instance.level = 'info'
-
-  var count = 0
-
-  var l1 = function () { count += 1 }
-  var l2 = function () { count += 1 }
-  var l3 = function () { count += 1 }
-  instance.on('level-change', l1)
-  instance.on('level-change', l2)
-  instance.on('level-change', l3)
-
-  instance.level = 'trace'
-  instance.removeListener('level-change', l3)
-  instance.level = 'fatal'
-  instance.removeListener('level-change', l1)
-  instance.level = 'debug'
-  instance.removeListener('level-change', l2)
-  instance.level = 'info'
-
-  t.is(count, 6)
-  t.end()
 })


### PR DESCRIPTION
I'm not sure if you guys want this. I just wanted to see how Pino would perform if it didn't rely on the `new` construct. I am attaching single runs of the full benchmark suite from the current master and this refactor branch. It would be nice to know how the runs compare on some other systems. I'll let you be the judge of the results.

There are a lot of changes here. You may want to simply view the full file instead of the diff. I started the work from the issue-209 branch in PR #210.

One nice change here, in my opinion, is that we don't have to expose the `_Pino` property for things like `pino-multi-stream`. Those sort of modules can simply get a new instance out of the factory function like normal and do true JavaScript "inheritance".

[refactor.bench.txt](https://github.com/pinojs/pino/files/852001/refactor.bench.txt)
[master.bench.txt](https://github.com/pinojs/pino/files/852002/master.bench.txt)


