### PR TITLE
Added isLevelEnabled function

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -250,6 +250,15 @@ Object.defineProperty(pinoPrototype, 'addLevel', {
   value: addLevel
 })
 
+function isLevelEnabled (logLevel) {
+  var logLevelVal = this.levels.values[logLevel]
+  return logLevelVal && (logLevelVal >= this._levelVal)
+}
+Object.defineProperty(pinoPrototype, 'isLevelEnabled', {
+  enumerable: true,
+  value: isLevelEnabled
+})
+
 function pino (opts, stream) {
   var iopts = opts
   var istream = stream

--- a/test/islevelenabled.test.js
+++ b/test/islevelenabled.test.js
@@ -1,0 +1,53 @@
+'use strict'
+
+var test = require('tap').test
+var pino = require('../')
+
+test('can check if current level enabled', function (t) {
+  t.plan(1)
+
+  var log = pino({level: 'debug'})
+  t.is(true, log.isLevelEnabled('debug'))
+})
+
+test('can check if level enabled after level set', function (t) {
+  t.plan(2)
+
+  var log = pino()
+  t.is(false, log.isLevelEnabled('debug'))
+  log.level = 'debug'
+  t.is(true, log.isLevelEnabled('debug'))
+})
+
+test('can check if higher level enabled', function (t) {
+  t.plan(1)
+
+  var log = pino({level: 'debug'})
+  t.is(true, log.isLevelEnabled('error'))
+})
+
+test('can check if lower level is disabled', function (t) {
+  t.plan(1)
+
+  var log = pino({level: 'error'})
+  t.is(false, log.isLevelEnabled('trace'))
+})
+
+test('can check if child has current level enabled', function (t) {
+  t.plan(3)
+
+  var log = pino().child({level: 'debug'})
+  t.is(true, log.isLevelEnabled('debug'))
+  t.is(true, log.isLevelEnabled('error'))
+  t.is(false, log.isLevelEnabled('trace'))
+})
+
+test('can check if custom level is enabled', function (t) {
+  t.plan(3)
+
+  var log = pino({level: 'debug'})
+  log.addLevel('foo', 35)
+  t.is(true, log.isLevelEnabled('foo'))
+  t.is(true, log.isLevelEnabled('error'))
+  t.is(false, log.isLevelEnabled('trace'))
+})


### PR DESCRIPTION
Adds a function to the Pino object that returns true if its argument is the current level or higher, false otherwise. The use case is to be able to put costly log computations behind a an `if` statement and only calculate them if a certain log level is enabled. e.g.

```javascript
if (logger.isLevelEnabled('debug')) {
  logger.debug(fetchLargeDocument())
}
```

Currently to do this I have to wrap the logger and include a function similar to the one this PR adds.