### PR TITLE
Really force color if forceColor: true

### DIFF
--- a/pretty.js
+++ b/pretty.js
@@ -71,6 +71,10 @@ function pretty (opts) {
       enabled: !!((chalk.supportsColor && dest.isTTY) || forceColor)
     })
 
+    if (forceColor && ctx.level === 0) {
+      ctx.level = 1
+    }
+
     levelColors = {
       default: ctx.white,
       60: ctx.bgRed,
@@ -81,7 +85,7 @@ function pretty (opts) {
       10: ctx.grey
     }
 
-    pipe.call(stream, dest, opts)
+    return pipe.call(stream, dest, opts)
   }
 
   return stream


### PR DESCRIPTION
chalk does not output any color if level=0 even if enabled=true.
This checks for that case and really-really forces at least some color.

Monkey-patched pipe method also lacked return breaking possible expectations for the behaviour of core pipe method.