### PR TITLE
Use `sonic-boom` for extreme mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "flatstr": "^1.0.5",
     "pino-std-serializers": "^2.0.0",
     "pump": "^3.0.0",
-    "quick-format-unescaped": "^1.1.2"
+    "quick-format-unescaped": "^1.1.2",
+    "sonic-boom": "^0.1.0"
   }
 }


### PR DESCRIPTION
This PR uses `sonic-boom` as the destination stream in extreme mode.

Currently, this is not working. I'm pushing up the broken code to get some guidance from @mcollina as to how it should really be implemented.