### PR TITLE
feat: flush & flushSync

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -369,6 +369,13 @@ parameters will be reduced accodringly.
 Flushes the content of the buffer in [extreme mode](extreme.md). It has no effect if
 extreme mode is not enabled.
 
+<a id="flushSync"></a>
+## .flushSync()
+
+### Discussion:
+Synchronously flushes the content of the buffer in [extreme mode](extreme.md). It has no effect if
+extreme mode is not enabled.
+
 <a id="addLevel"></a>
 ## .addLevel(name, lvl)
 

--- a/pino.js
+++ b/pino.js
@@ -221,15 +221,27 @@ Object.defineProperty(pinoPrototype, 'write', {
 })
 
 function flush () {
+  if (!this.stream.flush) {
+    return
+  }
+
+  this.stream.flush()
+}
+Object.defineProperty(pinoPrototype, 'flush', {
+  enumerable: true,
+  value: flush
+})
+
+function flushSync () {
   if (!this.stream.flushSync) {
     return
   }
 
   this.stream.flushSync()
 }
-Object.defineProperty(pinoPrototype, 'flush', {
+Object.defineProperty(pinoPrototype, 'flushSync', {
   enumerable: true,
-  value: flush
+  value: flushSync
 })
 
 function addLevel (name, lvl) {

--- a/test/extreme.test.js
+++ b/test/extreme.test.js
@@ -139,3 +139,21 @@ test('flush does nothing without extreme mode', function (t) {
   instance.flush()
   t.end()
 })
+
+test('flushSync does something with extreme mode', function (t) {
+  var instance = require('..')()
+  instance.flushSync()
+  t.end()
+})
+
+test('flushSync ensure stream is not writing', function (t) {
+  var pino = require('../')
+  var dest = pino.extreme()
+  var instance = pino(dest)
+  dest.write('hello world')
+  instance.flush()
+  t.equal(instance.stream._writing, true)
+  instance.flushSync()
+  t.equal(instance.stream._writing, false)
+  t.end()
+})


### PR DESCRIPTION
When in extreme mode you want to be able to flush to log every second but without blocking the event thread. The only time you usually want to do a sync flush is on shutdown.

e.g.

```js
setInterval(() => logger.flush(), 1000)
function terminate(code) {
   logger.flushSync()
   process.terminate(code)
}
```