### PR TITLE
Add redact API as first class citizen + faster redaction than pino-noir

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 * [Benchmarks](#benchmarks)
 * [API ⇗](docs/API.md)
 * [FAQ ⇗](docs/faq.md)
+* [Redaction ⇗](docs/redaction.md)
 * [Ecosystem ⇗](docs/ecosystem.md)
 * [Pretty Printing ⇗](docs/pretty.md)
 * [Extreme mode explained ⇗](docs/extreme.md)

--- a/benchmarks/redact.bench.js
+++ b/benchmarks/redact.bench.js
@@ -1,0 +1,77 @@
+'use strict'
+
+var bench = require('fastbench')
+var pino = require('../')
+var fs = require('fs')
+var dest = fs.createWriteStream('/dev/null')
+var plog = pino(dest)
+delete require.cache[require.resolve('../')]
+var plogExtreme = require('../')(pino.extreme('/dev/null'))
+delete require.cache[require.resolve('../')]
+var plogUnsafe = require('../')({safe: false}, dest)
+delete require.cache[require.resolve('../')]
+var plogUnsafeExtreme = require('../')({safe: false}, pino.extreme('/dev/null'))
+var plogRedact = pino({redact: ['a.b.c']}, dest)
+delete require.cache[require.resolve('../')]
+var plogExtremeRedact = require('../')({redact: ['a.b.c']}, pino.extreme('/dev/null'))
+delete require.cache[require.resolve('../')]
+var plogUnsafeRedact = require('../')({redact: ['a.b.c'], safe: false}, dest)
+delete require.cache[require.resolve('../')]
+var plogUnsafeExtremeRedact = require('../')({redact: ['a.b.c'], safe: false}, pino.extreme('/dev/null'))
+
+var max = 10
+
+// note that "redact me." is the same amount of bytes as the censor: "[Redacted]"
+
+var run = bench([
+  function benchPinoNoRedact (cb) {
+    for (var i = 0; i < max; i++) {
+      plog.info({a: {b: {c: 'redact me.', d: 'leave me'}}})
+    }
+    setImmediate(cb)
+  },
+  function benchPinoRedact (cb) {
+    for (var i = 0; i < max; i++) {
+      plogRedact.info({a: {b: {c: 'redact me.', d: 'leave me'}}})
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUnsafeNoRedact (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafe.info({a: {b: {c: 'redact me.', d: 'leave me'}}})
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUnsafeRedact (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafeRedact.info({a: {b: {c: 'redact me.', d: 'leave me'}}})
+    }
+    setImmediate(cb)
+  },
+  function benchPinoExtremeNoRedact (cb) {
+    for (var i = 0; i < max; i++) {
+      plogExtreme.info({a: {b: {c: 'redact me.', d: 'leave me'}}})
+    }
+    setImmediate(cb)
+  },
+  function benchPinoExtremeRedact (cb) {
+    for (var i = 0; i < max; i++) {
+      plogExtremeRedact.info({a: {b: {c: 'redact me.', d: 'leave me'}}})
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUnsafeExtremeNoRedact (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafeExtreme.info({a: {b: {c: 'redact me.', d: 'leave me'}}})
+    }
+    setImmediate(cb)
+  },
+  function benchPinoUnsafeExtremeRedact (cb) {
+    for (var i = 0; i < max; i++) {
+      plogUnsafeExtremeRedact.info({a: {b: {c: 'redact me.', d: 'leave me'}}})
+    }
+    setImmediate(cb)
+  }
+], 10000)
+
+run(run)

--- a/docs/API.md
+++ b/docs/API.md
@@ -36,7 +36,7 @@
 # module.exports
 
 <a id="constructor"></a>
-## .pino([options], [stream])
+## pino([options], [stream])
 
 ### Parameters:
 + `options` (object):
@@ -46,9 +46,16 @@
   * `serializers` (object): an object containing functions for custom serialization
     of objects. These functions should return an JSONifiable object and they
     should never throw. When logging an object, each top-level property matching the exact key of a serializer
-    will be serialized using the defined serializer.
-
-    Alternatively, it is possible to register a serializer under the key `Symbol.for('pino.*')` which will act upon the complete log object, i.e. every property.
+    will be serialized using the defined serializer. Alternatively, it is possible to register a serializer under the key `Symbol.for('pino.*')` which will act upon the complete log object, i.e. every property.
+  * `redact` (array|object): As an array, the `redact` option specifies paths that should 
+     have their values redacted from any log output. Each path must be a string, and the syntax
+     for declaring paths corresponds to JavaScript dot and bracket notation. 
+     See the [redaction](redaction.md) documentation for examples and more information.
+     **WARNING**: Never allow user input to define redacted paths. See [fast-redact#caveat](http://github.com/davidmarkclements/fast-redact#caveat) for details.
+     If an object is supplied, three options can be specified: 
+     * `paths` (array): Required. An array of paths
+     * `censor` (string): Optional. A value to overwrite key which are to be redacted. Default: `'[Redacted]'` 
+     * `remove` (boolean): Optional. Instead of censoring the value, remove both the key and the value. Default: `false`
   * `timestamp` (boolean|function): Enables or disables the inclusion of a timestamp in the
     log message. If a function is supplied, it must synchronously return a JSON string
     representation of the time, e.g. `,"time":1493426328206` (which is the default).

--- a/docs/howtos.md
+++ b/docs/howtos.md
@@ -7,7 +7,6 @@
 + [How to use Pino with debug](#debug)
 + [How to rotate log files](#rotate)
 + [How to save to multiple files](#multiple)
-+ [How to redact sensitive information](#redact)
 
 <a id="express"></a>
 ## How to use Pino with Express
@@ -214,41 +213,4 @@ writing only warnings and errors to `./warn-log:
 
 ```bash
 node app.js | pino-tee warn ./warn-logs > ./all-logs
-```
-
-<a id="redact"></a>
-## How do I redact sensitive information??
-
-Use [pino-noir](http://npm.im/pino-noir) for performant log redaction:
-
-Install and require [pino-noir](http://npm.im/pino-noir),
-initialize with the key paths you wish to redact and pass the
-resulting instance in through the `serializers` option
-
-```js
-var noir = require('pino-noir')
-var pino = require('pino')({
-  serializers: noir(['key', 'path.to.key'])
-})
-
-pino.info({
-  key: 'will be redacted',
-  path: {
-    to: {key: 'sensitive', another: 'thing'}
-  },
-  more: 'stuff'
-})
-
-// {"pid":7306,"hostname":"x","level":30,"time":1475519922198,"key":"[Redacted]","path":{"to":{"key":"[Redacted]","another":"thing"}},"more":"stuff","v":1}
-```
-
-If you have other serializers simply extend:
-
-```js
-var noir = require('pino-noir')
-var pino = require('pino')({
-  serializers: Object.assign(
-    noir(['key', 'path.to.key']),
-    {myCustomSerializer: () => {}}
-})
 ```

--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -1,0 +1,116 @@
+# Redaction
+
+To redact sensitive information, supply paths to keys that hold sensitive data 
+using the `redact` option:
+
+```js
+var pino = require('.')({
+  redact: ['key', 'path.to.key', 'stuff.thats[*].secret']
+})
+
+pino.info({
+  key: 'will be redacted',
+  path: {
+    to: {key: 'sensitive', another: 'thing'}
+  },
+  stuff: {
+    thats: [
+      {secret: 'will be redacted', logme: 'will be logged'},
+      {secret: 'as will this', logme: 'as will this'}
+    ]
+  }
+})
+```
+
+This will output:
+
+```JSON
+{"level":30,"time":1527777350011,"pid":3186,"hostname":"Davids-MacBook-Pro-3.local","key":"[Redacted]","path":{"to":{"key":"[Redacted]","another":"thing"}},"stuff":{"thats":[{"secret":"[Redacted]","logme":"will be logged"},{"secret":"[Redacted]","logme":"as will this"}]},"v":1}
+```
+
+The `redact` option can take an array (as shown in the above example) or 
+an object. This allows control over *how* information is redacted.
+
+For instance, setting the censor: 
+
+```js
+var pino = require('.')({
+  redact: {
+    paths: ['key', 'path.to.key', 'stuff.thats[*].secret'],
+    censor: '**GDPR COMPLIANT**'
+  }
+})
+
+pino.info({
+  key: 'will be redacted',
+  path: {
+    to: {key: 'sensitive', another: 'thing'}
+  },
+  stuff: {
+    thats: [
+      {secret: 'will be redacted', logme: 'will be logged'},
+      {secret: 'as will this', logme: 'as will this'}
+    ]
+  }
+})
+```
+
+This will output: 
+
+```JSON
+{"level":30,"time":1527778563934,"pid":3847,"hostname":"Davids-MacBook-Pro-3.local","key":"**GDPR COMPLIANT**","path":{"to":{"key":"**GDPR COMPLIANT**","another":"thing"}},"stuff":{"thats":[{"secret":"**GDPR COMPLIANT**","logme":"will be logged"},{"secret":"**GDPR COMPLIANT**","logme":"as will this"}]},"v":1}
+```
+
+The `redact.remove` option also allows for the key and value to be removed from output:
+
+```js
+var pino = require('.')({
+  redact: {
+    paths: ['key', 'path.to.key', 'stuff.thats[*].secret'],
+    remove: true
+  }
+})
+
+pino.info({
+  key: 'will be redacted',
+  path: {
+    to: {key: 'sensitive', another: 'thing'}
+  },
+  stuff: {
+    thats: [
+      {secret: 'will be redacted', logme: 'will be logged'},
+      {secret: 'as will this', logme: 'as will this'}
+    ]
+  }
+})
+```
+
+This will output
+
+```JSON
+{"level":30,"time":1527782356751,"pid":5758,"hostname":"Davids-MacBook-Pro-3.local","path":{"to":{"another":"thing"}},"stuff":{"thats":[{"logme":"will be logged"},{"logme":"as will this"}]},"v":1}
+```
+
+See [pino options in API](API.md#pino) for `redact` API details.
+
+## Overhead
+
+Pino's redaction functionality is built on top of [`fast-redact`](http://github.com/davidmarkclements/fast-redact)
+which adds about 2% overhead to `JSON.stringify` when using paths without wildcards.
+
+When used with pino logger with a single redacted path, any overhead is within noise - we haven't found
+a way to deterministically measure it's effect. This is because its not a bottleneck.
+
+However, wildcard redaction does carry a non-trivial cost relative to explicitly declaring the keys 
+(50% in a case where four keys are redacted across two objects). See 
+the [`fast-redact` benchmarks](https://github.com/davidmarkclements/fast-redact#benchmarks) for details.
+
+## Safety
+
+The `redact` option is intended as an initialization time configuration option. 
+It's extremely important that path strings do not originate from user input.  
+The `fast-redact` module uses a VM context to syntax check the paths, user input
+should never be combined with such an approach. See the [`fast-redact` Caveat](https://github.com/davidmarkclements/fast-redact#caveat)
+and the [`fast-redact` Approach](https://github.com/davidmarkclements/fast-redact#approach) for in-depth information. 
+
+

--- a/lib/redact.js
+++ b/lib/redact.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const fastRedact = require('fast-redact')
+const { rx, validator } = fastRedact
+
+const validate = validator({
+  ERR_CENSOR_MUST_BE_FUNCTION: () => 'pino – censor option may not be a function',
+  ERR_PATHS_MUST_BE_STRINGS: () => 'pino – redact option must be an array of strings',
+  ERR_INVALID_PATH: (s) => `pino – redact array contains an invalid path (${s})`
+})
+
+module.exports = function redact ({paths, censor, serialize}) {
+  assertValid(paths, censor)
+
+  const shape = paths.reduce((o, str) => {
+    rx.lastIndex = 0
+    rx.exec(str)
+    const { index } = rx.exec(str)
+    o[str.substr(0, index - 1)] = o[str.substr(0, index - 1)] || []
+    o[str.substr(0, index - 1)].push(str.substr(index, str.length - 1))
+    return o
+  }, {})
+
+  return Object.keys(shape).reduce((o, k) => {
+    o[k] = fastRedact({paths: shape[k], censor, serialize})
+    return o
+  }, {})
+}
+
+function assertValid (paths, censor) {
+  if (Array.isArray(paths) === false) { throw Error('pino – redact option must be an array of strings') }
+  validate({paths, censor})
+}

--- a/lib/redact.js
+++ b/lib/redact.js
@@ -44,7 +44,6 @@ function redact (opts, serialize) {
   }
   const serializedCensor = serialize(censor)
   const topCensor = () => serializedCensor
-
   return Object.keys(shape).reduce((o, k) => {
     // top level key:
     if (shape[k] === null) o[k] = topCensor

--- a/lib/redact.js
+++ b/lib/redact.js
@@ -9,7 +9,14 @@ const validate = validator({
   ERR_INVALID_PATH: (s) => `pino – redact array contains an invalid path (${s})`
 })
 
-module.exports = function redact ({paths, censor, serialize}) {
+// symbol for private use
+const format = Symbol('pino.format')
+
+redact.format = format
+
+module.exports = redact
+
+function redact ({paths, censor, serialize}) {
   assertValid(paths, censor)
 
   const shape = paths.reduce((o, str) => {
@@ -21,10 +28,17 @@ module.exports = function redact ({paths, censor, serialize}) {
     return o
   }, {})
 
+  // the redactor assigned to the format symbol key
+  // provides top level redaction for instances where
+  // an object is interpolated into the msg string
+  const result = {
+    [format]: fastRedact({paths, censor, serialize})
+  }
+
   return Object.keys(shape).reduce((o, k) => {
     o[k] = fastRedact({paths: shape[k], censor, serialize})
     return o
-  }, {})
+  }, result)
 }
 
 function assertValid (paths, censor) {

--- a/lib/redact.js
+++ b/lib/redact.js
@@ -24,7 +24,13 @@ function redact (opts, serialize) {
   const shape = paths.reduce((o, str) => {
     rx.lastIndex = 0
     rx.exec(str)
-    const { index } = rx.exec(str)
+    const next = rx.exec(str)
+    // top level key:
+    if (next === null) {
+      o[str] = null
+      return o
+    }
+    const { index } = next
     o[str.substr(0, index - 1)] = o[str.substr(0, index - 1)] || []
     o[str.substr(0, index - 1)].push(str.substr(index, str.length - 1))
     return o
@@ -36,9 +42,13 @@ function redact (opts, serialize) {
   const result = {
     [format]: fastRedact({paths, censor, serialize})
   }
+  const serializedCensor = serialize(censor)
+  const topCensor = () => serializedCensor
 
   return Object.keys(shape).reduce((o, k) => {
-    o[k] = fastRedact({paths: shape[k], censor, serialize})
+    // top level key:
+    if (shape[k] === null) o[k] = topCensor
+    else o[k] = fastRedact({paths: shape[k], censor, serialize})
     return o
   }, result)
 }

--- a/lib/redact.js
+++ b/lib/redact.js
@@ -4,20 +4,22 @@ const fastRedact = require('fast-redact')
 const { rx, validator } = fastRedact
 
 const validate = validator({
-  ERR_CENSOR_MUST_BE_FUNCTION: () => 'pino – censor option may not be a function',
-  ERR_PATHS_MUST_BE_STRINGS: () => 'pino – redact option must be an array of strings',
-  ERR_INVALID_PATH: (s) => `pino – redact array contains an invalid path (${s})`
+  ERR_CENSOR_MUST_NOT_BE_FUNCTION: () => 'pino – censor option may not be a function',
+  ERR_PATHS_MUST_BE_STRINGS: () => 'pino – redacted paths must be strings',
+  ERR_INVALID_PATH: (s) => `pino – redact paths array contains an invalid path (${s})`
 })
 
 // symbol for private use
 const format = Symbol('pino.format')
 
+const CENSOR = '[Redacted]'
+
 redact.format = format
 
 module.exports = redact
 
-function redact ({paths, censor, serialize}) {
-  assertValid(paths, censor)
+function redact (opts, serialize) {
+  const { paths, censor } = handle(opts)
 
   const shape = paths.reduce((o, str) => {
     rx.lastIndex = 0
@@ -41,7 +43,16 @@ function redact ({paths, censor, serialize}) {
   }, result)
 }
 
-function assertValid (paths, censor) {
-  if (Array.isArray(paths) === false) { throw Error('pino – redact option must be an array of strings') }
+function handle (opts) {
+  if (Array.isArray(opts)) {
+    opts = {paths: opts, censor: CENSOR}
+    validate(opts)
+    return opts
+  }
+  var { paths, censor = CENSOR, remove } = opts
+  if (Array.isArray(paths) === false) { throw Error('pino – redact must contain an array of strings') }
+  if (remove === true) censor = undefined
   validate({paths, censor})
+
+  return {paths, censor}
 }

--- a/package.json
+++ b/package.json
@@ -79,12 +79,12 @@
   },
   "dependencies": {
     "fast-json-parse": "^1.0.3",
-    "fast-redact": "^1.0.1",
+    "fast-redact": "^1.1.2",
     "fast-safe-stringify": "^2.0.4",
     "flatstr": "^1.0.5",
     "pino-std-serializers": "^2.0.0",
     "pump": "^3.0.0",
-    "quick-format-unescaped": "^1.1.2",
+    "quick-format-unescaped": "^2.0.1",
     "sonic-boom": "^0.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   },
   "dependencies": {
     "fast-json-parse": "^1.0.3",
+    "fast-redact": "^1.0.1",
     "fast-safe-stringify": "^2.0.4",
     "flatstr": "^1.0.5",
     "pino-std-serializers": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   },
   "dependencies": {
     "fast-json-parse": "^1.0.3",
-    "fast-redact": "^1.1.2",
+    "fast-redact": "^1.1.13",
     "fast-safe-stringify": "^2.0.4",
     "flatstr": "^1.0.5",
     "pino-std-serializers": "^2.0.0",

--- a/pino.js
+++ b/pino.js
@@ -23,8 +23,7 @@ var defaultOptions = {
   safe: true,
   name: undefined,
   serializers: {},
-  redact: [],
-  censor: '[Redacted]',
+  redact: null,
   timestamp: time.epochTime,
   level: 'info',
   levelVal: undefined,
@@ -300,12 +299,8 @@ function pino (opts, stream) {
 
   // internal options
   iopts.stringify = iopts.safe ? stringifySafe : JSON.stringify
-  iopts.stringifiers = (iopts.redact.length > 0) ? redact({
-    paths: iopts.redact,
-    censor: iopts.censor,
-    serialize: iopts.stringify
-  }) : {}
-  iopts.formatOpts = (iopts.redact.length > 0)
+  iopts.stringifiers = iopts.redact ? redact(iopts.redact, iopts.stringify) : {}
+  iopts.formatOpts = iopts.redact
     ? {stringify: iopts.stringifiers[redact.format]}
     : {stringify: iopts.stringify}
   iopts.messageKeyString = `,"${iopts.messageKey}":`

--- a/pino.js
+++ b/pino.js
@@ -193,7 +193,8 @@ function child (bindings) {
     chindings: asChindings(this, bindings),
     level: bindings.level || this.level,
     levelVal: isStandardLevelVal(this.levelVal) ? undefined : this.levelVal,
-    serializers: bindings.hasOwnProperty('serializers') ? Object.assign({}, this.serializers, bindings.serializers) : this.serializers
+    serializers: bindings.hasOwnProperty('serializers') ? Object.assign({}, this.serializers, bindings.serializers) : this.serializers,
+    stringifiers: this.stringifiers
   }
 
   var _child = Object.create(this)
@@ -304,7 +305,9 @@ function pino (opts, stream) {
     censor: iopts.censor,
     serialize: iopts.stringify
   }) : {}
-  iopts.formatOpts = {lowres: true}
+  iopts.formatOpts = (iopts.redact.length > 0)
+    ? {stringify: iopts.stringifiers[redact.format]}
+    : {stringify: iopts.stringify}
   iopts.messageKeyString = `,"${iopts.messageKey}":`
   iopts.end = ',"v":' + LOG_VERSION + '}' + (iopts.crlf ? '\r\n' : '\n')
   iopts.chindings = ''
@@ -322,7 +325,7 @@ function pino (opts, stream) {
   instance.end = iopts.end
   instance.name = iopts.name
   instance.timestamp = iopts.timestamp
-  instance.formatiopts = iopts.formatiopts
+  instance.formatOpts = iopts.formatOpts
   instance.onTerminated = iopts.onTerminated
   instance.messageKey = iopts.messageKey
   instance.messageKeyString = iopts.messageKeyString

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -1,0 +1,119 @@
+'use strict'
+
+var test = require('tap').test
+var pino = require('../')
+var sink = require('./helper').sink
+
+test('redact option – throws if not array', function (t) {
+  t.throws(() => {
+    pino({redact: 'req.headers.cookie'})
+  })
+  t.end()
+})
+
+test('redact option – throws if array does not only contain strings', function (t) {
+  t.throws(() => {
+    pino({redact: ['req.headers.cookie', {}]})
+  })
+  t.end()
+})
+
+test('redact option – throws if array contains an invalid path', function (t) {
+  t.throws(() => {
+    pino({redact: ['req,headers.cookie']})
+  })
+  t.end()
+})
+
+test('censor option – throws if censor is a function', function (t) {
+  t.throws(() => {
+    pino({redact: ['req.headers.cookie'], censor: () => {}})
+  })
+  t.end()
+})
+
+test('redact option – object', function (t) {
+  var instance = pino({redact: ['req.headers.cookie']}, sink(function (o, enc, cb) {
+    t.equals(o.req.headers.cookie, '[Redacted]')
+    t.end()
+  }))
+  instance.info({
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  })
+})
+
+test('redact option – child object', function (t) {
+  var instance = pino({redact: ['req.headers.cookie']}, sink(function (o, enc, cb) {
+    t.equals(o.req.headers.cookie, '[Redacted]')
+    t.end()
+  }))
+
+  instance.child({
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  }).info('message completed')
+})
+
+test('redact option – interpolated object', function (t) {
+  var instance = pino({redact: ['req.headers.cookie']}, sink(function (o, enc, cb) {
+    t.equals(JSON.parse(o.msg.replace(/test /, '')).req.headers.cookie, '[Redacted]')
+    t.end()
+  }))
+
+  instance.info('test', {
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  })
+})
+
+test('censor option – sets the redact value', function (t) {
+  var instance = pino({redact: ['req.headers.cookie'], censor: 'test'}, sink(function (o, enc, cb) {
+    t.equals(o.req.headers.cookie, 'test')
+    t.end()
+  }))
+  instance.info({
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  })
+})

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -53,6 +53,16 @@ test('redact.censor option – throws if censor is a function', function (t) {
   t.end()
 })
 
+test('redact option – top level key', function (t) {
+  var instance = pino({redact: ['key']}, sink(function (o, enc, cb) {
+    t.equals(o.key, '[Redacted]')
+    t.end()
+  }))
+  instance.info({
+    key: {redact: 'me'}
+  })
+})
+
 test('redact option – object', function (t) {
   var instance = pino({redact: ['req.headers.cookie']}, sink(function (o, enc, cb) {
     t.equals(o.req.headers.cookie, '[Redacted]')
@@ -222,6 +232,16 @@ test('redact.remove option – removes both key and value', function (t) {
       remoteAddress: '::ffff:127.0.0.1',
       remotePort: 58022
     }
+  })
+})
+
+test('redact.remove – top level key', function (t) {
+  var instance = pino({redact: {paths: ['key'], remove: true}}, sink(function (o, enc, cb) {
+    t.equals('key' in o, false)
+    t.end()
+  }))
+  instance.info({
+    key: {redact: 'me'}
   })
 })
 

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -25,9 +25,30 @@ test('redact option – throws if array contains an invalid path', function (t) 
   t.end()
 })
 
-test('censor option – throws if censor is a function', function (t) {
+test('redact.paths option – throws if not array', function (t) {
   t.throws(() => {
-    pino({redact: ['req.headers.cookie'], censor: () => {}})
+    pino({redact: {paths: 'req.headers.cookie'}})
+  })
+  t.end()
+})
+
+test('redact.paths option – throws if array does not only contain strings', function (t) {
+  t.throws(() => {
+    pino({redact: {paths: ['req.headers.cookie', {}]}})
+  })
+  t.end()
+})
+
+test('redact.paths option – throws if array contains an invalid path', function (t) {
+  t.throws(() => {
+    pino({redact: {paths: ['req,headers.cookie']}})
+  })
+  t.end()
+})
+
+test('redact.censor option – throws if censor is a function', function (t) {
+  t.throws(() => {
+    pino({redact: {paths: ['req.headers.cookie'], censor: () => {}}})
   })
   t.end()
 })
@@ -97,9 +118,231 @@ test('redact option – interpolated object', function (t) {
   })
 })
 
-test('censor option – sets the redact value', function (t) {
-  var instance = pino({redact: ['req.headers.cookie'], censor: 'test'}, sink(function (o, enc, cb) {
+test('redact.paths option – object', function (t) {
+  var instance = pino({redact: {paths: ['req.headers.cookie']}}, sink(function (o, enc, cb) {
+    t.equals(o.req.headers.cookie, '[Redacted]')
+    t.end()
+  }))
+  instance.info({
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  })
+})
+
+test('redact.paths option – child object', function (t) {
+  var instance = pino({redact: {paths: ['req.headers.cookie']}}, sink(function (o, enc, cb) {
+    t.equals(o.req.headers.cookie, '[Redacted]')
+    t.end()
+  }))
+
+  instance.child({
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  }).info('message completed')
+})
+
+test('redact.paths option – interpolated object', function (t) {
+  var instance = pino({redact: {paths: ['req.headers.cookie']}}, sink(function (o, enc, cb) {
+    t.equals(JSON.parse(o.msg.replace(/test /, '')).req.headers.cookie, '[Redacted]')
+    t.end()
+  }))
+
+  instance.info('test', {
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  })
+})
+
+test('redact.censor option – sets the redact value', function (t) {
+  var instance = pino({redact: {paths: ['req.headers.cookie'], censor: 'test'}}, sink(function (o, enc, cb) {
     t.equals(o.req.headers.cookie, 'test')
+    t.end()
+  }))
+  instance.info({
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  })
+})
+
+test('redact.remove option – removes both key and value', function (t) {
+  var instance = pino({redact: {paths: ['req.headers.cookie'], remove: true}}, sink(function (o, enc, cb) {
+    t.equals('cookie' in o.req.headers, false)
+    t.end()
+  }))
+  instance.info({
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  })
+})
+
+test('redact.paths preserves original object values after the log write', function (t) {
+  var instance = pino({redact: ['req.headers.cookie']}, sink(function (o, enc, cb) {
+    t.equals(o.req.headers.cookie, '[Redacted]')
+    t.equals(obj.req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
+    t.end()
+  }))
+  const obj = {
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  }
+  instance.info(obj)
+})
+
+test('redact.paths preserves original object values after the log write', function (t) {
+  var instance = pino({redact: {paths: ['req.headers.cookie']}}, sink(function (o, enc, cb) {
+    t.equals(o.req.headers.cookie, '[Redacted]')
+    t.equals(obj.req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
+    t.end()
+  }))
+  const obj = {
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  }
+  instance.info(obj)
+})
+
+test('redact.censor preserves original object values after the log write', function (t) {
+  var instance = pino({redact: {paths: ['req.headers.cookie'], censor: 'test'}}, sink(function (o, enc, cb) {
+    t.equals(o.req.headers.cookie, 'test')
+    t.equals(obj.req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
+    t.end()
+  }))
+  const obj = {
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  }
+  instance.info(obj)
+})
+
+test('redact.remove preserves original object values after the log write', function (t) {
+  var instance = pino({redact: {paths: ['req.headers.cookie'], remove: true}}, sink(function (o, enc, cb) {
+    t.equals('cookie' in o.req.headers, false)
+    t.equals('cookie' in obj.req.headers, true)
+    t.end()
+  }))
+  const obj = {
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  }
+  instance.info(obj)
+})
+
+test('redact – supports last position wildcard paths', function (t) {
+  var instance = pino({redact: ['req.headers.*']}, sink(function (o, enc, cb) {
+    t.equals(o.req.headers.cookie, '[Redacted]')
+    t.equals(o.req.headers.host, '[Redacted]')
+    t.equals(o.req.headers.connection, '[Redacted]')
+    t.end()
+  }))
+  instance.info({
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  })
+})
+
+test('redact – supports intermediate wildcard paths', function (t) {
+  var instance = pino({redact: ['req.*.cookie']}, sink(function (o, enc, cb) {
+    t.equals(o.req.headers.cookie, '[Redacted]')
     t.end()
   }))
   instance.info({


### PR DESCRIPTION
This integrates pino with [fast-redact](http://github.com/davidmarkclements/fast-redact) which is a generic version of `pino-noir` but adds 16x less over head to serialization (28% overhead with `pino-noir` vs 2% overhead with `fast-redact`)

`fast-redact`  will only work with Node 6+ because of its use of `Proxy` to validate paths, this is why it's appropriate for pino v5.

The proposal is:

* Redaction is a first class citizen in Pino v5
* In Pino v4, `pino-noir` remains as the method of redaction
* This also enables (fast) intermediate wildcards (e.g. a.*.c) which `pino-noir` doesn't have

These factors together with the speed improvements should further incentivize upgrading to v5.

The PR adds `redact` and `censor` options (`censor` defaults to `[Redacted]`)

```js
require('pino')({
  redact: ['req.headers.cookie'],
  censor: 'hidden :D'
})
```

This API solves leaky abstraction in pino-noir (having to pass in the standard serializers), 
and side steps the issue of needing to tag a serializer that.. well.. actually serializes. After spending some time thinking about it, imnho it's the cleanest and fastest way to integrate (we don't have to worry about whether `safe` is false etc etc)

## Redact benchmarks

Overhead of redaction is very low, sometimes redaction is faster – I chose a run where it's not faster. At any rate, redaction is within noise.

```sh
node benchmarks/redact.bench
```

```
benchPinoNoRedact*10000: 349.224ms
benchPinoRedact*10000: 350.569ms
benchPinoUnsafeNoRedact*10000: 327.524ms
benchPinoUnsafeRedact*10000: 330.655ms
benchPinoExtremeNoRedact*10000: 205.040ms
benchPinoExtremeRedact*10000: 215.273ms
benchPinoUnsafeExtremeNoRedact*10000: 193.195ms
benchPinoUnsafeExtremeRedact*10000: 193.174ms
```

## Server overhead

When linking this branch into `pino-http` and then redacting a Cookie header the overhead is within noise, it's hard to verify exactly without using an isolated machine - but  the redacting server is frequently faster by a few %. This is probably because the non-redacting server because it's serializing and writing fewer bytes but also, this redaction may be triggering further V8 optimizations (see benchmarks). Even setting the `censor` to the same content as the Cookie header yields either more or similar req/s as having no redaction.

This is the redacting server:
```js
var http = require('http')
var server = http.createServer(handle)

var logger = require('../')({
  redact: ['req.headers.cookie']
})

function handle (req, res) {
  logger(req, res)
  res.end('hello world')
}

server.listen(3000)
```

This is the `autocannon` command (using higher duration and connections to try to reduce the noise to signal ratio):

```sh
autocannon -d60 -c50 -H Cookie="SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;" localhost:3000
```

Results for the redacting server are:
```
Stat         Avg     Stdev  Max
Latency (ms) 2.63    0.77   39.75
Req/Sec      15985.8 987.5  18209
Bytes/Sec    1.77 MB 111 kB 2.02 MB
```

If we take redaction out, results are:

```
Latency (ms) 2.75     0.73    28.55
Req/Sec      15728.87 744.53  18668
Bytes/Sec    1.75 MB  86.1 kB 2.07 MB
```

Over several runs results fluctuate, essentially adding redaction to a server is within noise.

## Comparison Benchmarks

The global cost of adding redaction is adding a `stringifiers` object and checking if `stringifiers[key]` exists before using `this.stringify`. 

`benchmarks/object.bench.js` for just the pino benchmarks

### This branch:

```
benchPinoObj*10000: 299.598ms
benchPinoUnsafeObj*10000: 265.580ms
benchPinoExtremeObj*10000: 143.180ms
benchPinoUnsafeExtremeObj*10000: 140.752ms
```

### next-major

```
benchPinoObj*10000: 301.574ms
benchPinoUnsafeObj*10000: 275.551ms
benchPinoExtremeObj*10000: 158.657ms
benchPinoUnsafeExtremeObj*10000: 145.294ms
```

The cost of this change is approximately zero.


## Tests and Docs

I'll add tests and docs once we're in agreement on API






