### PR TITLE
unixTime

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -25,6 +25,7 @@
     + [.err](#errSerializer)
   + [.stdTimeFunctions](#stdTimeFunctions)
     + [.epochTime](#epochTimeFunction)
+    + [.unixTime](#unixTimeFunction)
     + [.slowTime](#slowTimeFunction)
     + [.nullTime](#nullTimeFunction)
 + [Metadata Support](#metadata)
@@ -41,7 +42,7 @@
   * `name` (string): the name of the logger. Default: `undefined`.
   * `serializers` (object): an object containing functions for custom serialization
     of objects. These functions should return an JSONifiable object and they
-    should never throw. When logging an object, each top-level property matching the exact key of a serializer 
+    should never throw. When logging an object, each top-level property matching the exact key of a serializer
     will be serialized using the defined serializer.
   * `timestamp` (boolean|function): Enables or disables the inclusion of a timestamp in the
     log message. If a function is supplied, it must synchronously return a JSON string
@@ -565,6 +566,11 @@ a string like `,"time":1493426328206`.
 ### .epochTime
 
 The default time function for Pino. Returns a string like `,"time":1493426328206`.
+
+<a id="unixTimeFunction"></a>
+### .unixTime
+
+Returns a unix time in seconds, like `,"time":1493426328`.
 
 <a id="slowTimeFunction"></a>
 ### .slowTime

--- a/lib/time.js
+++ b/lib/time.js
@@ -8,6 +8,10 @@ function epochTime () {
   return ',"time":' + Date.now()
 }
 
+function unixTime () {
+  return ',"time":' + Math.round(Date.now() / 1000.0)
+}
+
 function slowTime () {
   return ',"time":"' + (new Date()).toISOString() + '"'
 }
@@ -15,5 +19,6 @@ function slowTime () {
 module.exports = {
   nullTime: nullTime,
   epochTime: epochTime,
+  unixTime: unixTime,
   slowTime: slowTime
 }

--- a/test/timestamp.test.js
+++ b/test/timestamp.test.js
@@ -5,9 +5,10 @@ var pino = require('../')
 var sink = require('./helper').sink
 
 test('pino exposes standard time functions', function (t) {
-  t.plan(4)
+  t.plan(5)
   t.ok(pino.stdTimeFunctions)
   t.ok(pino.stdTimeFunctions.epochTime)
+  t.ok(pino.stdTimeFunctions.unixTime)
   t.ok(pino.stdTimeFunctions.slowTime)
   t.ok(pino.stdTimeFunctions.nullTime)
 })


### PR DESCRIPTION
Epoch, also known as Unix timestamps, is the number of seconds (not milliseconds!) that have elapsed since January 1, 1970 at 00:00:00 GMT (1970-01-01 00:00:00 GMT).
taken from https://www.freeformatter.com/epoch-timestamp-to-date-converter.html

See [PR](https://github.com/pinojs/pino/pull/291)

@jsumners 