### PR TITLE
Fix crash in request serializer when behind proxy

### DIFF
--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -5,8 +5,8 @@ function asReqValue (req) {
     method: req.method,
     url: req.url,
     headers: req.headers,
-    remoteAddress: req.connection.remoteAddress,
-    remotePort: req.connection.remotePort
+    remoteAddress: req.connection && req.connection.remoteAddress,
+    remotePort: req.connection && req.connection.remotePort
   }
 }
 


### PR DESCRIPTION
When used behind a proxy the `req.connection` is not always set which throws an error in the serializer. So this change makes sure we're not trying to log properties on an undefined object.