### PR TITLE
Helper to match log output against keywords in tests

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -7,6 +7,43 @@ const pid = process.pid
 const hostname = os.hostname()
 const v = 1
 
+function expected (str) {
+  var memo = new WeakMap()
+
+  var valid = {
+    string: n => n !== void 0 && n.length > 0 && typeof n === 'string',
+    array: n => Array.isArray(n) && n.length > 0,
+    object: n => n !== null && typeof n === 'object'
+  }
+  var cursor = {
+    set: (k, v) => (valid.object(k)) ? memo.set(k, v) : void 0,
+    get: (k) => (valid.object(k)) ? memo.get(k) : void 0,
+    has: (k) => (valid.object(k)) ? memo.has(k) : void 0
+  }
+
+  var shake = ({ s_, ndl_ }) => {
+    var delim = ' '
+    /* eslint-disable */
+    var sane = /([\s()[\[^\]]:*)/mg
+    /* eslint-enable */
+
+    if (!valid.string(s_) || !valid.array(ndl_)) return void 0
+
+    var tree = s_.replace(sane, ' ').split(delim).filter(o => ndl_.indexOf(o) !== -1)
+    return tree.length !== 0
+  }
+
+  return {
+    output: function output$ ({ has }) {
+      if (!valid.string(str)) return void 0
+      var prev = { str: str, has: has }
+      var tree = shake({ s_: str, ndl_: has })
+      if (!cursor.has(prev)) cursor.set(prev, tree)
+      return cursor.get(prev)
+    }
+  }
+}
+
 function once (emitter, name) {
   return new Promise((resolve, reject) => {
     if (name !== 'error') emitter.once('error', reject)
@@ -46,4 +83,10 @@ function sleep (ms) {
   })
 }
 
-module.exports = { sink, check, once, sleep }
+module.exports = {
+  expected,
+  sink,
+  check,
+  once,
+  sleep
+}

--- a/test/helper.js
+++ b/test/helper.js
@@ -7,6 +7,28 @@ const pid = process.pid
 const hostname = os.hostname()
 const v = 1
 
+/**
+ * @function expected
+ * @access public
+ *
+ * @description
+ * DOING: Should return the exposed members of the proxy as invocables.
+ * This function is intended to evaluate the expression of formats used
+ * in string literals against matching types for assertions.
+ *
+ * @example
+ *
+ * @See output$
+ * @inner
+ * // return expected('123 abc').output({ has: ['abc', '123']})
+ * // true
+ * // return expected('123 abc').output({ has: ['bca', '321']})
+ * // false
+ * {@link helper.test.js Tests for member output}
+ *
+ * @param {String} str - String literal to evaluate
+ * @returns {Boolean|Undefined}
+ */
 function expected (str) {
   var memo = new WeakMap()
 
@@ -21,21 +43,25 @@ function expected (str) {
     has: (k) => (valid.object(k)) ? memo.has(k) : void 0
   }
   var shake = ({ s_, ndl_ }) => {
-    var delim = ' '
+    var delim = ' ' // split str by this delimiter
     /* eslint-disable */
+    // redact () [] : and \s (lint not identifying regex)
     var sane = /([\s()[\[^\]]:*)/mg
     /* eslint-enable */
     if (!valid.string(s_) || !valid.array(ndl_)) return void 0
+    // sanitize str, split into array, iterate and evaluate presence of matched elements
     var tree = s_.replace(sane, ' ').split(delim).filter(o => ndl_.indexOf(o) !== -1)
     return tree.length !== 0
   }
 
   return {
+    // match any given list of elements against
+    // the supplied string. See header documenation of function for examples.
     output: function output$ ({ has }) {
       if (!valid.string(str)) return void 0
       var prev = { str: str, has: has }
       var tree = shake({ s_: str, ndl_: has })
-      if (!cursor.has(prev)) cursor.set(prev, tree)
+      if (!cursor.has(prev)) cursor.set(prev, tree) // return as selector
       return cursor.get(prev)
     }
   }

--- a/test/helper.js
+++ b/test/helper.js
@@ -20,15 +20,12 @@ function expected (str) {
     get: (k) => (valid.object(k)) ? memo.get(k) : void 0,
     has: (k) => (valid.object(k)) ? memo.has(k) : void 0
   }
-
   var shake = ({ s_, ndl_ }) => {
     var delim = ' '
     /* eslint-disable */
     var sane = /([\s()[\[^\]]:*)/mg
     /* eslint-enable */
-
     if (!valid.string(s_) || !valid.array(ndl_)) return void 0
-
     var tree = s_.replace(sane, ' ').split(delim).filter(o => ndl_.indexOf(o) !== -1)
     return tree.length !== 0
   }

--- a/test/helper.test.js
+++ b/test/helper.test.js
@@ -1,0 +1,49 @@
+'use strict'
+
+const { test } = require('tap')
+const { expected } = require('./helper')
+
+test('test helper expected to receive string and list of elements to match', async ({ is }) => {
+  var str = '[1459875739796] WARN : pino.final with prettyPrint does not support flushing [1459875739796] INFO  (123456 on abcdefghijklmnopqr): beforeExit'
+  var s$ = [
+    'pino.final',
+    'prettyPrint',
+    'beforeExit',
+    '123456',
+    'abcdefghijklmnopqr',
+    'WARN',
+    'INFO'
+  ]
+  is(expected(str).output({ has: s$ }), true)
+})
+test('test helper expected to receive string and list of elements to not match', async ({ is }) => {
+  var str = '[1459875739796] WARN : pino.final with prettyPrint does not support flushing [1459875739796] INFO  (123456 on abcdefghijklmnopqr): beforeExit'
+  var s$ = [
+    '!pino.final',
+    '!prettyPrint',
+    '!beforeExit',
+    '!123456',
+    '!abcdefghijklmnopqr',
+    '!WARN',
+    '!INFO'
+  ]
+  is(expected(str).output({ has: s$ }), false)
+})
+test('test helper expected to receieve empty value to not throw error', async ({ is }) => {
+  var str = ''
+  var s$ = [
+    'pino.final',
+    'prettyPrint',
+    'beforeExit',
+    '123456',
+    'abcdefghijklmnopqr',
+    'WARN',
+    'INFO'
+  ]
+  is(expected(str).output({ has: s$ }), undefined)
+})
+test('test helper expected to receieve non-array/list to not throw error', async ({ is }) => {
+  var str = '[1459875739796] WARN : pino.final with prettyPrint does not support flushing [1459875739796] INFO  (123456 on abcdefghijklmnopqr): beforeExit'
+  var s$ = ''
+  is(expected(str).output({ has: s$ }), undefined)
+})

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -5,7 +5,7 @@ const { test } = require('tap')
 const { join } = require('path')
 const execa = require('execa')
 const writer = require('flush-write-stream')
-const { once } = require('./helper')
+const { expected, once } = require('./helper')
 const pino = require('../')
 
 test('can be enabled via exported pino function', async ({ isNot }) => {
@@ -229,7 +229,7 @@ test('final works when returning a logger', async ({ isNot }) => {
   isNot(actual.match(/INFO\s+\(123456 on abcdefghijklmnopqr\): after/), null)
 })
 
-test('final works without prior logging', async ({ isNot }) => {
+test('final works without prior logging', async ({ is, isNot }) => {
   var actual = ''
   const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'pretty', 'final-no-log-before.js')])
 
@@ -238,6 +238,17 @@ test('final works without prior logging', async ({ isNot }) => {
     cb()
   }))
   await once(child, 'close')
+
   isNot(actual.match(/WARN\s+: pino.final with prettyPrint does not support flushing/), null)
   isNot(actual.match(/INFO\s+\(123456 on abcdefghijklmnopqr\): beforeExit/), null)
+  var s$ = [
+    'pino.final',
+    'prettyPrint',
+    'beforeExit',
+    '123456',
+    'abcdefghijklmnopqr',
+    'WARN',
+    'INFO'
+  ]
+  is(expected(actual).output({ has: s$ }), true)
 })


### PR DESCRIPTION
Haven't had any time this week at all except a small amount this evening to come to any contributions whatsoever as I'm in middle of finishing up a job.

**Disclaimer**
I'd say this is as bare of a helper as they get, I really wish I could set aside more time for it, but PTL if its of use. :boom: 

**Description**
(Edge-case? the current tests are never implicit).
Attempts to make more sense in finding specific keywords/elements of choice in the assertions made for the log output, completely optional and non-obtrusive.

**Edge case anyway**
Assert if a certain literal word occurs in the combination of another due side-effects of the output
