### PR TITLE
Modify pino.final to handle calls without a handler

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -662,7 +662,7 @@ of each function execution to avoid losing data.
 
 <a id="pino-final"></a>
 
-### `pino.final(logger, [handler]) => Function | Logger`
+### `pino.final(logger, [handler]) => Function | FinalLogger`
 
 The `pino.final` method can be used to acquire a final logger instance 
 or create an exit listener function.

--- a/docs/api.md
+++ b/docs/api.md
@@ -694,7 +694,7 @@ process.on('uncaughtException', pino.final(logger, (err, finalLogger) => {
 }))
 ```
 
-#### `pino.final(logger) => Logger`
+#### `pino.final(logger) => FinalLogger`
 
 In this case the `pino.final` method returns a finalLogger instance.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -661,15 +661,12 @@ of each function execution to avoid losing data.
 * See [Reopening log files](/docs/help.md#reopening)
 
 <a id="pino-final"></a>
-### `pino.final(logger, handler) => Function`
 
-The `pino.final` method supplies an exit listener function that can be
-supplied to process exit events such as `exit`, `uncaughtException`,
-`SIGHUP` and so on.
+### `pino.final(logger, [handler]) => Function | Logger`
 
-The exit listener function will call the supplied `handler` function
-with an error object (or else `null`), a `finalLogger` instance followed
-by any additional arguments the `handler` may be called with.
+The `pino.final` method can be used to acquire a final logger instance 
+or create an exit listener function.
+
 The `finalLogger` is a specialist logger that synchronously flushes
 on every write. This is important to gaurantee final log writes,
 both when using `pino.destination` or `pino.extreme` targets.
@@ -680,11 +677,30 @@ is a Node.js stream `pino.final` will throw. It's highly recommended
 for both performance and safety to use `pino.destination`/`pino.extreme`
 destinations.
 
+#### `pino.final(logger, handler) => Function`
+
+In this case the `pino.final` method supplies an exit listener function that can be
+supplied to process exit events such as `exit`, `uncaughtException`,
+`SIGHUP` and so on.
+
+The exit listener function will call the supplied `handler` function
+with an error object (or else `null`), a `finalLogger` instance followed
+by any additional arguments the `handler` may be called with.
+
 ```js
 process.on('uncaughtException', pino.final(logger, (err, finalLogger) => {
   finalLogger.error(err, 'uncaughtException')
   process.exit(1)
 }))
