### PR TITLE
Fix bin not waiting for stdin to close before exiting

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -3,6 +3,7 @@
 'use strict'
 
 var pretty = require('./pretty')
+var fs = require('fs')
 
 module.exports = pretty
 
@@ -17,20 +18,13 @@ if (arg('-h') || arg('--help')) {
     forceColor: arg('-c'),
     messageKey: messageKeyArg()
   })).pipe(process.stdout)
-  process.stdin.on('end', closeProcess)
-  process.on('SIGINT', waitClose)
-}
-
-function waitClose () {
-  setTimeout(closeProcess, 2000)
-}
-
-function closeProcess () {
-  process.exit()
+  if (!process.stdin.isTTY && !fs.fstatSync(process.stdin.fd).isFile()) {
+    process.once('SIGINT', function noOp () {})
+  }
 }
 
 function usage () {
-  return require('fs')
+  return fs
       .createReadStream(require('path').join(__dirname, 'usage.txt'))
 }
 

--- a/bin.js
+++ b/bin.js
@@ -17,6 +17,16 @@ if (arg('-h') || arg('--help')) {
     forceColor: arg('-c'),
     messageKey: messageKeyArg()
   })).pipe(process.stdout)
+  process.stdin.on('end', closeProcess)
+  process.on('SIGINT', waitClose)
+}
+
+function waitClose () {
+  setTimeout(closeProcess, 2000)
+}
+
+function closeProcess () {
+  process.exit()
 }
 
 function usage () {


### PR DESCRIPTION
Fix #357 

I don't think this should break anything since if stdout ends, process will immediately exit.
The process will wait for 2 sec before terminating. I think this should be enough time for most processes to exit but a longer timeout might be required.

This feature (and the timeout) can be implemented behind flags but I wanted to keep the usage simple