### PR TITLE
Improve the deep benchmark by 10%

### DIFF
--- a/benchmarks/deep-object.bench.js
+++ b/benchmarks/deep-object.bench.js
@@ -18,9 +18,6 @@ const plogUnsafeExtreme = require('../')({safe: false}, pino.extreme('/dev/null'
 const loglevel = require('./utils/wrap-log-level')(dest)
 
 const deep = Object.assign({}, require('../package.json'), { level: 'info' })
-deep.deep = Object.assign({}, JSON.parse(JSON.stringify(deep)))
-deep.deep.deep = Object.assign({}, JSON.parse(JSON.stringify(deep)))
-deep.deep.deep.deep = Object.assign({}, JSON.parse(JSON.stringify(deep)))
 
 const max = 10
 const blog = bunyan.createLogger({

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -45,7 +45,7 @@ function asString (str) {
   var found = false
   var point = 255
   const l = str.length
-  if (l > 42) {
+  if (l > 100) {
     return JSON.stringify(str)
   }
   for (var i = 0; i < l && point >= 32; i++) {
@@ -95,9 +95,26 @@ function asJson (obj, msg, num, time) {
     for (var key in obj) {
       value = obj[key]
       if ((notHasOwnProperty || obj.hasOwnProperty(key)) && value !== undefined) {
-        value = (stringifiers[key] || stringify)(serializers[key] ? serializers[key](value) : value)
-        if (value !== undefined) {
-          data += ',"' + key + '":' + value
+        value = serializers[key] ? serializers[key](value) : value
+
+        switch (typeof value) {
+          case 'undefined':
+            break
+          case 'string':
+            value = (stringifiers[key] || asString)(value)
+            if (value !== undefined) {
+              data += ',"' + key + '":' + value
+            }
+            break
+          case 'number':
+          case 'boolean':
+            data += ',"' + key + '":' + value
+            break
+          default:
+            value = (stringifiers[key] || stringify)(value)
+            if (value !== undefined) {
+              data += ',"' + key + '":' + value
+            }
         }
       }
     }

--- a/pino.js
+++ b/pino.js
@@ -60,7 +60,7 @@ function pino (...args) {
 
   assertNoLevelCollisions(pino.levels, customLevels)
 
-  const stringify = safe ? stringifySafe : JSON.stringify
+  const stringify = safe ? trySafe : JSON.stringify
   const stringifiers = redact ? redaction(redact, stringify) : {}
   const formatOpts = redact
     ? {stringify: stringifiers[redactFmtSym]}
@@ -112,3 +112,11 @@ pino.version = version
 pino.LOG_VERSION = LOG_VERSION
 
 module.exports = pino
+
+function trySafe (obj) {
+  try {
+    return JSON.stringify(obj)
+  } catch (_) {
+    return stringifySafe(obj)
+  }
+}


### PR DESCRIPTION
This PR does two things:

1. bring down the `deep` benchmark from 16KB per log line to 2KB. Those are still massive.
2. adds a fast path for strings, numbers and booleans so that we do not have to go in C++/`JSON.stringify`.

This is an alternative to #463 

Before:

```
benchBunyanDeepObj*10000: 2121.646ms
benchWinstonDeepObj*10000: 2946.068ms
benchBoleDeepObj*10000: 3726.740ms
benchLogLevelDeepObj*10000: 6570.217ms
benchPinoDeepObj*10000: 2721.078ms
benchPinoUnsafeDeepObj*10000: 2486.789ms
benchPinoExtremeDeepObj*10000: 2801.805ms
benchPinoUnsafeExtremeDeepObj*10000: 2590.682ms
benchBunyanDeepObj*10000: 2158.406ms
benchWinstonDeepObj*10000: 2752.963ms
benchBoleDeepObj*10000: 3433.998ms
benchLogLevelDeepObj*10000: 6406.703ms
benchPinoDeepObj*10000: 2869.529ms
benchPinoUnsafeDeepObj*10000: 2612.237ms
benchPinoExtremeDeepObj*10000: 2828.076ms
benchPinoUnsafeExtremeDeepObj*10000: 2547.889ms
```

After:

```
benchBunyanDeepObj*10000: 2041.287ms
benchWinstonDeepObj*10000: 2883.688ms
benchBoleDeepObj*10000: 3711.500ms
benchLogLevelDeepObj*10000: 6490.075ms
benchPinoDeepObj*10000: 2248.998ms
benchPinoUnsafeDeepObj*10000: 2223.362ms
benchPinoExtremeDeepObj*10000: 2316.757ms
benchPinoUnsafeExtremeDeepObj*10000: 2304.686ms
benchBunyanDeepObj*10000: 2165.046ms
benchWinstonDeepObj*10000: 2776.695ms
benchBoleDeepObj*10000: 3393.842ms
benchLogLevelDeepObj*10000: 6362.907ms
benchPinoDeepObj*10000: 2265.468ms
benchPinoUnsafeDeepObj*10000: 2267.382ms
benchPinoExtremeDeepObj*10000: 2272.065ms
benchPinoUnsafeExtremeDeepObj*10000: 2295.960ms
```

However this also improves the basic `'object'` benchmark:

before

```
benchBunyanObj*10000: 669.430ms
benchWinstonObj*10000: 562.287ms
benchBoleObj*10000: 574.375ms
benchLogLevelObject*10000: 558.069ms
benchPinoObj*10000: 299.204ms
benchPinoUnsafeObj*10000: 302.748ms
benchPinoExtremeObj*10000: 177.923ms
benchPinoUnsafeExtremeObj*10000: 161.237ms
benchBunyanObj*10000: 611.520ms
benchWinstonObj*10000: 474.447ms
benchBoleObj*10000: 325.590ms
benchLogLevelObject*10000: 520.530ms
benchPinoObj*10000: 281.796ms
benchPinoUnsafeObj*10000: 276.001ms
benchPinoExtremeObj*10000: 146.786ms
benchPinoUnsafeExtremeObj*10000: 146.729ms
```

after

```
benchBunyanObj*10000: 675.986ms
benchWinstonObj*10000: 565.977ms
benchBoleObj*10000: 594.813ms
benchLogLevelObject*10000: 583.699ms
benchPinoObj*10000: 277.615ms
benchPinoUnsafeObj*10000: 277.089ms
benchPinoExtremeObj*10000: 139.002ms
benchPinoUnsafeExtremeObj*10000: 130.699ms
benchBunyanObj*10000: 674.169ms
benchWinstonObj*10000: 490.112ms
benchBoleObj*10000: 323.424ms
benchLogLevelObject*10000: 520.541ms
benchPinoObj*10000: 244.344ms
benchPinoUnsafeObj*10000: 246.856ms
benchPinoExtremeObj*10000: 123.631ms
benchPinoUnsafeExtremeObj*10000: 122.023ms
```