+```
+
+#### `pino.final(logger) => Logger`
+
+In this case the `pino.final` method returns a finalLogger instance.
+
+```js
+var finalLogger = pino.final(logger)
+finalLogger.info('exiting...')
 ```
 
 * See [`destination` parameter](#destination)

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -275,7 +275,7 @@ function final (logger, handler) {
   if (typeof logger === 'undefined' || typeof logger.child !== 'function') {
     throw Error('expected a pino logger instance')
   }
-  var hasHandler = (typeof handler !== 'undefined')
+  const hasHandler = (typeof handler !== 'undefined')
   if (hasHandler && typeof handler !== 'function') {
     throw Error('expected a handler function')
   }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -277,7 +277,7 @@ function final (logger, handler) {
   }
   const hasHandler = (typeof handler !== 'undefined')
   if (hasHandler && typeof handler !== 'function') {
-    throw Error('expected a handler function')
+    throw Error('if supplied, the handler parameter should be a function')
   }
   const stream = logger[streamSym]
   if (!(stream instanceof SonicBoom)) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -275,12 +275,29 @@ function final (logger, handler) {
   if (typeof logger === 'undefined' || typeof logger.child !== 'function') {
     throw Error('expected a pino logger instance')
   }
-  if (typeof handler !== 'function') {
+  var hasHandler = (typeof handler !== 'undefined')
+  if (hasHandler && typeof handler !== 'function') {
     throw Error('expected a handler function')
   }
   const stream = logger[streamSym]
   if (!(stream instanceof SonicBoom)) {
     throw Error('only compatible with loggers with pino.destination and pino.extreme targets')
+  }
+
+  const finalLogger = new Proxy(logger, {
+    get: (logger, key) => {
+      if (key in logger.levels.values) {
+        return (...args) => {
+          logger[key](...args)
+          stream.flushSync()
+        }
+      }
+      return logger[key]
+    }
+  })
+
+  if (!hasHandler) {
+    return finalLogger
   }
 
   return (err = null, ...args) => {
@@ -292,17 +309,6 @@ function final (logger, handler) {
       // in practice there shouldn't be a situation where it isn't
       // however, swallow the error just in case (and for easier testing)
     }
-    const finalLogger = new Proxy(logger, {
-      get: (logger, key) => {
-        if (key in logger.levels.values) {
-          return (...args) => {
-            logger[key](...args)
-            stream.flushSync()
-          }
-        }
-        return logger[key]
-      }
-    })
     return handler(err, finalLogger, ...args)
   }
 }

--- a/test/final.test.js
+++ b/test/final.test.js
@@ -18,9 +18,9 @@ test('throws if not supplied a logger instance', async ({throws}) => {
   }, Error('expected a pino logger instance'))
 })
 
-test('throws if not supplied a handler', async ({throws}) => {
+test('throws if the supplied handler is not a function', async ({throws}) => {
   throws(() => {
-    pino.final(pino())
+    pino.final(pino(), 'dummy')
   }, Error('expected a handler function'))
 })
 
@@ -84,24 +84,15 @@ test('passes a specialized final logger instance', async ({is, isNot, error}) =>
   const logger = pino(dest)
   pino.final(logger, (err, finalLogger) => {
     error(err)
-
-    is(typeof finalLogger.trace, 'function')
-    is(typeof finalLogger.debug, 'function')
-    is(typeof finalLogger.info, 'function')
-    is(typeof finalLogger.warn, 'function')
-    is(typeof finalLogger.error, 'function')
-    is(typeof finalLogger.fatal, 'function')
-
-    isNot(finalLogger.trace, logger.trace)
-    isNot(finalLogger.debug, logger.debug)
-    isNot(finalLogger.info, logger.info)
-    isNot(finalLogger.warn, logger.warn)
-    isNot(finalLogger.error, logger.error)
-    isNot(finalLogger.fatal, logger.fatal)
-
-    is(finalLogger.child, logger.child)
-    is(finalLogger.levels, logger.levels)
+    testLoggers(logger, finalLogger, is, isNot)
   })()
+})
+
+test('returns a specialized final logger instance if no handler is passed', async ({is, isNot}) => {
+  const dest = pino.destination('/dev/null')
+  const logger = pino(dest)
+  const finalLogger = pino.final(logger)
+  testLoggers(logger, finalLogger, is, isNot)
 })
 
 test('final logger instances synchronously flush after a log method call', async ({pass, fail, error}) => {
@@ -147,3 +138,22 @@ test('also instruments custom log methods', async ({pass, fail, error}) => {
   await sleep(10)
   if (passed === false) fail('flushSync not called')
 })
+
+function testLoggers (logger, finalLogger, is, isNot) {
+  is(typeof finalLogger.trace, 'function')
+  is(typeof finalLogger.debug, 'function')
+  is(typeof finalLogger.info, 'function')
+  is(typeof finalLogger.warn, 'function')
+  is(typeof finalLogger.error, 'function')
+  is(typeof finalLogger.fatal, 'function')
+
+  isNot(finalLogger.trace, logger.trace)
+  isNot(finalLogger.debug, logger.debug)
+  isNot(finalLogger.info, logger.info)
+  isNot(finalLogger.warn, logger.warn)
+  isNot(finalLogger.error, logger.error)
+  isNot(finalLogger.fatal, logger.fatal)
+
+  is(finalLogger.child, logger.child)
+  is(finalLogger.levels, logger.levels)
+}

--- a/test/final.test.js
+++ b/test/final.test.js
@@ -21,7 +21,7 @@ test('throws if not supplied a logger instance', async ({throws}) => {
 test('throws if the supplied handler is not a function', async ({throws}) => {
   throws(() => {
     pino.final(pino(), 'dummy')
-  }, Error('expected a handler function'))
+  }, Error('if supplied, the handler parameter should be a function'))
 })
 
 test('throws if not supplied logger with pino.destination or pino.extreme instance', async ({throws, doesNotThrow}) => {
@@ -84,7 +84,22 @@ test('passes a specialized final logger instance', async ({is, isNot, error}) =>
   const logger = pino(dest)
   pino.final(logger, (err, finalLogger) => {
     error(err)
-    testLoggers(logger, finalLogger, is, isNot)
+    is(typeof finalLogger.trace, 'function')
+    is(typeof finalLogger.debug, 'function')
+    is(typeof finalLogger.info, 'function')
+    is(typeof finalLogger.warn, 'function')
+    is(typeof finalLogger.error, 'function')
+    is(typeof finalLogger.fatal, 'function')
+
+    isNot(finalLogger.trace, logger.trace)
+    isNot(finalLogger.debug, logger.debug)
+    isNot(finalLogger.info, logger.info)
+    isNot(finalLogger.warn, logger.warn)
+    isNot(finalLogger.error, logger.error)
+    isNot(finalLogger.fatal, logger.fatal)
+
+    is(finalLogger.child, logger.child)
+    is(finalLogger.levels, logger.levels)
   })()
 })
 
@@ -92,7 +107,22 @@ test('returns a specialized final logger instance if no handler is passed', asyn
   const dest = pino.destination('/dev/null')
   const logger = pino(dest)
   const finalLogger = pino.final(logger)
-  testLoggers(logger, finalLogger, is, isNot)
+  is(typeof finalLogger.trace, 'function')
+  is(typeof finalLogger.debug, 'function')
+  is(typeof finalLogger.info, 'function')
+  is(typeof finalLogger.warn, 'function')
+  is(typeof finalLogger.error, 'function')
+  is(typeof finalLogger.fatal, 'function')
+
+  isNot(finalLogger.trace, logger.trace)
+  isNot(finalLogger.debug, logger.debug)
+  isNot(finalLogger.info, logger.info)
+  isNot(finalLogger.warn, logger.warn)
+  isNot(finalLogger.error, logger.error)
+  isNot(finalLogger.fatal, logger.fatal)
+
+  is(finalLogger.child, logger.child)
+  is(finalLogger.levels, logger.levels)
 })
 
 test('final logger instances synchronously flush after a log method call', async ({pass, fail, error}) => {
@@ -138,22 +168,3 @@ test('also instruments custom log methods', async ({pass, fail, error}) => {
   await sleep(10)
   if (passed === false) fail('flushSync not called')
 })
-
-function testLoggers (logger, finalLogger, is, isNot) {
-  is(typeof finalLogger.trace, 'function')
-  is(typeof finalLogger.debug, 'function')
-  is(typeof finalLogger.info, 'function')
-  is(typeof finalLogger.warn, 'function')
-  is(typeof finalLogger.error, 'function')
-  is(typeof finalLogger.fatal, 'function')
-
-  isNot(finalLogger.trace, logger.trace)
-  isNot(finalLogger.debug, logger.debug)
-  isNot(finalLogger.info, logger.info)
-  isNot(finalLogger.warn, logger.warn)
-  isNot(finalLogger.error, logger.error)
-  isNot(finalLogger.fatal, logger.fatal)
-
-  is(finalLogger.child, logger.child)
-  is(finalLogger.levels, logger.levels)
-}


### PR DESCRIPTION
Modifies pino.final to be able to return the finalLogger directly. See #490