### PR TITLE
Fast UTC time as timestamp 

### DIFF
--- a/benchmarks/time.bench.js
+++ b/benchmarks/time.bench.js
@@ -1,0 +1,33 @@
+'use strict'
+
+var bench = require('fastbench')
+var pino = require('../')
+
+var epoch = pino({timestamp: pino.stdTimeFunctions.epochTime}, pino.destination('/dev/null'))
+var unix = pino({timestamp: pino.stdTimeFunctions.unixTime}, pino.destination('/dev/null'))
+var utc = pino({timestamp: pino.stdTimeFunctions.utcTime}, pino.destination('/dev/null'))
+
+var max = 100
+
+var run = bench([
+  function benchPinoEpochTime (cb) {
+    for (var i = 0; i < max; i++) {
+      epoch.info('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUnixTime (cb) {
+    for (var i = 0; i < max; i++) {
+      unix.info('hello world')
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUtcTime (cb) {
+    for (var i = 0; i < max; i++) {
+      utc.info('hello world')
+    }
+    setImmediate(cb)
+  }
+], 10000)
+
+run(run)

--- a/benchmarks/time.bench.js
+++ b/benchmarks/time.bench.js
@@ -3,6 +3,7 @@
 var bench = require('fastbench')
 var pino = require('../')
 
+var iso = pino({timestamp: pino.stdTimeFunctions.isoTime}, pino.destination('/dev/null'))
 var epoch = pino({timestamp: pino.stdTimeFunctions.epochTime}, pino.destination('/dev/null'))
 var unix = pino({timestamp: pino.stdTimeFunctions.unixTime}, pino.destination('/dev/null'))
 var utc = pino({timestamp: pino.stdTimeFunctions.utcTime}, pino.destination('/dev/null'))
@@ -10,6 +11,12 @@ var utc = pino({timestamp: pino.stdTimeFunctions.utcTime}, pino.destination('/de
 var max = 100
 
 var run = bench([
+  function benchPinoIsoTime (cb) {
+    for (var i = 0; i < max; i++) {
+      iso.info('hello world')
+    }
+    setImmediate(cb)
+  },
   function benchPinoEpochTime (cb) {
     for (var i = 0; i < max; i++) {
       epoch.info('hello world')

--- a/lib/time.js
+++ b/lib/time.js
@@ -22,5 +22,6 @@ module.exports = {
   nullTime: nullTime,
   epochTime: epochTime,
   unixTime: unixTime,
-  utcTime: utcTime
+  utcTime: utcTime,
+  defaultTime: utcTime
 }

--- a/lib/time.js
+++ b/lib/time.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const fastDate = require('fast-date')
+
 function nullTime () {
   return ''
 }
@@ -12,8 +14,13 @@ function unixTime () {
   return ',"time":' + Math.round(Date.now() / 1000.0)
 }
 
+function utcTime () {
+  return ',"time": "' + fastDate() + '"'
+}
+
 module.exports = {
   nullTime: nullTime,
   epochTime: epochTime,
-  unixTime: unixTime
+  unixTime: unixTime,
+  utcTime: utcTime
 }

--- a/lib/time.js
+++ b/lib/time.js
@@ -10,12 +10,20 @@ function epochTime () {
   return ',"time":' + Date.now()
 }
 
-function unixTime () {
-  return ',"time":' + Math.round(Date.now() / 1000.0)
-}
+const unixTime = fastDate({
+  format: 'unix',
+  prefix: ',"time":',
+  suffix: ''
+})
 
-function utcTime () {
-  return ',"time": "' + fastDate() + '"'
+const utcTime = fastDate({
+  format: 'utc',
+  prefix: ',"time":"',
+  suffix: '"'
+})
+
+function isoTime () {
+  return ',"time": "' + (new Date()).toISOString() + '"'
 }
 
 module.exports = {
@@ -23,5 +31,6 @@ module.exports = {
   epochTime: epochTime,
   unixTime: unixTime,
   utcTime: utcTime,
+  isoTime: isoTime,
   defaultTime: utcTime
 }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "zuul": "^3.11.1"
   },
   "dependencies": {
+    "fast-date": "^1.0.3",
     "fast-json-parse": "^1.0.3",
     "fast-safe-stringify": "^2.0.4",
     "flatstr": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "zuul": "^3.11.1"
   },
   "dependencies": {
-    "fast-date": "^2.0.0",
+    "fast-date": "^3.0.0",
     "fast-json-parse": "^1.0.3",
     "fast-safe-stringify": "^2.0.4",
     "flatstr": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "zuul": "^3.11.1"
   },
   "dependencies": {
-    "fast-date": "^1.0.3",
+    "fast-date": "^2.0.0",
     "fast-json-parse": "^1.0.3",
     "fast-safe-stringify": "^2.0.4",
     "flatstr": "^1.0.5",

--- a/pino.js
+++ b/pino.js
@@ -22,7 +22,7 @@ var defaultOptions = {
   safe: true,
   name: undefined,
   serializers: {},
-  timestamp: time.utcTime,
+  timestamp: time.defaultTime,
   level: 'info',
   levelVal: undefined,
   prettyPrint: false,

--- a/pino.js
+++ b/pino.js
@@ -22,7 +22,7 @@ var defaultOptions = {
   safe: true,
   name: undefined,
   serializers: {},
-  timestamp: time.epochTime,
+  timestamp: time.utcTime,
   level: 'info',
   levelVal: undefined,
   prettyPrint: false,

--- a/test/extreme.test.js
+++ b/test/extreme.test.js
@@ -13,21 +13,28 @@ if (process.version.indexOf('v0.10') >= 0) {
 }
 
 test('extreme mode', function (t) {
-  var now = Date.now
   var hostname = os.hostname
   var proc = process
   global.process = {
     __proto__: process,
     pid: 123456
   }
-  Date.now = function () {
-    return 1459875739796
+  global.Date = class extends Date {
+    constructor (...args) {
+      args[0] = 1459875739000
+      super(...args)
+    }
+    now () {
+      return 1459875739000
+    }
   }
+
   os.hostname = function () {
     return 'abcdefghijklmnopqr'
   }
   delete require.cache[require.resolve('../')]
   var pino = require('../')
+  pino.stdTimeFunctions.defaultTime()
   var expected = ''
   var actual = ''
   var normal = pino(writeStream(function (s, enc, cb) {
@@ -60,7 +67,7 @@ test('extreme mode', function (t) {
 
     t.teardown(function () {
       os.hostname = hostname
-      Date.now = now
+      global.Date = Object.getPrototypeOf(global.Date)
       global.process = proc
     })
 
@@ -69,16 +76,22 @@ test('extreme mode', function (t) {
 })
 
 test('extreme mode with child', function (t) {
-  var now = Date.now
   var hostname = os.hostname
   var proc = process
   global.process = {
     __proto__: process,
     pid: 123456
   }
-  Date.now = function () {
-    return 1459875739796
+  global.Date = class extends Date {
+    constructor (...args) {
+      args[0] = 1459875739000
+      super(...args)
+    }
+    now () {
+      return 1459875739000
+    }
   }
+
   os.hostname = function () {
     return 'abcdefghijklmnopqr'
   }
@@ -118,7 +131,7 @@ test('extreme mode with child', function (t) {
 
     t.teardown(function () {
       os.hostname = hostname
-      Date.now = now
+      global.Date = Object.getPrototypeOf(global.Date)
       global.process = proc
     })
 

--- a/test/extreme.test.js
+++ b/test/extreme.test.js
@@ -24,7 +24,7 @@ test('extreme mode', function (t) {
       args[0] = 1459875739000
       super(...args)
     }
-    now () {
+    static now () {
       return 1459875739000
     }
   }
@@ -87,7 +87,7 @@ test('extreme mode with child', function (t) {
       args[0] = 1459875739000
       super(...args)
     }
-    now () {
+    static now () {
       return 1459875739000
     }
   }

--- a/test/fixtures/extreme.js
+++ b/test/fixtures/extreme.js
@@ -4,7 +4,7 @@ global.Date = class extends Date {
     args[0] = 1459875739000
     super(...args)
   }
-  now () {
+  static now () {
     return 1459875739000
   }
 }

--- a/test/fixtures/extreme.js
+++ b/test/fixtures/extreme.js
@@ -1,5 +1,13 @@
 global.process = { __proto__: process, pid: 123456 }
-Date.now = function () { return 1459875739796 }
+global.Date = class extends Date {
+  constructor (...args) {
+    args[0] = 1459875739000
+    super(...args)
+  }
+  now () {
+    return 1459875739000
+  }
+}
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 var pino = require(require.resolve('./../../'))
 var extreme = pino(pino.extreme())

--- a/test/fixtures/extreme_child.js
+++ b/test/fixtures/extreme_child.js
@@ -4,7 +4,7 @@ global.Date = class extends Date {
     args[0] = 1459875739000
     super(...args)
   }
-  now () {
+  static now () {
     return 1459875739000
   }
 }

--- a/test/fixtures/extreme_child.js
+++ b/test/fixtures/extreme_child.js
@@ -1,5 +1,13 @@
 global.process = { __proto__: process, pid: 123456 }
-Date.now = function () { return 1459875739796 }
+global.Date = class extends Date {
+  constructor (...args) {
+    args[0] = 1459875739000
+    super(...args)
+  }
+  now () {
+    return 1459875739000
+  }
+}
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 var pino = require(require.resolve('./../../'))
 var extreme = pino(pino.extreme()).child({ hello: 'world' })

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -22,14 +22,14 @@ test('metadata works', function (t) {
       v: 1
     })
   })
-  var now = Date.now()
+  var now = Number(new Date(pino.stdTimeFunctions.defaultTime()))
   var instance = pino({}, {
     [Symbol.for('needsMetadata')]: true,
     write: function (chunk) {
       t.equal(instance, this.lastLogger)
       t.equal(30, this.lastLevel)
       t.equal('a msg', this.lastMsg)
-      t.ok(Number(this.lastTime) >= now)
+      t.ok(Number(new Date(this.lastTime)) >= now)
       t.deepEqual({ hello: 'world' }, this.lastObj)
       dest.write(chunk)
     }

--- a/test/timestamp.test.js
+++ b/test/timestamp.test.js
@@ -5,11 +5,12 @@ var pino = require('../')
 var sink = require('./helper').sink
 
 test('pino exposes standard time functions', function (t) {
-  t.plan(4)
+  t.plan(5)
   t.ok(pino.stdTimeFunctions)
   t.ok(pino.stdTimeFunctions.epochTime)
   t.ok(pino.stdTimeFunctions.unixTime)
   t.ok(pino.stdTimeFunctions.nullTime)
+  t.ok(pino.stdTimeFunctions.utcTime)
 })
 
 test('pino accepts external time functions', function (t) {


### PR DESCRIPTION
I've fixed up http://npm.im/fast-date so it doesn't use internals or deprecated API's, and it's still faster than `Date.now()`. 

Would we consider making UTC the default in pino v5? If not let's at least include it as an option

```
benchPinoEpochTime*10000: 929.780ms
benchPinoUnixTime*10000: 853.191ms
benchPinoUtcTime*10000: 817.595ms
benchPinoEpochTime*10000: 865.573ms
benchPinoUnixTime*10000: 861.808ms
benchPinoUtcTime*10000: 782.988ms
```