### PR TITLE
Improved serialized error stack traces in pretty mode

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -18,8 +18,8 @@ if (arg('-h') || arg('--help')) {
     forceColor: arg('-c'),
     messageKey: argWithParam('-m'),
     dateFormat: argWithParam('--dateFormat'),
-    errorProps: argWithParam('--errorProps').split(/\s?,\s?/),
-    errorLikeObjectKeys: argWithParam('--errorLikeObjectKeys').split(/\s?,\s?/),
+    errorProps: paramToArray(argWithParam('--errorProps')),
+    errorLikeObjectKeys: paramToArray(argWithParam('--errorLikeObjectKeys')),
     localTime: arg('--localTime')
   })).pipe(process.stdout)
   if (!process.stdin.isTTY && !fs.fstatSync(process.stdin.fd).isFile()) {
@@ -48,4 +48,12 @@ function argWithParam (s) {
     throw new Error(s + ' flag provided without a string argument')
   }
   return argValue
+}
+
+function paramToArray (param) {
+  if (!param) {
+    return
+  }
+
+  return param.split(/\s?,\s?/)
 }

--- a/bin.js
+++ b/bin.js
@@ -16,9 +16,10 @@ if (arg('-h') || arg('--help')) {
     timeTransOnly: arg('-t'),
     levelFirst: arg('-l'),
     forceColor: arg('-c'),
-    messageKey: messageKeyArg(),
-    dateFormat: dateFormat(),
-    errorProps: errorPropsArg(),
+    messageKey: argWithParam('-m'),
+    dateFormat: argWithParam('--dateFormat'),
+    errorProps: argWithParam('--errorProps').split(/\s?,\s?/),
+    errorLikeObjectKeys: argWithParam('--errorLikeObjectKeys').split(/\s?,\s?/),
     localTime: arg('--localTime')
   })).pipe(process.stdout)
   if (!process.stdin.isTTY && !fs.fstatSync(process.stdin.fd).isFile()) {
@@ -35,43 +36,16 @@ function arg (s) {
   return !!~process.argv.indexOf(s)
 }
 
-function messageKeyArg () {
-  if (!arg('-m')) {
+function argWithParam (s) {
+  if (!arg(s)) {
     return
   }
-  var messageKeyIndex = process.argv.indexOf('-m') + 1
-  var messageKey = process.argv.length > messageKeyIndex &&
-    process.argv[messageKeyIndex]
+  var argIndex = process.argv.indexOf(s) + 1
+  var argValue = process.argv.length > argIndex &&
+    process.argv[argIndex]
 
-  if (!messageKey) {
-    throw new Error('-m flag provided without a string argument')
+  if (!argValue) {
+    throw new Error(s + ' flag provided without a string argument')
   }
-  return messageKey
-}
-
-function dateFormat () {
-  if (!arg('--dateFormat')) {
-    return
-  }
-  var dateFormatIndex = process.argv.indexOf('--dateFormat') + 1
-  var dateFormat = process.argv.length > dateFormatIndex &&
-    process.argv[dateFormatIndex]
-  if (!dateFormat) {
-    throw new Error('--dateFormat flag provided without a string argument')
-  }
-  return dateFormat
-}
-
-function errorPropsArg () {
-  if (!arg('--errorProps')) {
-    return
-  }
-  var errorPropsIndex = process.argv.indexOf('--errorProps') + 1
-  var errorProps = process.argv.length > errorPropsIndex &&
-    process.argv[errorPropsIndex]
-  if (!errorProps) {
-    throw new Error('--errorProps flag provided without a string argument')
-  }
-  var errorPropsArr = errorProps.split(',')
-  return errorPropsArr
+  return argValue
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -126,7 +126,7 @@ Returns a new [logger](#logger) instance.
   * `forceColor` (boolean): if set to `true`, will add color information to the formatted output
   message. Default: `false`.
   * `crlf` (boolean): emit `\r\n` instead of `\n`. Default: `false`.
-  * `errorLikeObjectKeys` (array): error-like objects containing stack traces that should be ŕettified. Default: `['err', 'error']`.
+  * `errorLikeObjectKeys` (array): error-like objects containing stack traces that should be prettified. Default: `['err', 'error']`.
 
 ### Example:
 ```js

--- a/docs/API.md
+++ b/docs/API.md
@@ -126,6 +126,7 @@ Returns a new [logger](#logger) instance.
   * `forceColor` (boolean): if set to `true`, will add color information to the formatted output
   message. Default: `false`.
   * `crlf` (boolean): emit `\r\n` instead of `\n`. Default: `false`.
+  * `errorLikeObjectKeys` (array): error-like objects containing stack traces that should be ŕettified. Default: `['err', 'error']`.
 
 ### Example:
 ```js

--- a/pretty.js
+++ b/pretty.js
@@ -53,12 +53,18 @@ function _lpadzero (aTarget, aLength, aPadChar) {
 function withSpaces (value, eol) {
   var lines = value.split(/\r?\n/)
   for (var i = 1; i < lines.length; i++) {
-    lines[i] = '    ' + lines[i]
+    lines[i] = indent(4) + lines[i]
   }
   return lines.join(eol)
 }
 
+function indent (n) {
+  return Array(n + 1).join(' ')
+}
+
 function filter (value, messageKey, eol, errorLikeObjectKeys, excludeStandardKeys) {
+  errorLikeObjectKeys = errorLikeObjectKeys || []
+
   var keys = Object.keys(value)
   var filteredKeys = [messageKey]
 
@@ -70,18 +76,22 @@ function filter (value, messageKey, eol, errorLikeObjectKeys, excludeStandardKey
 
   for (var i = 0; i < keys.length; i++) {
     if (errorLikeObjectKeys.indexOf(keys[i]) !== -1) {
-      var arrayOfLines = ('    ' + keys[i] + ': ' + withSpaces(JSON.stringify(value[keys[i]], null, 2), eol) + eol).split('\n')
+      var arrayOfLines = (indent(4) + keys[i] + ': ' + withSpaces(JSON.stringify(value[keys[i]], null, 2), eol) + eol).split('\n')
       result += arrayOfLines.map(line => {
         if (/^\s*"stack"/.test(line)) {
-          var indentSize = /^\s*/.exec(line)[0].length
-          const indentation = Array(indentSize).join(' ')
-          return line.replace(/\\n/g, '\n' + indentation)
+          var matches = /^(\s*"stack":)\s*"(.*)"$/.exec(line)
+
+          var indentSize = /^\s*/.exec(line)[0].length + 3
+          var indentation = indent(indentSize)
+          return matches[1] + '\n' +
+            indent(2) + indentation +
+            matches[2].replace(/\\n/g, '\n' + indent(2) + indentation)
         }
 
         return line
       }).join('\n')
     } else if (filteredKeys.indexOf(keys[i]) < 0) {
-      result += '    ' + keys[i] + ': ' + withSpaces(JSON.stringify(value[keys[i]], null, 2), eol) + eol
+      result += indent(4) + keys[i] + ': ' + withSpaces(JSON.stringify(value[keys[i]], null, 2), eol) + eol
     }
   }
 

--- a/pretty.js
+++ b/pretty.js
@@ -81,7 +81,7 @@ function filter (value, messageKey, eol, errorLikeObjectKeys, excludeStandardKey
         if (/^\s*"stack"/.test(line)) {
           var matches = /^(\s*"stack":)\s*"(.*)"$/.exec(line)
 
-          var indentSize = /^\s*/.exec(line)[0].length + 3
+          var indentSize = /^\s*/.exec(line)[0].length + 2
           var indentation = indent(indentSize)
           return matches[1] + '\n' +
             indent(2) + indentation +

--- a/pretty.js
+++ b/pretty.js
@@ -53,7 +53,7 @@ function _lpadzero (aTarget, aLength, aPadChar) {
 function withSpaces (value, eol) {
   var lines = value.split(/\r?\n/)
   for (var i = 1; i < lines.length; i++) {
-    lines[i] = indent(4) + lines[i]
+    lines[i] = '    ' + lines[i]
   }
   return lines.join(eol)
 }
@@ -76,7 +76,7 @@ function filter (value, messageKey, eol, errorLikeObjectKeys, excludeStandardKey
 
   for (var i = 0; i < keys.length; i++) {
     if (errorLikeObjectKeys.indexOf(keys[i]) !== -1) {
-      var arrayOfLines = (indent(4) + keys[i] + ': ' + withSpaces(JSON.stringify(value[keys[i]], null, 2), eol) + eol).split('\n')
+      var arrayOfLines = ('    ' + keys[i] + ': ' + withSpaces(JSON.stringify(value[keys[i]], null, 2), eol) + eol).split('\n')
 
       for (var j = 0; j < arrayOfLines.length; j++) {
         if (j !== 0) {
@@ -89,19 +89,18 @@ function filter (value, messageKey, eol, errorLikeObjectKeys, excludeStandardKey
           var matches = /^(\s*"stack":)\s*"(.*)",?$/.exec(line)
 
           if (matches.length === 3) {
-            var indentSize = /^\s*/.exec(line)[0].length + 2
+            var indentSize = /^\s*/.exec(line)[0].length + 4
             var indentation = indent(indentSize)
 
-            result += matches[1] + '\n' +
-            indent(2) + indentation +
-            matches[2].replace(/\\n/g, '\n' + indent(2) + indentation)
+            result += matches[1] + '\n' + indentation +
+              matches[2].replace(/\\n/g, '\n' + indentation)
           }
         } else {
           result += line
         }
       }
     } else if (filteredKeys.indexOf(keys[i]) < 0) {
-      result += indent(4) + keys[i] + ': ' + withSpaces(JSON.stringify(value[keys[i]], null, 2), eol) + eol
+      result += '    ' + keys[i] + ': ' + withSpaces(JSON.stringify(value[keys[i]], null, 2), eol) + eol
     }
   }
 

--- a/pretty.js
+++ b/pretty.js
@@ -77,19 +77,27 @@ function filter (value, messageKey, eol, errorLikeObjectKeys, excludeStandardKey
   for (var i = 0; i < keys.length; i++) {
     if (errorLikeObjectKeys.indexOf(keys[i]) !== -1) {
       var arrayOfLines = (indent(4) + keys[i] + ': ' + withSpaces(JSON.stringify(value[keys[i]], null, 2), eol) + eol).split('\n')
-      result += arrayOfLines.map(line => {
+
+      for (var j = 0; j < arrayOfLines.length; j++) {
+        if (j !== 0) {
+          result += '\n'
+        }
+
+        var line = arrayOfLines[j]
+
         if (/^\s*"stack"/.test(line)) {
           var matches = /^(\s*"stack":)\s*"(.*)"$/.exec(line)
 
           var indentSize = /^\s*/.exec(line)[0].length + 2
           var indentation = indent(indentSize)
-          return matches[1] + '\n' +
+
+          result += matches[1] + '\n' +
             indent(2) + indentation +
             matches[2].replace(/\\n/g, '\n' + indent(2) + indentation)
+        } else {
+          result += line
         }
-
-        return line
-      }).join('\n')
+      }
     } else if (filteredKeys.indexOf(keys[i]) < 0) {
       result += indent(4) + keys[i] + ': ' + withSpaces(JSON.stringify(value[keys[i]], null, 2), eol) + eol
     }

--- a/pretty.js
+++ b/pretty.js
@@ -58,10 +58,6 @@ function withSpaces (value, eol) {
   return lines.join(eol)
 }
 
-function indent (n) {
-  return Array(n + 1).join(' ')
-}
-
 function filter (value, messageKey, eol, errorLikeObjectKeys, excludeStandardKeys) {
   errorLikeObjectKeys = errorLikeObjectKeys || []
 
@@ -90,7 +86,7 @@ function filter (value, messageKey, eol, errorLikeObjectKeys, excludeStandardKey
 
           if (matches.length === 3) {
             var indentSize = /^\s*/.exec(line)[0].length + 4
-            var indentation = indent(indentSize)
+            var indentation = Array(indentSize + 1).join(' ')
 
             result += matches[1] + '\n' + indentation +
               matches[2].replace(/\\n/g, '\n' + indentation)
@@ -116,7 +112,7 @@ function pretty (opts) {
   var formatter = opts && opts.formatter
   var dateFormat = opts && opts.dateFormat
   var errorProps = opts && opts.errorProps
-  var errorLikeObjectKeys = opts && opts.errorlikeobjectkeys
+  var errorLikeObjectKeys = opts && opts.errorLikeObjectKeys
   var localTime = opts && opts.localTime
   var levelFirst = opts && opts.levelFirst
   var messageKey = opts && opts.messageKey

--- a/pretty.js
+++ b/pretty.js
@@ -86,14 +86,16 @@ function filter (value, messageKey, eol, errorLikeObjectKeys, excludeStandardKey
         var line = arrayOfLines[j]
 
         if (/^\s*"stack"/.test(line)) {
-          var matches = /^(\s*"stack":)\s*"(.*)"$/.exec(line)
+          var matches = /^(\s*"stack":)\s*"(.*)",?$/.exec(line)
 
-          var indentSize = /^\s*/.exec(line)[0].length + 2
-          var indentation = indent(indentSize)
+          if (matches.length === 3) {
+            var indentSize = /^\s*/.exec(line)[0].length + 2
+            var indentation = indent(indentSize)
 
-          result += matches[1] + '\n' +
+            result += matches[1] + '\n' +
             indent(2) + indentation +
             matches[2].replace(/\\n/g, '\n' + indent(2) + indentation)
+          }
         } else {
           result += line
         }

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -105,7 +105,7 @@ test('pino transform prettifies Error', function (t) {
   instance.info(err)
 })
 
-function getIndendLevel (str) {
+function getIndentLevel (str) {
   return (/^\s*/.exec(str) || [''])[0].length
 }
 
@@ -132,7 +132,7 @@ test('pino transform prettifies Error in property within errorLikeObjectKeys', f
       currentTrace = expectedTraces.shift()
 
       t.ok(line.indexOf(currentTrace) >= 0, `${i} line matches`)
-      t.ok(getIndendLevel(line) > getIndendLevel(currentStack), `${i} proper indentation`)
+      t.ok(getIndentLevel(line) > getIndentLevel(currentStack), `${i} proper indentation`)
     }
     i++
     return line

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -9,6 +9,7 @@ var writeStream = require('flush-write-stream')
 var fork = require('child_process').fork
 var split = require('split2')
 var hostname = os.hostname()
+var serializers = require('pino-std-serializers')
 
 test('pino transform prettifies', function (t) {
   t.plan(4)
@@ -51,6 +52,7 @@ test('pino pretty force color on flag', function (t) {
 
   instance.info('hello world')
 })
+
 test('pino transform can just parse the dates', function (t) {
   t.plan(1)
   var prettier = pretty({ timeTransOnly: true })
@@ -101,6 +103,44 @@ test('pino transform prettifies Error', function (t) {
   var instance = pino(prettier)
 
   instance.info(err)
+})
+
+function getIndendLevel (str) {
+  return (/^\s*/.exec(str) || [''])[0].length
+}
+
+test('pino transform prettifies Error in property within errorLikeObjectKeys', function (t) {
+  var prettier = pretty({
+    errorLikeObjectKeys: ['err']
+  })
+
+  var err = new Error('hello world')
+  var expectedTraces = err.stack.split('\n').slice(1)
+
+  t.plan(expectedTraces.length * 2)
+
+  var i = 0
+  var currentTrace = ''
+  var currentStack = ''
+
+  prettier.pipe(split(function (line) {
+    if (/^\s*"stack"/.test(line)) {
+      currentStack = line
+    }
+
+    if (/^\s*at/.test(line)) {
+      currentTrace = expectedTraces.shift()
+
+      t.ok(line.indexOf(currentTrace) >= 0, `${i} line matches`)
+      t.ok(getIndendLevel(line) > getIndendLevel(currentStack), `${i} proper indentation`)
+    }
+    i++
+    return line
+  }))
+
+  var instance = pino({ serializers: { err: serializers.err } }, prettier)
+
+  instance.info({ err })
 })
 
 test('pino transform preserve output if not valid JSON', function (t) {


### PR DESCRIPTION
Fixes #373

## Motivation

Display properly indented multi-line stack-traces for error-like objects in pretty mode.

## Sample code

```javascript
const pino = require('pino');

const logger = pino({
  serializers: {
    err: pino.stdSerializers.err,
    error: pino.stdSerializers.err,
  }
});

const err = new Error('dummy error');

logger.error(err);
logger.error({ err });
logger.error({ error: err });
```

## Current output

![before](https://user-images.githubusercontent.com/16565602/37611818-37112ba4-2b82-11e8-912c-1a58e017e0b6.png)

## Patched output

![after](https://user-images.githubusercontent.com/16565602/37611856-4d08483e-2b82-11e8-8fbb-c5d0999ac486.png)

## Discussion

- I opted to include default values for `errorLikeObjectKeys` prop to be `['err', 'error']`, as these are the most natural object keys for errors. It's possible to change that using the CLI arg `--errorLikeObjectKeys` or passing a `errorLikeObjectKeys` as an option when invoking `pino.pretty()`. However, I'm not sure how to properly document this. Suggestions?
