### PR TITLE
Add profiling scripts

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,6 @@
+# Profiling Pino
+
+1. Install `0x`: `npm install -g 0x`
+2. Run a profile script: `0x profile/basic.profile.js`
+3. View the resulting flamegraph
+4. Enter "pino" in the search field to view the relevant results

--- a/profile/basic-alt.profile.js
+++ b/profile/basic-alt.profile.js
@@ -1,0 +1,32 @@
+'use strict'
+
+var fs = require('fs')
+var pino = require('../')
+var dest = fs.createWriteStream('/dev/null')
+
+var log = pino(dest)
+
+setTimeout(() => {
+  var i = 0
+  var max = 10000
+
+  // warmup
+  for (i; i < max; i += 1) {
+    log.info('hello world')
+  }
+
+  // iteration 1
+  for (i; i < max; i += 1) {
+    log.info('hello world')
+  }
+
+  // iteration 2
+  for (i; i < max; i += 1) {
+    log.info('hello world')
+  }
+
+  // iteration 3
+  for (i; i < max; i += 1) {
+    log.info('hello world')
+  }
+}, 500)

--- a/profile/basic.profile.js
+++ b/profile/basic.profile.js
@@ -1,0 +1,30 @@
+'use strict'
+
+var fs = require('fs')
+var http = require('http')
+var pino = require('../')
+var dest = fs.createWriteStream('/dev/null')
+
+var log = pino(dest)
+var server = http.createServer(function (req, res) {
+  log.info('hello world')
+  res.writeHead(200, {'Content-Type': 'text/plain'})
+  res.end('okay')
+})
+
+server.listen(0, function () {
+  var port = server.address().port
+  var addr = `http://localhost:${port}`
+  var iterations = 0
+  function doGet (cb) {
+    http.get(addr, function () {
+      iterations += 1
+      if (iterations < 10000) return doGet(cb)
+      cb()
+    })
+  }
+
+  doGet(function () {
+    server.close()
+  })
+})


### PR DESCRIPTION
The goal of this PR is to add a few profiling scripts that exercise the same things as the benchmark scripts. I'm submitting my initial implementation of the basic profile to get your feedback. I don't think this is something that can be automated, but I do think it would be useful when things are majorly changed.

As an example:

![2017-03-20_18-05-36](https://cloud.githubusercontent.com/assets/321201/24124022/3f233a52-0d98-11e7-9a6f-6555dcdfda09.png)

I'm not sure when those crept in, if they were always present, or what. But I do know we should look into why they are showing up.
