### PR TITLE
std serializers api typo + deprecation unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   ],
   "scripts": {
     "browser-test": "zuul tape test/browser*test.js --local",
-    "test": "standard | snazzy && tap --no-cov test/*test.js",
-    "ci": "standard | snazzy && tap --cov test/*test.js",
+    "test": "standard | snazzy && NODE_OPTIONS='--no-warnings' tap --no-cov test/*test.js",
+    "ci": "standard | snazzy &&  NODE_OPTIONS='--no-warnings' tap --cov test/*test.js",
     "bench-all": "node benchmarks/runbench all",
     "bench-basic": "node benchmarks/runbench basic",
     "bench-object": "node benchmarks/runbench object",

--- a/pino.js
+++ b/pino.js
@@ -383,7 +383,7 @@ module.exports.stdSerializers = {
   res: serializers.res,
   err: serializers.err,
   wrapRequestSerializer: serializers.wrapRequestSerializer,
-  wrapRespnonseSerializer: serializers.wrapResponseSerializer
+  wrapResponseSerializer: serializers.wrapResponseSerializer
 }
 module.exports.stdTimeFunctions = Object.assign({}, time)
 module.exports.pretty = pretty

--- a/pino.js
+++ b/pino.js
@@ -5,6 +5,7 @@ var EventEmitter = require('events').EventEmitter
 var stringifySafe = require('fast-safe-stringify')
 var serializers = require('pino-std-serializers')
 var fs = require('fs')
+var util = require('util')
 var pump = require('pump')
 var flatstr = require('flatstr')
 var pretty = require('./pretty')
@@ -326,7 +327,7 @@ function pino (opts, stream) {
 
   if (iopts.slowtime) {
     instance.time = time.slowTime
-    process.emitWarning('use `timestamp: pino.stdTimeFunctions.slowTime`', '(pino) `slowtime` is deprecated')
+    util.deprecate(tools.noop, '(pino) `slowtime` is deprecated: use `timestamp: pino.stdTimeFunctions.slowTime`')()
   } else if (iopts.timestamp && Function.prototype.isPrototypeOf(iopts.timestamp)) {
     instance.time = iopts.timestamp
   } else if (iopts.timestamp) {
@@ -385,6 +386,17 @@ module.exports.stdSerializers = {
   wrapRequestSerializer: serializers.wrapRequestSerializer,
   wrapResponseSerializer: serializers.wrapResponseSerializer
 }
+
+Object.defineProperty(module.exports.stdSerializers, 'wrapRespnonseSerializer', {
+  enumerable: true,
+  get: util.deprecate(
+    function () {
+      return serializers.wrapResponseSerializer
+    },
+    '`pino.stdSerializers.wrapRespnonseSerializer` is deprecated: use `pino.stdSerializers.wrapResponseSerializer`'
+  )
+})
+
 module.exports.stdTimeFunctions = Object.assign({}, time)
 module.exports.pretty = pretty
 Object.defineProperty(

--- a/test/deprecated.test.js
+++ b/test/deprecated.test.js
@@ -1,0 +1,45 @@
+'use strict'
+
+var test = require('tap').test
+var pino = require('../')
+var sink = require('./helper').sink
+
+test('opts.slowtime', function (t) {
+  if (typeof process.emitWarning === 'function') {
+    process.once('warning', (msg) => {
+      t.is(/`slowtime` is deprecated/.test(msg), true)
+      t.end()
+    })
+  } else {
+    const write = process.stderr.write
+    process.stderr.write = (msg) => {
+      t.is(/`slowtime` is deprecated/.test(msg), true)
+      process.nextTick(t.end)
+      process.stderr.write = write
+    }
+  }
+
+  var instance = pino({slowtime: true},
+    sink(function (chunk, enc, cb) {
+      t.ok(Date.parse(chunk.time) <= new Date(), 'time is greater than Date.now()')
+    }))
+
+  instance.info('hello world')
+})
+
+test('pino.stdSerializers.wrapRespnonseSerializer', function (t) {
+  if (typeof process.emitWarning === 'function') {
+    process.once('warning', (msg) => {
+      t.is(/`pino.stdSerializers.wrapRespnonseSerializer` is deprecated/.test(msg), true)
+      t.end()
+    })
+  } else {
+    const write = process.stderr.write
+    process.stderr.write = (msg) => {
+      t.is(/`pino.stdSerializers.wrapRespnonseSerializer` is deprecated/.test(msg), true)
+      process.nextTick(t.end)
+      process.stderr.write = write
+    }
+  }
+  t.is(pino.stdSerializers.wrapRespnonseSerializer, pino.stdSerializers.wrapResponseSerializer)
+})


### PR DESCRIPTION
this is a no brainer to fix, 

however: I'm assuming this is a patch release not a major, because even though we're technically changing the API - we should consider the current API broken

I doubt anyone is relying on the typo, we would have had a PR by now... surely