### PR TITLE
Adding a line ending option

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -87,6 +87,7 @@
     * `hostname` (os.hostname)
     * `name` of logger if supplied as option
   * `crlf` (boolean): logs newline delimited JSON with `\r\n` instead of `\n`. Default: `false`.
+  * `appendLineEndings (boolean): controls whether or not newlines are appended to logs. Default: `true`.
 + `stream` (Writable): a writable stream where the logs will be written.
   It can also receive some log-line [metadata](#metadata), if the
   relative protocol is enabled. Default: `process.stdout`
@@ -126,6 +127,7 @@ Returns a new [logger](#logger) instance.
   * `forceColor` (boolean): if set to `true`, will add color information to the formatted output
   message. Default: `false`.
   * `crlf` (boolean): emit `\r\n` instead of `\n`. Default: `false`.
+  * `appendLineEndings (boolean): if not set to `false`, enables line endings as determined by `crlf`. Default: `true`.
   * `errorLikeObjectKeys` (array): error-like objects containing stack traces that should be prettified. Default: `['err', 'error']`.
 
 ### Example:

--- a/pino.js
+++ b/pino.js
@@ -39,6 +39,7 @@ var defaultOptions = {
     hostname: os.hostname()
   },
   enabled: true,
+  appendLineEndings: true,
   messageKey: 'msg'
 }
 
@@ -299,7 +300,7 @@ function pino (opts, stream) {
   iopts.stringify = iopts.safe ? stringifySafe : JSON.stringify
   iopts.formatOpts = {lowres: true}
   iopts.messageKeyString = `,"${iopts.messageKey}":`
-  iopts.end = ',"v":' + LOG_VERSION + '}' + (iopts.crlf ? '\r\n' : '\n')
+  iopts.end = ',"v":' + LOG_VERSION + '}' + (iopts.appendLineEndings !== false ? (iopts.crlf ? '\r\n' : '\n') : '')
   iopts.cache = !iopts.extreme ? null : {
     size: 4096,
     buf: ''

--- a/test/crlf.test.js
+++ b/test/crlf.test.js
@@ -55,3 +55,15 @@ test('pretty can log CRLF', function (t) {
   t.is(stream.data, 'foo\r\nbar\r\n')
   t.end()
 })
+
+test('line endings can be toggled off', function (t) {
+  t.plan(1)
+  var stream = capture()
+  var logger = pino({
+    appendLineEndings: false
+  }, stream)
+  logger.info('foo')
+  logger.error('bar')
+  t.ok(/foo[^\n]+bar[^\n]/.test(stream.data))
+  t.end()
+})


### PR DESCRIPTION
Currently, `pino` appends a new line to every log line, and can be switched between `\n` and `\r\n`.

This pull request adds a separate boolean switch that would allow a user to opt out of line endings entirely.