### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,15 +80,14 @@
     "tap": "^12.1.0",
     "tape": "^4.9.0",
     "through2": "^3.0.0",
-    "winston": "^3.1.0"
+    "winston": "^3.1.0",
+    "pump": "^3.0.0"
   },
   "dependencies": {
-    "fast-json-parse": "^1.0.3",
     "fast-redact": "^1.4.2",
     "fast-safe-stringify": "^2.0.6",
     "flatstr": "^1.0.9",
     "pino-std-serializers": "^2.3.0",
-    "pump": "^3.0.0",
     "quick-format-unescaped": "^3.0.0",
     "sonic-boom": "^0.7.1"
   }


### PR DESCRIPTION
I noticed that `fast-json-parse` are listed as a dependency but not used in any of the code and that `pump` is listed under dependencies but only used in the benchmarks. This removes `fast-json-parse` as a dependency and moved `pump` to be a devDependency so its less deps to install for users of the lib.

This also eliminated a security warning when installing the dependencies in this module:

```sh
npm WARN notice [SECURITY] static-eval has the following vulnerability: 1 moderate. Go here for more details: https://nodesecurity.io/advisories?search=static-eval&version=0.1.1 - Run `npm i npm@latest -g` to upgrade your npm version, and then `npm audit` to get more info.
```