### PR TITLE
browser-transmit-timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,11 +322,15 @@ The `logEvent` format is structured like so:
 
 ```js
 { 
+  ts = Number,
   messages = Array, 
   bindings = Array, 
   level: { label = String, value = Number}
 }
 ```
+
+The `ts` property is a unix epoch timestamp in milliseconds, the time is taken from the moment the
+logger method is called.
 
 The `messages` array is all arguments passed to logger method, (for instance `logger.info('a', 'b', 'c')`
 would result in `messages` array `['a', 'b', 'c']`).

--- a/test/browser.transmit.test.js
+++ b/test/browser.transmit.test.js
@@ -70,6 +70,26 @@ test('passes send function messages in logEvent object', function (t) {
   logger.fatal({test: 'test'}, 'another test')
 })
 
+test('supplies a timestamp (ts) in logEvent object which is exactly the same as the `time` property in asObject mode', function (t) {
+  t.plan(1)
+  var expected
+  var logger = pino({
+    browser: {
+      asObject: true, // implict because `write`, but just to be explicit
+      write: function (o) {
+        expected = o.time
+      },
+      transmit: {
+        send: function (level, logEvent) {
+          t.is(logEvent.ts, expected)
+        }
+      }
+    }
+  })
+
+  logger.fatal('test')
+})
+
 test('passes send function child bindings via logEvent object', function (t) {
   t.plan(4)
   var logger = pino({


### PR DESCRIPTION
pretty big omission from the new transmit API, 
logEvents should have a timestamp so when it reaches the server we know
the time of the logEvent (the logEvent doesn't contain the final object, so no `time` prop)

Code has been refactored so we only wrap
the logger function once, and then perform operations (serialize, asObject mode, transmit) from there instead of having heirarchy of function wrappers. 

This also means we can take a timestamp right when the log message is called, and then use that in asObject for `time` prop and as the `ts` prop in the `logEvent` - so we have a consistent timestamp

