### PR TITLE
closes #228

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "fast-safe-stringify": "^1.1.11",
     "flatstr": "^1.0.4",
     "pump": "^1.0.2",
-    "quick-format-unescaped": "^1.0.0",
+    "quick-format-unescaped": "^1.1.1",
     "split2": "^2.0.1"
   }
 }


### PR DESCRIPTION
update quick-format-unescape to v 1.1.1 - avoid use of const since qfu is now used in browser pino, and const won't work in IE10

