### PR TITLE
Base option readme fix

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -117,7 +117,7 @@ Default: `{pid: process.pid, hostname: os.hostname}`
 
 Key-value object added as child logger to each log line.
 
-Set to `null` to avoid adding `pid` and `hostname` properties to each log.
+Set to `null` to avoid adding `pid`, `hostname` and `name` properties to each log.
 
 #### `enabled` (Boolean)
 


### PR DESCRIPTION
Fix to API docs to correct the missing `name` property in base option.

Fixes https://github.com/pinojs/pino/issues/494