### PR TITLE
 fix invalid JSON when `redact.remove` acts on chindings

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -152,7 +152,9 @@ function asChindings (instance, bindings) {
       value !== undefined
     if (valid === true) {
       value = serializers[key] ? serializers[key](value) : value
-      data += ',"' + key + '":' + (stringifiers[key] || stringify)(value)
+      value = (stringifiers[key] || stringify)(value)
+      if (value === undefined) continue
+      data += ',"' + key + '":' + value
     }
   }
   return data

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -230,6 +230,15 @@ test('redact.remove – top level key', async ({ is }) => {
   is('key' in o, false)
 })
 
+test('redact.remove – top level key in child logger', async ({ is }) => {
+  const stream = sink()
+  const opts = { redact: { paths: ['key'], remove: true } }
+  const instance = pino(opts, stream).child({ key: { redact: 'me' } })
+  instance.info('test')
+  const o = await once(stream, 'data')
+  is('key' in o, false)
+})
+
 test('redact.paths preserves original object values after the log write', async ({ is }) => {
   const stream = sink()
   const instance = pino({ redact: ['req.headers.cookie'] }, stream)


### PR DESCRIPTION
This PR contains 2 commits.

The first holds the failing test case.
This second fixes the issue, passing the test.

The issue was that using `redact.remove` on a key that was
subsequently used in a child binding, was cause logging on
the child logger to produce JSON with `"key":undefined` in it.

While this doesn't crash the logger, the JSON is invalid and therefore
will break many receiving systems, at best causing logs to be missed.

In the test suite, the output is `JSON.parse`d which throws due to the
invalid output.