### PR TITLE
Use _headers instead of _header for the http res serializer.

### DIFF
--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -13,7 +13,7 @@ function asReqValue (req) {
 function asResValue (res) {
   return {
     statusCode: res.statusCode,
-    header: res._header
+    headers: res._headers || {}
   }
 }
 

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -105,7 +105,9 @@ test('http response support', function (t) {
       v: 1,
       res: {
         statusCode: originalRes.statusCode,
-        header: originalRes._header
+        headers: {
+          'x-pino': 42
+        }
       }
     })
     cb()
@@ -113,6 +115,7 @@ test('http response support', function (t) {
 
   var server = http.createServer(function (req, res) {
     originalRes = res
+    res.setHeader('x-pino', '42')
     res.end('hello')
     instance.info(res, 'my response')
   }).listen(function (err) {
@@ -144,7 +147,49 @@ test('http response support via a serializer', function (t) {
       v: 1,
       res: {
         statusCode: originalRes.statusCode,
-        header: originalRes._header
+        headers: {
+          'x-pino': 42
+        }
+      }
+    })
+    cb()
+  }))
+
+  var server = http.createServer(function (req, res) {
+    originalRes = res
+    res.setHeader('x-pino', '42')
+    res.end('hello')
+    instance.info({ res: res }, 'my response')
+  }).listen(function (err) {
+    t.error(err)
+    t.teardown(server.close.bind(server))
+
+    http.get('http://localhost:' + server.address().port, function (res) {
+      res.resume()
+    })
+  })
+})
+
+test('http response support with no headers', function (t) {
+  t.plan(3)
+
+  var originalRes
+  var instance = pino({
+    serializers: {
+      res: pino.stdSerializers.res
+    }
+  }, sink(function (chunk, enc, cb) {
+    t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
+    delete chunk.time
+    t.deepEqual(chunk, {
+      pid: pid,
+      hostname: hostname,
+      level: 30,
+      msg: 'my response',
+      v: 1,
+      res: {
+        statusCode: originalRes.statusCode,
+        headers: {}
       }
     })
     cb()


### PR DESCRIPTION
Fixes https://github.com/pinojs/pino-http/issues/32.

Unfortunately, I think this is semver major. What do we want to do?