### PR TITLE
Clarify serializers further

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -40,8 +40,8 @@
   * `name` (string): the name of the logger. Default: `undefined`.
   * `serializers` (object): an object containing functions for custom serialization
     of objects. These functions should return an JSONifiable object and they
-    should never throw. Each property name of this object will match to a
-    property name is logged objects.
+    should never throw. When logging an object, each top-level property matching the exact key of a serializer 
+    will be serialized using the defined serializer.
   * `timestamp` (boolean|function): Enables or disables the inclusion of a timestamp in the
     log message. If a function is supplied, it must synchronously return a JSON string
     representation of the time, e.g. `,"time":1493426328206 (which is the default).


### PR DESCRIPTION
This commit removes wrong wording, clarifies the matching happens based on the key and explains we match only for top-level properties of logged objects.

Let me know how you feel about the wording. I'd be happy to tweak it a little further.

(Sick response time you got there @mcollina 🕙😉! and I'm benchmarking if those single letter vars in `genLog` really matter, if they don't I'm coming back one more time 😛!)