### PR TITLE
browser serializers, closes #219

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ By default, in the browser,
 ### Browser Options
 
 Pino can be passed a `browser` object in the options object,
-which can have a `write` property or an `asObject` property.
+which can have the following properties: 
 
 #### `asObject` (Boolean)
 
@@ -240,6 +240,67 @@ var pino = require('pino')({browser: {write: {
   }
 }}})
 ```
+
+#### `serialize`: (Boolean | Array)
+
+The serializers provided to `pino` are ignored by default in the browser, including
+the standard serializers provided with Pino. Since the default destination for log
+messages is the console, values such as `Error` objects are enhanced for inspection, 
+which they otherwise wouldn't be if the Error serializer was enabled.
+
+We can turn all serializers on, 
+
+```js
+var pino = require('pino')({
+  browser: {
+    serialize: true
+  }
+})
+```
+
+Or we can selectively enable them via an array:
+
+```js
+var pino = require('pino')({
+  serializers: {
+    custom: myCustomSerializer,
+    another: anotherSerializer
+  },
+  browser: {
+    serialize: ['custom']
+  }
+})
+// following will apply myCustomSerializer to the custom property,
+// but will not apply anotherSerizlier to another key
+pino.info({custom: 'a', another: 'b'})  
+```
+
+When `serialize` is `true` the standard error serializer is also enabled (see https://github.com/pinojs/pino/blob/master/docs/API.md#stdSerializers).
+This is a global serializer which will apply to any `Error` objects passed to the logger methods.
+
+If `serialize` is an array the standard error serializer is also automatically enabled, it can
+be explicitly disabled by including a string in the serialize array: `!stdSerializers.err`, like so:
+
+```js
+var pino = require('pino')({
+  serializers: {
+    custom: myCustomSerializer,
+    another: anotherSerializer
+  },
+  browser: {
+    serialize: ['!stdSerializers.err', 'custom'] //will not serialize Errors, will serialize `custom` keys
+  }
+})
+```
+
+The `serialize` array also applies to any child logger serializers (see https://github.com/pinojs/pino/blob/master/docs/API.md#discussion-2
+for how to set child-bound serializers).
+
+Unlike server pino the serializers apply to every object passed to the logger method,
+if the `asObject` option is `true`, this results in the serializers applying to the
+first object (as in server pino).      
+
+For more info on serializers see https://github.com/pinojs/pino/blob/master/docs/API.md#parameters.
 
 <a name="caveats"></a>
 ## Caveats

--- a/test/browser.serializers.test.js
+++ b/test/browser.serializers.test.js
@@ -1,0 +1,320 @@
+'use strict'
+var test = require('tap').test
+var pino = require('../browser')
+
+var parentSerializers = {
+  test: function () { return 'parent' }
+}
+
+var childSerializers = {
+  test: function () { return 'child' }
+}
+
+test('serializers override values', function (t) {
+  t.plan(1)
+
+  var parent = pino({ serializers: parentSerializers,
+    browser: { serialize: true,
+      write: function (o) {
+        t.is(o.test, 'parent')
+      }}})
+
+  parent.fatal({test: 'test'})
+})
+
+test('without the serialize option, serializers do not override values', function (t) {
+  t.plan(1)
+
+  var parent = pino({ serializers: parentSerializers,
+    browser: {
+      write: function (o) {
+        t.is(o.test, 'test')
+      }}})
+
+  parent.fatal({test: 'test'})
+})
+
+test('if serialize option is true, standard error serializer is auto enabled', function (t) {
+  t.plan(1)
+  var err = Error('test')
+  err.code = 'test'
+  err.type = 'Error' // get that cov
+  var expect = pino.stdSerializers.err(err)
+
+  var consoleError = console.error
+  console.error = function (err) {
+    t.deepEqual(err, expect)
+  }
+  delete require.cache[require.resolve('../browser')]
+
+  var logger = require('../browser')({
+    browser: { serialize: true }
+  })
+
+  console.error = consoleError
+
+  delete require.cache[require.resolve('../browser')]
+
+  logger.fatal(err)
+})
+
+test('if serialize option is array, standard error serializer is auto enabled', function (t) {
+  t.plan(1)
+  var err = Error('test')
+  err.code = 'test'
+  var expect = pino.stdSerializers.err(err)
+
+  var consoleError = console.error
+  console.error = function (err) {
+    t.deepEqual(err, expect)
+  }
+  delete require.cache[require.resolve('../browser')]
+
+  var logger = require('../browser')({
+    browser: { serialize: [] }
+  })
+
+  console.error = consoleError
+
+  delete require.cache[require.resolve('../browser')]
+
+  logger.fatal(err)
+})
+
+test('if serialize option is array containing !stdSerializers.err, standard error serializer is disabled', function (t) {
+  t.plan(1)
+  var err = Error('test')
+  err.code = 'test'
+  var expect = err
+
+  var consoleError = console.error
+  console.error = function (err) {
+    t.is(err, expect)
+  }
+  delete require.cache[require.resolve('../browser')]
+
+  var logger = require('../browser')({
+    browser: { serialize: ['!stdSerializers.err'] }
+  })
+
+  console.error = consoleError
+
+  delete require.cache[require.resolve('../browser')]
+
+  logger.fatal(err)
+})
+
+test('in browser, serializers apply to all objects', function (t) {
+  t.plan(3)
+  var consoleError = console.error
+  console.error = function (test, test2, test3, test4, test5) {
+    t.is(test.key, 'serialized')
+    t.is(test2.key2, 'serialized2')
+    t.is(test5.key3, 'serialized3')
+  }
+  delete require.cache[require.resolve('../browser')]
+
+  var logger = require('../browser')({
+    serializers: {
+      key: function () { return 'serialized' },
+      key2: function () { return 'serialized2' },
+      key3: function () { return 'serialized3' }
+    },
+    browser: { serialize: true }
+  })
+
+  console.error = consoleError
+
+  delete require.cache[require.resolve('../browser')]
+
+  logger.fatal({key: 'test'}, {key2: 'test'}, 'str should skip', [{foo: 'array should skip'}], {key3: 'test'})
+})
+
+test('serialize can be an array of selected serializers', function (t) {
+  t.plan(3)
+  var consoleError = console.error
+  console.error = function (test, test2, test3, test4, test5) {
+    t.is(test.key, 'test')
+    t.is(test2.key2, 'serialized2')
+    t.is(test5.key3, 'test')
+  }
+  delete require.cache[require.resolve('../browser')]
+
+  var logger = require('../browser')({
+    serializers: {
+      key: function () { return 'serialized' },
+      key2: function () { return 'serialized2' },
+      key3: function () { return 'serialized3' }
+    },
+    browser: { serialize: ['key2'] }
+  })
+
+  console.error = consoleError
+
+  delete require.cache[require.resolve('../browser')]
+
+  logger.fatal({key: 'test'}, {key2: 'test'}, 'str should skip', [{foo: 'array should skip'}], {key3: 'test'})
+})
+
+test('serialize filter applies to child loggers', function (t) {
+  t.plan(3)
+  var consoleError = console.error
+  console.error = function (binding, test, test2, test3, test4, test5) {
+    t.is(test.key, 'test')
+    t.is(test2.key2, 'serialized2')
+    t.is(test5.key3, 'test')
+  }
+  delete require.cache[require.resolve('../browser')]
+
+  var logger = require('../browser')({
+    browser: { serialize: ['key2'] }
+  })
+
+  console.error = consoleError
+
+  delete require.cache[require.resolve('../browser')]
+
+  logger.child({aBinding: 'test',
+    serializers: {
+      key: function () { return 'serialized' },
+      key2: function () { return 'serialized2' },
+      key3: function () { return 'serialized3' }
+    }}).fatal({key: 'test'}, {key2: 'test'}, 'str should skip', [{foo: 'array should skip'}], {key3: 'test'})
+})
+
+test('parent serializers apply to child bindings', function (t) {
+  t.plan(1)
+  var consoleError = console.error
+  console.error = function (binding) {
+    t.is(binding.key, 'serialized')
+  }
+  delete require.cache[require.resolve('../browser')]
+
+  var logger = require('../browser')({
+    serializers: {
+      key: function () { return 'serialized' }
+    },
+    browser: { serialize: true }
+  })
+
+  console.error = consoleError
+
+  delete require.cache[require.resolve('../browser')]
+
+  logger.child({key: 'test'}).fatal({test: 'test'})
+})
+
+test('child serializers apply to child bindings', function (t) {
+  t.plan(1)
+  var consoleError = console.error
+  console.error = function (binding) {
+    t.is(binding.key, 'serialized')
+  }
+  delete require.cache[require.resolve('../browser')]
+
+  var logger = require('../browser')({
+    browser: { serialize: true }
+  })
+
+  console.error = consoleError
+
+  delete require.cache[require.resolve('../browser')]
+
+  logger.child({key: 'test',
+    serializers: {
+      key: function () { return 'serialized' }
+    }}).fatal({test: 'test'})
+})
+
+test('child does not overwrite parent serializers', function (t) {
+  t.plan(2)
+
+  var c = 0
+  var parent = pino({ serializers: parentSerializers,
+    browser: { serialize: true,
+      write: function (o) {
+        c++
+        if (c === 1) t.is(o.test, 'parent')
+        if (c === 2) t.is(o.test, 'child')
+      }}})
+  var child = parent.child({ serializers: childSerializers })
+
+  parent.fatal({test: 'test'})
+  child.fatal({test: 'test'})
+})
+
+test('children inherit parent serializers', function (t) {
+  t.plan(1)
+
+  var parent = pino({ serializers: parentSerializers,
+    browser: { serialize: true,
+      write: function (o) {
+        t.is(o.test, 'parent')
+      }}})
+
+  var child = parent.child({a: 'property'})
+  child.fatal({test: 'test'})
+})
+
+test('children serializers get called', function (t) {
+  t.plan(1)
+
+  var parent = pino({
+    test: 'this',
+    browser: { serialize: true,
+      write: function (o) {
+        t.is(o.test, 'child')
+      }}})
+
+  var child = parent.child({ 'a': 'property', serializers: childSerializers })
+
+  child.fatal({test: 'test'})
+})
+
+test('children serializers get called when inherited from parent', function (t) {
+  t.plan(1)
+
+  var parent = pino({
+    test: 'this',
+    serializers: parentSerializers,
+    browser: { serialize: true,
+      write: function (o) {
+        t.is(o.test, 'pass')
+      }}})
+
+  var child = parent.child({serializers: {test: function () { return 'pass' }}})
+
+  child.fatal({test: 'fail'})
+})
+
+test('non overriden serializers are available in the children', function (t) {
+  t.plan(4)
+  var pSerializers = {
+    onlyParent: function () { return 'parent' },
+    shared: function () { return 'parent' }
+  }
+
+  var cSerializers = {
+    shared: function () { return 'child' },
+    onlyChild: function () { return 'child' }
+  }
+
+  var c = 0
+
+  var parent = pino({ serializers: pSerializers,
+    browser: { serialize: true,
+      write: function (o) {
+        c++
+        if (c === 1) t.is(o.shared, 'child')
+        if (c === 2) t.is(o.onlyParent, 'parent')
+        if (c === 3) t.is(o.onlyChild, 'child')
+        if (c === 4) t.is(o.onlyChild, 'test')
+      }}})
+
+  var child = parent.child({ serializers: cSerializers })
+
+  child.fatal({shared: 'test'})
+  child.fatal({onlyParent: 'test'})
+  child.fatal({onlyChild: 'test'})
+  parent.fatal({onlyChild: 'test'})
+})

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -112,7 +112,15 @@ test('exposes faux stdSerializers', function (t) {
   t.ok(pino.stdSerializers.err)
   t.deepEqual(pino.stdSerializers.req(), {})
   t.deepEqual(pino.stdSerializers.res(), {})
-  t.deepEqual(pino.stdSerializers.err(), {})
+  t.end()
+})
+
+test('exposes err stdSerializer', function (t) {
+  t.ok(pino.stdSerializers)
+  t.ok(pino.stdSerializers.req)
+  t.ok(pino.stdSerializers.res)
+  t.ok(pino.stdSerializers.err)
+  t.ok(pino.stdSerializers.err(Error()))
   t.end()
 })
 

--- a/test/serializers.test.js
+++ b/test/serializers.test.js
@@ -11,23 +11,43 @@ var childSerializers = {
   test: function () { return 'child' }
 }
 
-test('child does not override parent serializers', function (t) {
+test('serializers override values', function (t) {
+  t.plan(1)
+
+  var parent = pino({ serializers: parentSerializers }, sink(function (o, enc, cb) {
+    t.is(o.test, 'parent')
+    cb()
+  }))
+  parent.child({ serializers: childSerializers })
+
+  parent.fatal({test: 'test'})
+})
+
+test('child does not overwrite parent serializers', function (t) {
   t.plan(2)
 
-  var parent = pino({ serializers: parentSerializers })
+  var c = 0
+  var parent = pino({ serializers: parentSerializers }, sink(function (o, enc, cb) {
+    c++
+    if (c === 1) t.is(o.test, 'parent')
+    if (c === 2) t.is(o.test, 'child')
+    cb()
+  }))
   var child = parent.child({ serializers: childSerializers })
 
-  t.equal(parent.serializers.test(), 'parent')
-  t.equal(child.serializers.test(), 'child')
+  parent.fatal({test: 'test'})
+  child.fatal({test: 'test'})
 })
 
 test('children inherit parent serializers', function (t) {
   t.plan(1)
 
-  var parent = pino({ serializers: parentSerializers })
-  var child = parent.child({a: 'property'})
+  var parent = pino({ serializers: parentSerializers }, sink(function (o, enc, cb) {
+    t.is(o.test, 'parent')
+  }))
 
-  t.equal(child.serializers.test(), 'parent')
+  var child = parent.child({a: 'property'})
+  child.fatal({test: 'test'})
 })
 
 test('children serializers get called', function (t) {
@@ -35,16 +55,12 @@ test('children serializers get called', function (t) {
 
   var parent = pino({
     test: 'this'
-  }, sink(function (chunk, enc, cb) {
+  }, sink(function (o, enc, cb) {
+    t.is(o.test, 'child')
     cb()
   }))
 
   var child = parent.child({ 'a': 'property', serializers: childSerializers })
-
-  child.serializers.test = function () {
-    t.ok('serializer called')
-    return 'called'
-  }
 
   child.fatal({test: 'test'})
 })
@@ -54,19 +70,15 @@ test('children serializers get called when inherited from parent', function (t) 
 
   var parent = pino({
     test: 'this',
-    serializers: childSerializers
-  }, sink(function (chunk, enc, cb) {
+    serializers: parentSerializers
+  }, sink(function (o, enc, cb) {
+    t.is(o.test, 'pass')
     cb()
   }))
 
-  var child = parent.child({ 'a': 'property' })
+  var child = parent.child({serializers: {test: function () { return 'pass' }}})
 
-  child.serializers.test = function () {
-    t.ok('serializer called')
-    return 'called'
-  }
-
-  child.fatal({test: 'test'})
+  child.fatal({test: 'fail'})
 })
 
 test('non overriden serializers are available in the children', function (t) {
@@ -80,12 +92,22 @@ test('non overriden serializers are available in the children', function (t) {
     shared: function () { return 'child' },
     onlyChild: function () { return 'child' }
   }
-  var parent = pino({ serializers: pSerializers })
+
+  var c = 0
+
+  var parent = pino({ serializers: pSerializers }, sink(function (o, enc, cb) {
+    c++
+    if (c === 1) t.is(o.shared, 'child')
+    if (c === 2) t.is(o.onlyParent, 'parent')
+    if (c === 3) t.is(o.onlyChild, 'child')
+    if (c === 4) t.is(o.onlyChild, 'test')
+    cb()
+  }))
 
   var child = parent.child({ serializers: cSerializers })
 
-  t.equal(child.serializers.shared(), 'child')
-  t.equal(child.serializers.onlyParent(), 'parent')
-  t.equal(child.serializers.onlyChild(), 'child')
-  t.notOk(parent.serializers.onlyChild)
+  child.fatal({shared: 'test'})
+  child.fatal({onlyParent: 'test'})
+  child.fatal({onlyChild: 'test'})
+  parent.fatal({onlyChild: 'test'})
 })


### PR DESCRIPTION
* see readme for full description - default mode differs from server pino in that it applies serializers to all objects prior to passing to console.log, `asObject` mode essentially ends up the same as server pino
* needed for relaying log messages (want to be able to serialize on the client before sending to server)
* 100% cov 

