### PR TITLE
Added basic multistream support

### DIFF
--- a/lib/multistream.js
+++ b/lib/multistream.js
@@ -1,0 +1,33 @@
+'use strict'
+
+function MultiStream () {
+  if (!(this instanceof MultiStream)) {
+    return new MultiStream()
+  }
+
+  this.streams = new Map()
+
+  // enable metadata on pino
+  this[Symbol.for('needsMetadata')] = true
+}
+
+MultiStream.prototype.add = function (level, i) {
+  const array = this.streams.get(level) || []
+  array.push(i)
+  this.streams.set(level, array)
+  return this
+}
+
+MultiStream.prototype.write = function (str) {
+  const array = this.streams.get(this.lastLevel)
+
+  if (!array || array.length === 0) {
+    return
+  }
+
+  for (var i = 0; i < array.length; i++) {
+    array[i].write(str)
+  }
+}
+
+module.exports = MultiStream

--- a/test/multistream.test.js
+++ b/test/multistream.test.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const test = require('tap').test
+const pino = require('..')
+const sink = require('./helper').sink
+
+test('baisc multistream', function (t) {
+  t.plan(2)
+
+  const multistream = pino.multistream()
+  const instance = pino({ level: 'debug' }, multistream)
+
+  multistream.add(30, sink(function (chunk, enc, cb) {
+    delete chunk.time
+    delete chunk.pid
+    delete chunk.hostname
+    t.deepEqual(chunk, {
+      level: 30,
+      msg: 'info log line',
+      v: 1
+    })
+    cb()
+  }))
+
+  multistream.add(20, sink(function (chunk, enc, cb) {
+    delete chunk.time
+    delete chunk.pid
+    delete chunk.hostname
+    t.deepEqual(chunk, {
+      level: 20,
+      msg: 'debug log line',
+      v: 1
+    })
+    cb()
+  }))
+
+  instance.info('info log line')
+  instance.debug('debug log line')
+})


### PR DESCRIPTION
This is a work-in-progress. If we need to go forward, it would require more work to iron out all the details. This is just to check with you if it is something we might want.

MultiStream support is shared by all pino instances, and it allows to drop log lines after the fact.
You will require to enable all the log levels down the lowest one you want to log to. Instead of wrapping multiple pino instances like pino-multi-stream does, it adds a "metadata" protocol between pino and the target stream, so that it knows at which level the log line was logged into.

These are the numbers from pino-multi-stream:

```
benchBunyanTen*10000: 5050.589ms
benchPinoMSTen*10000: 5530.074ms
benchPinoNewTen*10000: 4588.214ms
benchBunyanFour*10000: 2166.170ms
benchPinoMSFour*10000: 1525.052ms
benchPinoNewFour*10000: 1352.454ms
benchBunyanOne*10000: 673.961ms
benchPinoMSOne*10000: 357.467ms
benchPinoNewOne*10000: 271.021ms
```

PinoNew is the code in this PR. To note that with one single destination, I get the same numbers with a normal stream.