### PR TITLE
Update fast-json-stringify

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "fast-json-parse": "^1.0.3",
-    "fast-safe-stringify": "^1.2.3",
+    "fast-safe-stringify": "^2.0.4",
     "flatstr": "^1.0.5",
     "pino-std-serializers": "^2.0.0",
     "pump": "^3.0.0",


### PR DESCRIPTION
As per Project 1 (https://github.com/pinojs/pino/projects/1), this PR updates the `fast-json-stringify` dependency. Release notes should include:

> + Update `fast-json-stringify`: see https://github.com/davidmarkclements/fast-safe-stringify/blob/23fc3d1/CHANGELOG.md for notes on the breakages introduced by this.

@davidmarkclements: how about updating https://github.com/davidmarkclements/fast-safe-stringify/releases so that link isn't so ugly?