### PR TITLE
Remove unuseful `require.resolve` preventing easy webpack bundling of…

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -7,9 +7,9 @@ var pid = process.pid
 var os = require('os')
 var hostname = os.hostname()
 var baseLog = flatstr('{"pid":' + pid + ',"hostname":"' + hostname + '",')
-var levels = require(require.resolve('./levels'))
-var serializers = require(require.resolve('./serializers'))
-var time = require(require.resolve('./time'))
+var levels = require('./levels')
+var serializers = require('./serializers')
+var time = require('./time')
 
 function noop () {}
 


### PR DESCRIPTION
… the node version