### PR TITLE
inline asJson

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -98,24 +98,19 @@ function asJson (obj, msg, num, time) {
         value = serializers[key] ? serializers[key](value) : value
 
         switch (typeof value) {
-          case 'undefined':
-            break
-          case 'string':
-            value = (stringifiers[key] || asString)(value)
-            if (value !== undefined) {
-              data += ',"' + key + '":' + value
-            }
-            break
+          case 'undefined': continue
           case 'number':
           case 'boolean':
             data += ',"' + key + '":' + value
+            continue
+          case 'string':
+            value = (stringifiers[key] || asString)(value)
             break
           default:
             value = (stringifiers[key] || stringify)(value)
-            if (value !== undefined) {
-              data += ',"' + key + '":' + value
-            }
         }
+        if (value === undefined) continue
+        data += ',"' + key + '":' + value
       }
     }
   }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -101,6 +101,7 @@ function asJson (obj, msg, num, time) {
           case 'undefined': continue
           case 'number':
           case 'boolean':
+            if (stringifiers[key]) value = stringifiers[key](value)
             data += ',"' + key + '":' + value
             continue
           case 'string':

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -371,3 +371,47 @@ test('redact – supports intermediate wildcard paths', async ({is}) => {
   const { req } = await once(stream, 'data')
   is(req.headers.cookie, '[Redacted]')
 })
+
+test('redacts numbers at the top level', async ({is}) => {
+  const stream = sink()
+  const instance = pino({redact: ['id']}, stream)
+  const obj = {
+    id: 7915
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o.id, '[Redacted]')
+})
+
+test('redacts booleans at the top level', async ({is}) => {
+  const stream = sink()
+  const instance = pino({redact: ['maybe']}, stream)
+  const obj = {
+    maybe: true
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o.maybe, '[Redacted]')
+})
+
+test('redacts strings at the top level', async ({is}) => {
+  const stream = sink()
+  const instance = pino({redact: ['s']}, stream)
+  const obj = {
+    s: 's'
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o.s, '[Redacted]')
+})
+
+test('redacts null at the top level', async ({is}) => {
+  const stream = sink()
+  const instance = pino({redact: ['n']}, stream)
+  const obj = {
+    n: null
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o.n, '[Redacted]')
+})


### PR DESCRIPTION
```sh
 node --trace-turbo-inlining benchmarks/basic.bench.js | grep asJson
```
```
Inlining asString into asJson
  - size:473, name: asJson
  - size:473, name: asJson
  - size:473, name: asJson
  - size:473, name: asJson
Inlining asJson into write
  - size:473, name: asJson
  - size:473, name: asJson
Inlining asJson into LOG
  - size:473, name: asJson
  - size:473, name: asJson
  - size:473, name: asJson
  - size:473, name: asJson
Inlining asString into asJson
  - size:473, name: asJson
Inlining asJson into benchPinoNodeStream
  - size:473, name: asJson
Inlining asJson into LOG
```

* This seems to make no difference to benchmarks
* If the destination is a Node Stream `asJson` will not inline – no idea why

