### PR TITLE
Make _baseLog configurable

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,12 +1,7 @@
 'use strict'
 
-var flatstr = require('flatstr')
 var format = require('quick-format-unescaped')
 var util = require('util')
-var pid = process.pid
-var os = require('os')
-var hostname = os.hostname()
-var baseLog = flatstr('{"pid":' + pid + ',"hostname":"' + hostname + '",')
 var levels = require('./levels')
 var serializers = require('./serializers')
 var isStandardLevelVal = levels.isStandardLevelVal
@@ -30,10 +25,7 @@ function applyOptions (self, opts) {
     if (levelIsStandard === false && valIsStandard === false) self.addLevel(opts.level, opts.levelVal)
   }
   self._setLevel(opts.level)
-  var str = baseLog +
-    (self.name === undefined ? '' : '"name":' + self.stringify(self.name) + ',')
-  Number(str)
-  self._baseLog = str
+  self._baseLog = '{'
 }
 
 function defineLevelsProperty (onObject) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -25,7 +25,6 @@ function applyOptions (self, opts) {
     if (levelIsStandard === false && valIsStandard === false) self.addLevel(opts.level, opts.levelVal)
   }
   self._setLevel(opts.level)
-  self._baseLog = '{'
 }
 
 function defineLevelsProperty (onObject) {

--- a/pino.js
+++ b/pino.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var os = require('os')
 var EventEmitter = require('events').EventEmitter
 var stringifySafe = require('fast-safe-stringify')
 var fs = require('fs')
@@ -34,6 +35,10 @@ var defaultOptions = {
   },
   enabled: true,
   messageKey: 'msg'
+}
+var defaultBaseLog = {
+  pid: process.pid,
+  hostname: os.hostname()
 }
 
 var pinoPrototype = Object.create(EventEmitter.prototype, {
@@ -336,6 +341,15 @@ function pino (opts, stream) {
       var fd = (istream.fd) ? istream.fd : istream._handle.fd
       fs.writeSync(fd, buf)
     }
+  }
+
+  var baseLog = (typeof iopts.baseLog === 'object') ? iopts.baseLog : defaultBaseLog
+  instance = instance.child(baseLog)
+
+  if (iopts.name !== undefined) {
+    instance = instance.child({
+      name: iopts.name
+    })
   }
 
   return instance

--- a/pino.js
+++ b/pino.js
@@ -133,7 +133,7 @@ function asJson (obj, msg, num) {
   var hasObj = obj !== undefined && obj !== null
   var objError = hasObj && obj instanceof Error
   msg = !msg && objError ? obj.message : msg || undefined
-  var data = this._baseLog + this._lscache[num] + this.time()
+  var data = '{' + this._lscache[num] + this.time()
   if (msg !== undefined) {
     // JSON.stringify is safe here
     data += this.messageKeyString + JSON.stringify('' + msg)


### PR DESCRIPTION
I don't personally see why a general logger should force `pid` and `hostname` to be there in the first place. In some cases(containers, faas) those might be so short-lived or random that it would convey next to no information. In other cases some would just like to structure `pid` and `hostname` differently - under another property for example.

This PR doesn't change the default behaviour but at least makes it possible to overwrite `_baseLog` on runtime removing `name`, `pid` and `hostname` from log events.