### PR TITLE
Fix failing test - Allow censor function

### DIFF
--- a/lib/redaction.js
+++ b/lib/redaction.js
@@ -5,7 +5,6 @@ const { redactFmtSym } = require('./symbols')
 const { rx, validator } = fastRedact
 
 const validate = validator({
-  ERR_CENSOR_MUST_NOT_BE_FUNCTION: () => 'pino – censor option may not be a function',
   ERR_PATHS_MUST_BE_STRINGS: () => 'pino – redacted paths must be strings',
   ERR_INVALID_PATH: (s) => `pino – redact paths array contains an invalid path (${s})`
 })

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -40,12 +40,6 @@ test('redact.paths option – throws if array contains an invalid path', async (
   })
 })
 
-test('redact.censor option – throws if censor is a function', async ({ throws }) => {
-  throws(() => {
-    pino({ redact: { paths: ['req.headers.cookie'], censor: () => {} } })
-  })
-})
-
 test('redact option – top level key', async ({ is }) => {
   const stream = sink()
   const instance = pino({ redact: ['key'] }, stream)


### PR DESCRIPTION
`fast-redact` allows the `censor` option to be a function starting in version [`1.4.0`](https://github.com/davidmarkclements/fast-redact/releases).