### PR TITLE
Convert -Infinity to null

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -111,7 +111,7 @@ function asJson (obj, msg, num, time) {
           case 'undefined': continue
           case 'number':
             /* eslint no-fallthrough: "off" */
-            if (value === Infinity || isNaN(value)) {
+            if (Number.isFinite(value) === false) {
               value = null
             }
             // this case explicity falls through to the next one

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -542,6 +542,17 @@ test('correctly log Infinity', async (t) => {
   t.is(num, null)
 })
 
+test('correctly log -Infinity', async (t) => {
+  const stream = sink()
+  const instance = pino(stream)
+
+  const o = { num: -Infinity }
+  instance.info(o)
+
+  const { num } = await once(stream, 'data')
+  t.is(num, null)
+})
+
 test('correctly log NaN', async (t) => {
   const stream = sink()
   const instance = pino(stream)


### PR DESCRIPTION
Building on top of #519, this adds support for converting all invalid number values to `null` (really the only value left to handle was `-Infinity`, but this change does it all with one function call).