### PR TITLE
Don't use default levels if useOnlyCustomLevels is specified

### DIFF
--- a/lib/levels.js
+++ b/lib/levels.js
@@ -1,6 +1,6 @@
 'use strict'
 const flatstr = require('flatstr')
-const { lsCacheSym, levelValSym, useLevelLabelsSym, changeLevelNameSym } = require('./symbols')
+const { lsCacheSym, levelValSym, useLevelLabelsSym, changeLevelNameSym, useOnlyCustomLevelsSym } = require('./symbols')
 const { noop, genLog } = require('./tools')
 
 const levels = {
@@ -42,7 +42,11 @@ function genLsCache (instance) {
   return instance
 }
 
-function isStandardLevel (level) {
+function isStandardLevel (level, useOnlyCustomLevels) {
+  if (useOnlyCustomLevels) {
+    return false
+  }
+
   switch (level) {
     case 'fatal':
     case 'error':
@@ -65,13 +69,14 @@ function setLevel (level) {
   if (values[level] === undefined) throw Error('unknown level ' + level)
   const preLevelVal = this[levelValSym]
   const levelVal = this[levelValSym] = values[level]
+  const useOnlyCustomLevelsVal = this[useOnlyCustomLevelsSym]
 
   for (var key in values) {
     if (levelVal > values[key]) {
       this[key] = noop
       continue
     }
-    this[key] = isStandardLevel(key) ? levelMethods[key] : genLog(values[key])
+    this[key] = isStandardLevel(key, useOnlyCustomLevelsVal) ? levelMethods[key] : genLog(values[key])
   }
 
   this.emit(

--- a/test/custom-levels.test.js
+++ b/test/custom-levels.test.js
@@ -31,6 +31,23 @@ test('custom levels does not override default levels', async ({ is }) => {
   is(level, 30)
 })
 
+test('default levels can be redefined using custom levels', async ({ is }) => {
+  const stream = sink()
+  const logger = pino({
+    customLevels: {
+      info: 35,
+      debug: 45
+    },
+    useOnlyCustomLevels: true
+  }, stream)
+
+  is(logger.hasOwnProperty('info'), true)
+
+  logger.info('test')
+  const { level } = await once(stream, 'data')
+  is(level, 35)
+})
+
 test('custom levels overrides default level label if use useOnlyCustomLevels', async ({ is }) => {
   const stream = sink()
   const logger = pino({


### PR DESCRIPTION
As said in #507, I gave it a try to allow to override the standard levels, but for some reason the priority in the test is `null`.