### PR TITLE
Add inline note for clarification

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -35,6 +35,7 @@ const {
 } = require('./meta')
 
 // note: use of class is satirical
+// https://github.com/pinojs/pino/pull/433#pullrequestreview-127703127
 const constructor = class Pino {}
 const prototype = {
   constructor,


### PR DESCRIPTION
A question was asked on StackOverflow about how to extend Pino. This led to a discussion in the question's comments about Pino with a link to the satirical prototype and an expression of confusion.

Question: https://stackoverflow.com/questions/54158917/extended-class-methods-are-not-exposed

Since not everyone keeps up with our PRs, the joke in the code comment can be lost on people. This PR helps to clear things up for them.