### PR TITLE
Fix typo in `withSpaces` function

### DIFF
--- a/pretty.js
+++ b/pretty.js
@@ -24,7 +24,7 @@ var standardKeys = [
 ]
 
 function withSpaces (value, eol) {
-  var lines = value.split('\r?\n')
+  var lines = value.split(/\r?\n/)
   for (var i = 1; i < lines.length; i++) {
     lines[i] = '    ' + lines[i]
   }

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -239,6 +239,27 @@ test('pino transform prettifies properties', function (t) {
   instance.info({ a: 'b' }, 'hello world')
 })
 
+test('pino transform prettifies nested properties', function (t) {
+  t.plan(5)
+  var expectedLines = [
+    undefined,
+    '    a: {',
+    '      "b": {',
+    '        "c": "d"',
+    '      }',
+    '    }'
+  ]
+  var prettier = pretty()
+  prettier.pipe(split(function (line) {
+    var expectedLine = expectedLines.shift()
+    if (expectedLine !== undefined) {
+      t.equal(line, expectedLine, 'prettifies the line')
+    }
+  }))
+  var instance = pino(prettier)
+  instance.info({ a: { b: { c: 'd' } } }, 'hello world')
+})
+
 test('pino transform treats the name with care', function (t) {
   t.plan(1)
   var prettier = pretty()


### PR DESCRIPTION
I wondered why using the "pretty" feature didn't make my logs look that pretty.

Then I looked at the code and found out why: It looks like someone passed a string to `value.split()` when they clearly meant to pass a regex.

Tested this fix with my project, and it looks much better.

Before fix:
```
[2017-11-28T21:45:08.685Z] INFO (16172 on MIS7501): incoming request
    reqId: 1
    req: {
  "id": 1,
  "method": "GET",
  "url": "/api/auth/getCurrentUser",
  "remoteAddress": "::1",
  "remotePort": 58871
}
```

After fix:
```
[2017-11-28T21:46:25.319Z] INFO (15812 on MIS7501): incoming request
    reqId: 1
    req: {
      "id": 1,
      "method": "GET",
      "url": "/api/auth/getCurrentUser",
      "remoteAddress": "::1",
      "remotePort": 58881
    }
```