### PR TITLE
fix: formatOpts typo

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -320,7 +320,7 @@ function pino (opts, stream) {
   instance.timestamp = iopts.timestamp
   instance.slowtime = iopts.slowtime
   instance.cache = iopts.cache
-  instance.formatiopts = iopts.formatiopts
+  instance.formatOpts = iopts.formatOpts
   instance.onTerminated = iopts.onTerminated
   instance.messageKey = iopts.messageKey
   instance.messageKeyString = iopts.messageKeyString

--- a/pino.js
+++ b/pino.js
@@ -297,7 +297,7 @@ function pino (opts, stream) {
 
   // internal options
   iopts.stringify = iopts.safe ? stringifySafe : JSON.stringify
-  iopts.formatOpts = {lowres: true}
+  iopts.formatOpts = {lowres: !iopts.safe}
   iopts.messageKeyString = `,"${iopts.messageKey}":`
   iopts.end = ',"v":' + LOG_VERSION + '}' + (iopts.crlf ? '\r\n' : '\n')
   iopts.cache = !iopts.extreme ? null : {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -506,3 +506,25 @@ test('when safe is true it should ONLY use `fast-safe-stringify`', function (t) 
   })
   t.end()
 })
+
+test('when safe is true, fast-safe-stringify must be used when interpolating', function (t) {
+  var instance = pino({safe: true}, sink(function (chunk, enc, cb) {
+    const { msg } = chunk
+    t.is(msg, 'test {"a":{"b":{"c":"[Circular]"}}}')
+    t.end()
+  }))
+  var o = { a: { b: {} } }
+  o.a.b.c = o.a.b
+  instance.info('test', o)
+})
+
+test('when safe is false, interpolation output circulars at the root', function (t) {
+  var instance = pino({safe: false}, sink(function (chunk, enc, cb) {
+    const { msg } = chunk
+    t.is(msg, 'test "[Circular]"')
+    t.end()
+  }))
+  var o = { a: { b: {} } }
+  o.a.b.c = o.a.b
+  instance.info('test', o)
+})


### PR DESCRIPTION
search and replace gone awry

So the impact of this not saying `formatOpts` means that `{lowres: true}` was not being passed to `quick-format-unescape` which means any log messages that interpolate an object with a circular will say 'text content "[Circular]"' instead of 'text content {"path": {"to": "[Circular]"}}'