### PR TITLE
Remove slowtime support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -49,7 +49,7 @@
     Alternatively, it is possible to register a serializer under the key `Symbol.for('pino.*')` which will act upon the complete log object, i.e. every property.
   * `timestamp` (boolean|function): Enables or disables the inclusion of a timestamp in the
     log message. If a function is supplied, it must synchronously return a JSON string
-    representation of the time, e.g. `,"time":1493426328206 (which is the default).
+    representation of the time, e.g. `,"time":1493426328206` (which is the default).
     If set to `false`, no timestamp will be included in the output.
     See [stdTimeFunctions](#stdTimeFunctions) for a set of available functions
     for passing in as a value for this option. Caution: any sort of formatted

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,7 +28,6 @@
   + [.stdTimeFunctions](#stdTimeFunctions)
     + [.epochTime](#epochTimeFunction)
     + [.unixTime](#unixTimeFunction)
-    + [.slowTime](#slowTimeFunction)
     + [.nullTime](#nullTimeFunction)
 + [Metadata Support](#metadata)
 
@@ -55,13 +54,6 @@
     See [stdTimeFunctions](#stdTimeFunctions) for a set of available functions
     for passing in as a value for this option. Caution: any sort of formatted
     time will significantly slow down Pino's performance.
-  * `slowtime` (boolean): Outputs ISO time stamps (`'2016-03-09T15:18:53.889Z'`)
-     instead of Epoch time stamps (`1457536759176`). **WARNING**: This option
-     carries a 25% performance drop. We recommend using default Epoch timestamps
-     and transforming logs after if required. The `pino -t` command will do this
-     for you (see [CLI](cli.md)). Default: `false`.
-     **Deprecation**: this option is scheduled to be removed in Pino 5.0.0. Use
-     `timestamp: pino.stdTimeFunctions.slowTime` instead.
   * `extreme` (boolean): Enables extreme mode, yields an additional 60% performance
     (from 250ms down to 100ms per 10000 ops). There are trade-off's should be
     understood before usage. See [Extreme mode explained](extreme.md). Default: `false`.
@@ -610,13 +602,6 @@ The default time function for Pino. Returns a string like `,"time":1493426328206
 ### .unixTime
 
 Returns a unix time in seconds, like `,"time":1493426328`.
-
-<a id="slowTimeFunction"></a>
-### .slowTime
-
-Returns an ISO formatted string like `,"time":"2017-04-29T00:47:49.354Z". It is
-highly recommended that you avoid this function. It incurs a significant
-performance penalty.
 
 <a id="nullTimeFunction"></a>
 ### .nulltime

--- a/lib/time.js
+++ b/lib/time.js
@@ -12,13 +12,8 @@ function unixTime () {
   return ',"time":' + Math.round(Date.now() / 1000.0)
 }
 
-function slowTime () {
-  return ',"time":"' + (new Date()).toISOString() + '"'
-}
-
 module.exports = {
   nullTime: nullTime,
   epochTime: epochTime,
-  unixTime: unixTime,
-  slowTime: slowTime
+  unixTime: unixTime
 }

--- a/pino.js
+++ b/pino.js
@@ -23,7 +23,6 @@ var defaultOptions = {
   name: undefined,
   serializers: {},
   timestamp: time.epochTime,
-  slowtime: false,
   extreme: false,
   level: 'info',
   levelVal: undefined,
@@ -325,7 +324,6 @@ function pino (opts, stream) {
   instance.end = iopts.end
   instance.name = iopts.name
   instance.timestamp = iopts.timestamp
-  instance.slowtime = iopts.slowtime
   instance.cache = iopts.cache
   instance.formatiopts = iopts.formatiopts
   instance.onTerminated = iopts.onTerminated
@@ -334,10 +332,7 @@ function pino (opts, stream) {
 
   applyOptions(instance, iopts)
 
-  if (iopts.slowtime) {
-    instance.time = time.slowTime
-    util.deprecate(tools.noop, '(pino) `slowtime` is deprecated: use `timestamp: pino.stdTimeFunctions.slowTime`')()
-  } else if (iopts.timestamp && Function.prototype.isPrototypeOf(iopts.timestamp)) {
+  if (iopts.timestamp && Function.prototype.isPrototypeOf(iopts.timestamp)) {
     instance.time = iopts.timestamp
   } else if (iopts.timestamp) {
     instance.time = time.epochTime

--- a/test/deprecated.test.js
+++ b/test/deprecated.test.js
@@ -2,30 +2,6 @@
 
 var test = require('tap').test
 var pino = require('../')
-var sink = require('./helper').sink
-
-test('opts.slowtime', function (t) {
-  if (typeof process.emitWarning === 'function') {
-    process.once('warning', (msg) => {
-      t.is(/`slowtime` is deprecated/.test(msg), true)
-      t.end()
-    })
-  } else {
-    const write = process.stderr.write
-    process.stderr.write = (msg) => {
-      t.is(/`slowtime` is deprecated/.test(msg), true)
-      process.nextTick(t.end)
-      process.stderr.write = write
-    }
-  }
-
-  var instance = pino({slowtime: true},
-    sink(function (chunk, enc, cb) {
-      t.ok(Date.parse(chunk.time) <= new Date(), 'time is greater than Date.now()')
-    }))
-
-  instance.info('hello world')
-})
 
 test('pino.stdSerializers.wrapRespnonseSerializer', function (t) {
   if (typeof process.emitWarning === 'function') {

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -5,7 +5,6 @@ var os = require('os')
 var pino = require('../')
 var sink = require('./helper').sink
 var http = require('http')
-var time = require('../lib/time')
 
 var pid = process.pid
 var hostname = os.hostname()
@@ -203,16 +202,6 @@ test('http response support via a serializer', function (t) {
       res.resume()
     })
   })
-})
-
-test('slowtime', function (t) {
-  var instance = pino({timestamp: time.slowTime},
-    sink(function (chunk, enc, cb) {
-      t.ok(Date.parse(chunk.time) <= new Date(), 'time is greater than Date.now()')
-      t.end()
-    }))
-
-  instance.info('hello world')
 })
 
 test('http request support via serializer in a child', function (t) {

--- a/test/timestamp.test.js
+++ b/test/timestamp.test.js
@@ -5,11 +5,10 @@ var pino = require('../')
 var sink = require('./helper').sink
 
 test('pino exposes standard time functions', function (t) {
-  t.plan(5)
+  t.plan(4)
   t.ok(pino.stdTimeFunctions)
   t.ok(pino.stdTimeFunctions.epochTime)
   t.ok(pino.stdTimeFunctions.unixTime)
-  t.ok(pino.stdTimeFunctions.slowTime)
   t.ok(pino.stdTimeFunctions.nullTime)
 })
 


### PR DESCRIPTION
As per longstanding deprecation notice and https://github.com/pinojs/pino/projects/1, this PR removes the `slowtime` feature. This relegates time prettification to prettifiers. If people really want slow time, they can supply their own time formatting function via the `timestamp` option at logger instantiation (https://github.com/pinojs/pino/blob/a8d0b48408ca0262d398cd96309b9ea54cb1ec86/docs/API.md#parameters).