### PR TITLE
fix: support logging errors that do not contain a stack

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -146,7 +146,8 @@ function asJson (obj, msg, num, time) {
   if (hasObj) {
     var notHasOwnProperty = obj.hasOwnProperty === undefined
     if (objError) {
-      data += ',"type":"Error","stack":' + this.stringify(obj.stack)
+      data += ',"type":"Error"'
+      data += obj.stack ? ',"stack":' + this.stringify(obj.stack) : ''
     }
     // if global serializer is set, call it first
     if (this.serializers[Symbol.for('pino.*')]) {

--- a/pretty.js
+++ b/pretty.js
@@ -217,7 +217,9 @@ function pretty (opts) {
     line += eol
 
     if (value.type === 'Error') {
-      line += '    ' + withSpaces(value.stack, eol) + eol
+      line += value.stack
+        ? '    ' + withSpaces(value.stack, eol) + eol
+        : ''
 
       var propsForPrint
       if (errorProps && errorProps.length > 0) {

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -128,3 +128,18 @@ test('an error with statusCode property is not confused for a http response', fu
   instance.level = name
   instance[name](err)
 })
+
+test('stack is omitted if it is not set on err', t => {
+  t.plan(2)
+  var err = new Error('myerror')
+  delete err.stack
+  var instance = pino(sink(function (chunk, enc, cb) {
+    t.ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
+    delete chunk.time
+    t.equal(chunk.hasOwnProperty('stack'), false)
+    cb()
+  }))
+
+  instance.level = name
+  instance[name](err)
+})

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -105,6 +105,24 @@ test('pino transform prettifies Error', function (t) {
   instance.info(err)
 })
 
+test('pino transform prettifies Error without stack', function (t) {
+  var prettier = pretty()
+  var err = new Error('hello world')
+  delete err.stack
+  var expected = [err.message]
+
+  t.plan(expected.length)
+
+  prettier.pipe(split(function (line) {
+    t.ok(line.indexOf(expected.shift()) >= 0, 'line matches')
+    return line
+  }))
+
+  var instance = pino(prettier)
+
+  instance.info(err)
+})
+
 function getIndentLevel (str) {
   return (/^\s*/.exec(str) || [''])[0].length
 }


### PR DESCRIPTION
Fixes #456 

Custom errors may not have their stack property set.
Pino used to serialize undefined stack which created invalid JSON output

Given the following contrived example:
```js
const logger = require('pino')();
const err = new Error();
delete err.stack;
logger.error(err);
```
Would output:
```
{"level":50,"time":1532087320790,"msg":"","pid":20631,"hostname":"dev.local","type":"Error","stack":undefined,"v":1}
```
This is invalid JSON due to the `"stack":undefined` at the end of that output line.

This PR adds a fix to avoid logging the stack if it is not set. So the above code now outputs:

```
{"level":50,"time":1532094347667,"msg":"","pid":25624,"hostname":"dev.local","type":"Error","v":1}
```