### PR TITLE
Simplify switch statement

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -108,7 +108,9 @@ function asJson (obj, msg, num, time) {
         value = serializers[key] ? serializers[key](value) : value
 
         switch (typeof value) {
-          case 'undefined': continue
+          case 'undefined':
+          case 'function':
+            continue
           case 'number':
             /* eslint no-fallthrough: "off" */
             if (Number.isFinite(value) === false) {
@@ -121,10 +123,6 @@ function asJson (obj, msg, num, time) {
             continue
           case 'string':
             value = (stringifiers[key] || asString)(value)
-            break
-          case 'function':
-            // ignore functions
-            value = undefined
             break
           default:
             value = (stringifiers[key] || stringify)(value)


### PR DESCRIPTION
Both the `'undefined'` and `'function'` cases can be handled in the same way.