### PR TITLE
epoch time is in seconds not ms

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -5,7 +5,7 @@ function nullTime () {
 }
 
 function epochTime () {
-  return ',"time":' + Date.now()
+  return ',"time":' + Math.round(Date.now()/1000.0)
 }
 
 function slowTime () {


### PR DESCRIPTION
Epoch, also known as Unix timestamps, is the number of seconds (not milliseconds!) that have elapsed since January 1, 1970 at 00:00:00 GMT (1970-01-01 00:00:00 GMT). 
taken from https://www.freeformatter.com/epoch-timestamp-to-date-converter.html