### PR TITLE
browser write hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,59 @@ Pino is compatible with [`browserify`](http://npm.im) for browser side usage:
 
 This can be useful with isomorphic/universal JavaScript code.
 
-In the browser, `pino` uses corresponding [Log4j](https://en.wikipedia.org/wiki/Log4j) `console` methods (`console.error`, `console.warn`, `console.info`, `console.debug`, `console.trace`) and uses `console.error` for any `fatal` level logs.
+By default, in the browser, 
+`pino` uses corresponding [Log4j](https://en.wikipedia.org/wiki/Log4j) `console` methods (`console.error`, `console.warn`, `console.info`, `console.debug`, `console.trace`) and uses `console.error` for any `fatal` level logs.
+
+### Browser Options
+
+Pino can be passed a `browser` object in the options object, 
+which can have a `write` property or an `asObject` property. 
+
+#### `asObject` (Boolean)
+
+```js
+var pino = require('pino')({browser: {asObject: true}})
+```
+
+The `asObject` option will create a pino-like log object instead of
+passing all arguments to a console method, for instance: 
+
+```js
+pino.info('hi') // creates and logs {msg: 'hi', level: 30, time: <ts>}
+```
+
+When `write` is set, `asObject` will always be `true`.
+
+#### `write` (Function | Object)
+
+Instead of passing log messages to `console.log` they can be passed to
+a supplied function. 
+
+If `write` is set to a single function, all logging objects are passed
+to this function.
+
+```js
+var pino = require('pino')({browser: {write: (o) => {
+  // do something with o
+}}})
+```
+
+If `write` is an object, it can have methods that correspond to the 
+levels. When a message is logged at a given level, the corresponding 
+method is called. If a method isn't present, the logging falls back 
+to using the `console`. 
+
+
+```js
+var pino = require('pino')({browser: {write: {
+  info: function (o) {
+    //process info log object
+  },
+  error: function (o) { 
+    //process error log object
+  }
+}}})
+```
 
 <a name="caveats"></a>
 ## Caveats

--- a/docs/API.md
+++ b/docs/API.md
@@ -61,6 +61,7 @@
     it is up to you to terminate the process; you **must** perform only synchronous operations at this point.
     See [Extreme mode explained](extreme.md) for more detail.
   * `enabled` (boolean): enables logging. Default: `true`
+  * `browser` (Object): browser only, may have `asObject` and `write` keys, see [Pino in the Browser](../readme.md#browser) 
 + `stream` (Writable): a writable stream where the logs will be written.
   Default: `process.stdout`
 

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -71,11 +71,6 @@ test('exposes LOG_VERSION', function (t) {
   t.end()
 })
 
-test('exposes faux _Pino constructor', function (t) {
-  t.ok(isFunc(pino._Pino))
-  t.end()
-})
-
 test('exposes faux stdSerializers', function (t) {
   t.ok(pino.stdSerializers)
   t.ok(pino.stdSerializers.req)
@@ -114,8 +109,153 @@ test('in absence of console, log methods become noops', function (t) {
   t.end()
 })
 
-test('exposes faux _Pino constructor', function (t) {
-  t.ok(isFunc(pino._Pino))
+test('opts.browser.asObject logs pino-like object to console', function (t) {
+  t.plan(3)
+  var info = console.info
+  console.info = function (o) {
+    t.is(o.level, 30)
+    t.is(o.msg, 'test')
+    t.ok(o.time)
+    console.info = info
+  }
+  var instance = require('../browser')({
+    browser: {
+      asObject: true
+    }
+  })
+
+  instance.info('test')
+})
+
+test('opts.browser.write func log single string', function (t) {
+  t.plan(3)
+  var instance = pino({
+    browser: {
+      write: function (o) {
+        t.is(o.level, 30)
+        t.is(o.msg, 'test')
+        t.ok(o.time)
+      }
+    }
+  })
+  instance.info('test')
+  t.end()
+})
+
+test('opts.browser.write func string joining', function (t) {
+  t.plan(3)
+  var instance = pino({
+    browser: {
+      write: function (o) {
+        t.is(o.level, 30)
+        t.is(o.msg, 'test test2 test3')
+        t.ok(o.time)
+      }
+    }
+  })
+  instance.info('test', 'test2', 'test3')
+  t.end()
+})
+
+test('opts.browser.write func string object joining', function (t) {
+  t.plan(3)
+  var instance = pino({
+    browser: {
+      write: function (o) {
+        t.is(o.level, 30)
+        t.is(o.msg, 'test {"test":"test2"} {"test":"test3"}')
+        t.ok(o.time)
+      }
+    }
+  })
+  instance.info('test', {test: 'test2'}, {test: 'test3'})
+  t.end()
+})
+
+test('opts.browser.write func string interpolation', function (t) {
+  t.plan(3)
+  var instance = pino({
+    browser: {
+      write: function (o) {
+        t.is(o.level, 30)
+        t.is(o.msg, 'test2 test ({\\"test\\":\\"test3\\"})')
+        t.ok(o.time)
+      }
+    }
+  })
+  instance.info('%s test (%j)', 'test2', {test: 'test3'})
+  t.end()
+})
+
+test('opts.browser.write func number', function (t) {
+  t.plan(3)
+  var instance = pino({
+    browser: {
+      write: function (o) {
+        t.is(o.level, 30)
+        t.is(o.msg, 1)
+        t.ok(o.time)
+      }
+    }
+  })
+  instance.info(1)
+  t.end()
+})
+
+test('opts.browser.write func log single object', function (t) {
+  t.plan(3)
+  var instance = pino({
+    browser: {
+      write: function (o) {
+        t.is(o.level, 30)
+        t.is(o.test, 'test')
+        t.ok(o.time)
+      }
+    }
+  })
+  instance.info({test: 'test'})
+  t.end()
+})
+
+test('opts.browser.write obj writes to methods corresponding to level', function (t) {
+  t.plan(3)
+  var instance = pino({
+    browser: {
+      write: {
+        error: function (o) {
+          t.is(o.level, 50)
+          t.is(o.test, 'test')
+          t.ok(o.time)
+        }
+      }
+    }
+  })
+  instance.error({test: 'test'})
+  t.end()
+})
+
+test('opts.browser.write obj falls back to console where a method is not supplied', function (t) {
+  t.plan(6)
+  var info = console.info
+  console.info = function (o) {
+    t.is(o.level, 30)
+    t.is(o.msg, 'test')
+    t.ok(o.time)
+    console.info = info
+  }
+  var instance = require('../browser')({
+    browser: {
+      write: {
+        error: function (o) {
+          t.is(o.level, 50)
+          t.is(o.test, 'test')
+          t.ok(o.time)
+        }
+      }
+    }
+  })
+  instance.error({test: 'test'})
+  instance.info('test')
   t.end()
 })
 


### PR DESCRIPTION
* introduces object based logging that corresponds to pino logs
* object based logging can be turned on independently with `asObject` option
* supply an individual write function to capture all logs
* supply an object to capture logs on level by level basis
* if an object, any methods that aren't supplied fallback to logging to console
* `asObject` is mandatorily enabled if `write` is supplied

cc @cyberthom @temsa