### PR TITLE
Ignore domain related error properties

### DIFF
--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -36,7 +36,7 @@ function asErrValue (err) {
     stack: err.stack
   }
   for (var key in err) {
-    if (obj[key] === undefined) {
+    if (obj[key] === undefined && !key.startsWith('domain')) {
       obj[key] = err[key]
     }
   }

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -79,7 +79,7 @@ test('type, message and stack should be first level properties', function (t) {
 
 test('err serializer', function (t) {
   t.plan(2)
-  var err = Object.assign(new Error('myerror'), {foo: 'bar'})
+  var err = Object.assign(new Error('myerror'), {foo: 'bar', domain: {}, domainEmitter: {}, domainThrown: true, domainBound: function () {}})
   var instance = pino({
     serializers: {
       err: pino.stdSerializers.err


### PR DESCRIPTION
Although it is deprecated, these properties are still being added to the error objects: https://nodejs.org/api/domain.html#domain_additions_to_error_objects

This leads to confusing long, unreadable error logs on syntax errors and such (e.g.TypeError "Cannot read property 'x' of undefined")

This ignores these properties on the standard error serializer.