### PR TITLE
Convert NaN and Infinity to null.

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -110,6 +110,11 @@ function asJson (obj, msg, num, time) {
         switch (typeof value) {
           case 'undefined': continue
           case 'number':
+            /* eslint no-fallthrough: "off" */
+            if (value === Infinity || isNaN(value)) {
+              value = null
+            }
+            // this case explicity falls through to the next one
           case 'boolean':
             if (stringifiers[key]) value = stringifiers[key](value)
             data += ',"' + key + '":' + value

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -530,3 +530,25 @@ test('throws when setting useOnlyCustomLevels without customLevels', async ({ is
     is(message, 'customLevels is required if useOnlyCustomLevels is set true')
   }
 })
+
+test('correctly log Infinity', async (t) => {
+  const stream = sink()
+  const instance = pino(stream)
+
+  const o = { num: Infinity }
+  instance.info(o)
+
+  const { num } = await once(stream, 'data')
+  t.is(num, null)
+})
+
+test('correctly log NaN', async (t) => {
+  const stream = sink()
+  const instance = pino(stream)
+
+  const o = { num: NaN }
+  instance.info(o)
+
+  const { num } = await once(stream, 'data')
+  t.is(num, null)
+})


### PR DESCRIPTION
As noted in https://github.com/pinojs/pino-pretty/issues/36 by @nwoltman, we are not logging `Infinity` and `NaN`  correctly. This PR makes them log as `null`.