### PR TITLE
Issue #281, not truncating surplus format arguments when using util.format

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -91,8 +91,7 @@ function genLog (z) {
     if (p > 1) {
       l = typeof a === 'string' ? countInterp(a, '%j') : 0
       if (l) {
-        n.length = l + countInterp(a, '%d') + countInterp(a, '%s') + 1
-        o = `${util.format.apply(null, n)}`
+        o = util.format.apply(null, n)
       } else {
         o = format(n, this.formatOpts)
       }


### PR DESCRIPTION
This changes has surplus message format values (surplus - more than the number of placeholder tokens in the message string, specifically those we count - %d, %j, %s) would still be present in the message result, regardless whether util.format or quick-format-unescaped is used (which is dependent on whether or not a %j placeholder is present).  
After this change the behaviour will match the documentation in the case we have a %j placeholder, and won't change otherwise - though it's fairly similar already (the difference being, quick-format-unescaped uses JSON.stringify for this surpluses, which is considerable faster but doesn't give the same result as util.format which the documentation suggests is used).  
Performance wise, the behaviour is the same as long as you don't pass surpluses, with the benefit of not having to count the placeholders.


PS. Notice I also removed the wrap of the util.format call with the template literal, as it did nothing - it had no additional value other than the return value, so it acted as a cast to string, but util.format always returns a string.

