### PR TITLE
Add property to expose Pino version

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -3,6 +3,7 @@
 + [pino](#constructor)
 + [pino.pretty](#pretty)
 + [Logger Instance](#logger)
+  * [.pino](#version)
   * [.child](#child)
   * [.level](#level)
   * [.fatal](#fatal)
@@ -61,7 +62,7 @@
     it is up to you to terminate the process; you **must** perform only synchronous operations at this point.
     See [Extreme mode explained](extreme.md) for more detail.
   * `enabled` (boolean): enables logging. Default: `true`
-  * `browser` (Object): browser only, may have `asObject` and `write` keys, see [Pino in the Browser](../readme.md#browser) 
+  * `browser` (Object): browser only, may have `asObject` and `write` keys, see [Pino in the Browser](../readme.md#browser)
 + `stream` (Writable): a writable stream where the logs will be written.
   Default: `process.stdout`
 
@@ -119,6 +120,17 @@ in this section.
 
 <a id="logger"></a>
 # Logger
+
+<a id="version"></a>
+## .pino
+
+Exposes the current version of Pino.
+
+### Example:
+```js
+var log = require('pino')()
+if ('pino' in child) conosole.log(`pino version: ${log.pino}`)
+```
 
 <a id="child"></a>
 ## .child(bindings)

--- a/pino.js
+++ b/pino.js
@@ -38,6 +38,10 @@ var pinoPrototype = Object.create(EventEmitter.prototype, {
   stream: {
     value: process.stdout,
     writable: true
+  },
+  pino: {
+    value: require('./package.json').version,
+    enumerable: true
   }
 })
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -9,6 +9,19 @@ var check = require('./helper').check
 var pid = process.pid
 var hostname = os.hostname()
 
+test('pino version is exposed', function (t) {
+  t.plan(2)
+  var instance = pino()
+  t.ok(instance.pino)
+  t.is(instance.pino, require('../package.json').version)
+})
+
+test('child exposes pino version', function (t) {
+  t.plan(1)
+  var child = pino().child({foo: 'bar'})
+  t.ok(child.pino)
+})
+
 function levelTest (name, level) {
   test(name + ' logs as ' + level, function (t) {
     t.plan(2)


### PR DESCRIPTION
This PR exposes the current version as a property on the logger. Since we don't expose the actual prototype, and it really can't be exposed, we can't use `pinoPrototype.isPrototypeOf(instance)` to check if a logger instance is an instance of Pino. This PR gives a rudimentary way to validate instances.