### PR TITLE
fix: retain logger bindings after transmitting `logEvent`s

### DIFF
--- a/test/browser-transmit.test.js
+++ b/test/browser-transmit.test.js
@@ -255,7 +255,7 @@ test('applies all serializers to messages and bindings (serialize:true)', ({ end
 })
 
 test('extracts correct bindings and raw messages over multiple transmits', ({ end, same, is }) => {
-  let messages = null
+  var messages = null
   let bindings = null
 
   const logger = pino({

--- a/test/browser-transmit.test.js
+++ b/test/browser-transmit.test.js
@@ -256,7 +256,7 @@ test('applies all serializers to messages and bindings (serialize:true)', ({ end
 
 test('extracts correct bindings and raw messages over multiple transmits', ({ end, same, is }) => {
   var messages = null
-  let bindings = null
+  var bindings = null
 
   const logger = pino({
     browser: {

--- a/test/browser-transmit.test.js
+++ b/test/browser-transmit.test.js
@@ -254,7 +254,7 @@ test('applies all serializers to messages and bindings (serialize:true)', ({ end
   end()
 })
 
-test('extracts bindings and raw messages', ({ end, same, is }) => {
+test('extracts correct bindings and raw messages over multiple transmits', ({ end, same, is }) => {
   let messages = null
   let bindings = null
 


### PR DESCRIPTION
Closes #584 

The bindings maintained under a child logger's _logEvent object were getting wiped after the first call to `transmit`. When generating a logEvent object for the transmit.send call, this meant that a logger's bindings were not extracted out of the messages. This PR ensures the bindings are retained between transmits and end up under the logEvent.bindings property instead of being mixed into logEvent.messages.

**Benchmarks**

```diff
-master@2a81679a6592715
+fix-transmit-messages

Running BASIC benchmark

-benchBunyan*10000: 561.129ms
+benchBunyan*10000: 544.901ms
-benchWinston*10000: 422.243ms
+benchWinston*10000: 423.400ms
-benchBole*10000: 407.839ms
+benchBole*10000: 413.937ms
-benchDebug*10000: 287.340ms
+benchDebug*10000: 281.658ms
-benchLogLevel*10000: 274.597ms
+benchLogLevel*10000: 279.563ms
-benchPino*10000: 309.389ms
+benchPino*10000: 309.083ms
-benchPinoExtreme*10000: 90.824ms
+benchPinoExtreme*10000: 91.668ms
-benchPinoNodeStream*10000: 200.534ms
+benchPinoNodeStream*10000: 196.076ms
-benchBunyan*10000: 496.626ms
+benchBunyan*10000: 481.924ms
-benchWinston*10000: 349.838ms
+benchWinston*10000: 362.080ms
-benchBole*10000: 219.696ms
+benchBole*10000: 225.968ms
-benchDebug*10000: 274.312ms
+benchDebug*10000: 277.185ms
-benchLogLevel*10000: 263.372ms
+benchLogLevel*10000: 264.848ms
-benchPino*10000: 293.829ms
+benchPino*10000: 285.842ms
-benchPinoExtreme*10000: 84.216ms
+benchPinoExtreme*10000: 84.464ms
-benchPinoNodeStream*10000: 192.575ms
+benchPinoNodeStream*10000: 186.535ms

Running OBJECT benchmark

-benchBunyanObj*10000: 556.458ms
+benchBunyanObj*10000: 578.467ms
-benchWinstonObj*10000: 452.774ms
+benchWinstonObj*10000: 450.565ms
-benchBoleObj*10000: 446.243ms
+benchBoleObj*10000: 440.769ms
-benchLogLevelObject*10000: 443.777ms
+benchLogLevelObject*10000: 463.468ms
-benchPinoObj*10000: 335.796ms
+benchPinoObj*10000: 336.154ms
-benchPinoExtremeObj*10000: 103.997ms
+benchPinoExtremeObj*10000: 102.715ms
-benchPinoNodeStreamObj*10000: 213.045ms
+benchPinoNodeStreamObj*10000: 216.157ms
-benchBunyanObj*10000: 492.832ms
+benchBunyanObj*10000: 503.221ms
-benchWinstonObj*10000: 410.650ms
+benchWinstonObj*10000: 390.522ms
-benchBoleObj*10000: 256.716ms
+benchBoleObj*10000: 250.599ms
-benchLogLevelObject*10000: 415.313ms
+benchLogLevelObject*10000: 423.028ms
-benchPinoObj*10000: 321.488ms
+benchPinoObj*10000: 318.437ms
-benchPinoExtremeObj*10000: 97.919ms
+benchPinoExtremeObj*10000: 94.062ms
-benchPinoNodeStreamObj*10000: 203.623ms
+benchPinoNodeStreamObj*10000: 205.795ms

Running DEEP-OBJECT benchmark

-benchBunyanDeepObj*10000: 1499.645ms
+benchBunyanDeepObj*10000: 1468.590ms
-benchWinstonDeepObj*10000: 2224.009ms
+benchWinstonDeepObj*10000: 2207.797ms
-benchBoleDeepObj*10000: 2848.580ms
+benchBoleDeepObj*10000: 2840.871ms
-benchLogLevelDeepObj*10000: 4769.186ms
+benchLogLevelDeepObj*10000: 4718.712ms
-benchPinoDeepObj*10000: 1887.926ms
+benchPinoDeepObj*10000: 1883.490ms
-benchPinoExtremeDeepObj*10000: 1703.258ms
+benchPinoExtremeDeepObj*10000: 1694.540ms
-benchPinoNodeStreamDeepObj*10000: 1754.070ms
+benchPinoNodeStreamDeepObj*10000: 1734.179ms
-benchBunyanDeepObj*10000: 1491.405ms
+benchBunyanDeepObj*10000: 1492.497ms
-benchWinstonDeepObj*10000: 2099.793ms
+benchWinstonDeepObj*10000: 2075.532ms
-benchBoleDeepObj*10000: 2602.119ms
+benchBoleDeepObj*10000: 2584.757ms
-benchLogLevelDeepObj*10000: 4659.009ms
+benchLogLevelDeepObj*10000: 4618.975ms
-benchPinoDeepObj*10000: 1916.236ms
+benchPinoDeepObj*10000: 1847.240ms
-benchPinoExtremeDeepObj*10000: 1687.628ms
+benchPinoExtremeDeepObj*10000: 1682.834ms
-benchPinoNodeStreamDeepObj*10000: 1731.839ms
+benchPinoNodeStreamDeepObj*10000: 1723.243ms

Running MULTI-ARG benchmark

-benchBunyanMulti*10000: 576.759ms
+benchBunyanMulti*10000: 574.509ms
-benchWinstonMulti*10000: 431.788ms
+benchWinstonMulti*10000: 437.443ms
-benchBoleMulti*10000: 427.840ms
+benchBoleMulti*10000: 423.254ms
-benchLogLevelMulti*10000: 315.148ms
+benchLogLevelMulti*10000: 307.634ms
-benchDebugMulti*10000: 288.075ms
+benchDebugMulti*10000: 285.802ms
-benchPinoMulti*10000: 324.449ms
+benchPinoMulti*10000: 309.131ms
-benchPinoExtremeMulti*10000: 95.333ms
+benchPinoExtremeMulti*10000: 101.205ms
-benchPinoNodeStreamMulti*10000: 202.846ms
+benchPinoNodeStreamMulti*10000: 205.650ms
-benchBunyanInterpolate*10000: 509.953ms
+benchBunyanInterpolate*10000: 488.661ms
-benchWinstonInterpolate*10000: 375.997ms
+benchWinstonInterpolate*10000: 373.363ms
-benchBoleInterpolate*10000: 244.610ms
+benchBoleInterpolate*10000: 236.983ms
-benchPinoInterpolate*10000: 320.913ms
+benchPinoInterpolate*10000: 304.030ms
-benchPinoExtremeInterpolate*10000: 97.066ms
+benchPinoExtremeInterpolate*10000: 96.273ms
-benchPinoNodeStreamInterpolate*10000: 202.630ms
+benchPinoNodeStreamInterpolate*10000: 206.872ms
-benchBunyanInterpolateAll*10000: 579.038ms
+benchBunyanInterpolateAll*10000: 563.776ms
-benchWinstonInterpolateAll*10000: 374.659ms
+benchWinstonInterpolateAll*10000: 372.305ms
-benchBoleInterpolateAll*10000: 308.236ms
+benchBoleInterpolateAll*10000: 307.832ms
-benchPinoInterpolateAll*10000: 421.298ms
+benchPinoInterpolateAll*10000: 437.199ms
-benchPinoExtremeInterpolateAll*10000: 181.635ms
+benchPinoExtremeInterpolateAll*10000: 183.075ms
-benchPinoNodeStreamInterpolateAll*10000: 303.225ms
+benchPinoNodeStreamInterpolateAll*10000: 302.006ms
-benchBunyanInterpolateExtra*10000: 747.805ms
+benchBunyanInterpolateExtra*10000: 739.044ms
-benchWinstonInterpolateExtra*10000: 370.756ms
+benchWinstonInterpolateExtra*10000: 373.576ms
-benchBoleInterpolateExtra*10000: 446.847ms
+benchBoleInterpolateExtra*10000: 435.733ms
-benchPinoInterpolateExtra*10000: 494.209ms
+benchPinoInterpolateExtra*10000: 496.169ms
-benchPinoExtremeInterpolateExtra*10000: 254.331ms
+benchPinoExtremeInterpolateExtra*10000: 260.523ms
-benchPinoNodeStreamInterpolateExtra*10000: 374.580ms
+benchPinoNodeStreamInterpolateExtra*10000: 370.351ms
-benchBunyanInterpolateDeep*10000: 11989.110ms
+benchBunyanInterpolateDeep*10000: 11906.115ms
-benchWinstonInterpolateDeep*10000: 11232.736ms
+benchWinstonInterpolateDeep*10000: 11375.401ms
-benchBoleInterpolateDeep*10000: 11839.100ms
+benchBoleInterpolateDeep*10000: 11690.640ms
-benchPinoInterpolateDeep*10000: 11616.814ms
+benchPinoInterpolateDeep*10000: 11545.146ms
-benchPinoExtremeInterpolateDeep*10000: 11706.178ms
+benchPinoExtremeInterpolateDeep*10000: 11708.535ms
-benchPinoNodeStreamInterpolateDeep*10000: 11490.052ms
+benchPinoNodeStreamInterpolateDeep*10000: 11501.561ms
-benchBunyanMulti*10000: 498.331ms
+benchBunyanMulti*10000: 498.318ms
-benchWinstonMulti*10000: 436.983ms
+benchWinstonMulti*10000: 437.478ms
-benchBoleMulti*10000: 232.634ms
+benchBoleMulti*10000: 227.512ms
-benchLogLevelMulti*10000: 304.068ms
+benchLogLevelMulti*10000: 306.152ms
-benchDebugMulti*10000: 283.661ms
+benchDebugMulti*10000: 276.045ms
-benchPinoMulti*10000: 305.238ms
+benchPinoMulti*10000: 298.045ms
-benchPinoExtremeMulti*10000: 89.269ms
+benchPinoExtremeMulti*10000: 88.061ms
-benchPinoNodeStreamMulti*10000: 204.230ms
+benchPinoNodeStreamMulti*10000: 203.677ms
-benchBunyanInterpolate*10000: 509.725ms
+benchBunyanInterpolate*10000: 490.517ms
-benchWinstonInterpolate*10000: 429.665ms
+benchWinstonInterpolate*10000: 429.718ms
-benchBoleInterpolate*10000: 241.187ms
+benchBoleInterpolate*10000: 233.703ms
-benchPinoInterpolate*10000: 316.668ms
+benchPinoInterpolate*10000: 334.210ms
-benchPinoExtremeInterpolate*10000: 92.930ms
+benchPinoExtremeInterpolate*10000: 93.315ms
-benchPinoNodeStreamInterpolate*10000: 208.171ms
+benchPinoNodeStreamInterpolate*10000: 208.191ms
-benchBunyanInterpolateAll*10000: 585.736ms
+benchBunyanInterpolateAll*10000: 552.099ms
-benchWinstonInterpolateAll*10000: 431.328ms
+benchWinstonInterpolateAll*10000: 436.553ms
-benchBoleInterpolateAll*10000: 304.976ms
+benchBoleInterpolateAll*10000: 302.464ms
-benchPinoInterpolateAll*10000: 416.145ms
+benchPinoInterpolateAll*10000: 411.550ms
-benchPinoExtremeInterpolateAll*10000: 180.559ms
+benchPinoExtremeInterpolateAll*10000: 176.221ms
-benchPinoNodeStreamInterpolateAll*10000: 304.128ms
+benchPinoNodeStreamInterpolateAll*10000: 293.883ms
-benchBunyanInterpolateExtra*10000: 738.098ms
+benchBunyanInterpolateExtra*10000: 706.041ms
-benchWinstonInterpolateExtra*10000: 431.329ms
+benchWinstonInterpolateExtra*10000: 434.494ms
-benchBoleInterpolateExtra*10000: 440.655ms
+benchBoleInterpolateExtra*10000: 428.564ms
-benchPinoInterpolateExtra*10000: 476.959ms
+benchPinoInterpolateExtra*10000: 491.434ms
-benchPinoExtremeInterpolateExtra*10000: 249.184ms
+benchPinoExtremeInterpolateExtra*10000: 254.757ms
-benchPinoNodeStreamInterpolateExtra*10000: 366.402ms
+benchPinoNodeStreamInterpolateExtra*10000: 369.844ms
-benchBunyanInterpolateDeep*10000: 11853.691ms
+benchBunyanInterpolateDeep*10000: 11787.110ms
-benchWinstonInterpolateDeep*10000: 11119.098ms
+benchWinstonInterpolateDeep*10000: 11269.770ms
-benchBoleInterpolateDeep*10000: 11800.776ms
+benchBoleInterpolateDeep*10000: 11778.500ms
-benchPinoInterpolateDeep*10000: 11586.357ms
+benchPinoInterpolateDeep*10000: 11549.489ms
-benchPinoExtremeInterpolateDeep*10000: 11713.808ms
+benchPinoExtremeInterpolateDeep*10000: 11684.977ms
-benchPinoNodeStreamInterpolateDeep*10000: 11722.178ms
+benchPinoNodeStreamInterpolateDeep*10000: 11470.978ms

Running LONG-STRING benchmark

-benchBunyan*1000: 517.666ms
+benchBunyan*1000: 488.432ms
-benchWinston*1000: 502.635ms
+benchWinston*1000: 495.466ms
-benchBole*1000: 642.846ms
+benchBole*1000: 638.192ms
-benchPino*1000: 261.685ms
+benchPino*1000: 260.711ms
-benchPinoExtreme*1000: 229.106ms
+benchPinoExtreme*1000: 224.670ms
-benchPinoNodeStream*1000: 435.777ms
+benchPinoNodeStream*1000: 417.491ms
-benchBunyan*1000: 458.919ms
+benchBunyan*1000: 447.558ms
-benchWinston*1000: 440.479ms
+benchWinston*1000: 426.824ms
-benchBole*1000: 431.929ms
+benchBole*1000: 415.887ms
-benchPino*1000: 263.742ms
+benchPino*1000: 254.697ms
-benchPinoExtreme*1000: 222.805ms
+benchPinoExtreme*1000: 218.407ms
-benchPinoNodeStream*1000: 428.478ms
+benchPinoNodeStream*1000: 411.574ms

Running CHILD benchmark

-benchBunyanChild*10000: 567.493ms
+benchBunyanChild*10000: 586.267ms
-benchBoleChild*10000: 419.999ms
+benchBoleChild*10000: 421.346ms
-benchPinoChild*10000: 338.945ms
+benchPinoChild*10000: 341.946ms
-benchPinoExtremeChild*10000: 114.671ms
+benchPinoExtremeChild*10000: 112.460ms
-benchPinoNodeStreamChild*10000: 225.626ms
+benchPinoNodeStreamChild*10000: 227.379ms
-benchBunyanChild*10000: 503.690ms
+benchBunyanChild*10000: 521.455ms
-benchBoleChild*10000: 260.879ms
+benchBoleChild*10000: 256.240ms
-benchPinoChild*10000: 321.065ms
+benchPinoChild*10000: 313.854ms
-benchPinoExtremeChild*10000: 98.448ms
+benchPinoExtremeChild*10000: 102.387ms
-benchPinoNodeStreamChild*10000: 207.843ms
+benchPinoNodeStreamChild*10000: 207.110ms

Running CHILD-CHILD benchmark

-benchBunyanChildChild*10000: 618.211ms
+benchBunyanChildChild*10000: 603.190ms
-benchPinoChildChild*10000: 344.214ms
+benchPinoChildChild*10000: 344.286ms
-benchPinoExtremeChildChild*10000: 115.772ms
+benchPinoExtremeChildChild*10000: 116.445ms
-benchPinoNodeStreamChildChild*10000: 220.681ms
+benchPinoNodeStreamChildChild*10000: 226.080ms
-benchBunyanChildChild*10000: 533.559ms
+benchBunyanChildChild*10000: 527.748ms
-benchPinoChildChild*10000: 316.138ms
+benchPinoChildChild*10000: 327.563ms
-benchPinoExtremeChildChild*10000: 104.926ms
+benchPinoExtremeChildChild*10000: 105.466ms
-benchPinoNodeStreamChildChild*10000: 204.724ms
+benchPinoNodeStreamChildChild*10000: 207.909ms

Running CHILD-CREATION benchmark

-benchBunyanCreation*10000: 616.200ms
+benchBunyanCreation*10000: 593.715ms
-benchBoleCreation*10000: 435.486ms
+benchBoleCreation*10000: 437.114ms
-benchPinoCreation*10000: 362.138ms
+benchPinoCreation*10000: 352.944ms
-benchPinoExtremeCreation*10000: 139.233ms
+benchPinoExtremeCreation*10000: 137.403ms
-benchPinoNodeStreamCreation*10000: 246.720ms
+benchPinoNodeStreamCreation*10000: 244.496ms
-benchBunyanCreation*10000: 541.271ms
+benchBunyanCreation*10000: 524.649ms
-benchBoleCreation*10000: 275.391ms
+benchBoleCreation*10000: 280.806ms
-benchPinoCreation*10000: 345.924ms
+benchPinoCreation*10000: 340.122ms
-benchPinoExtremeCreation*10000: 113.397ms
+benchPinoExtremeCreation*10000: 113.752ms
-benchPinoNodeStreamCreation*10000: 224.750ms
+benchPinoNodeStreamCreation*10000: 220.402ms


BASIC benchmark averages

-Bunyan average: 528.878ms
+Bunyan average: 513.412ms
-Winston average: 386.041ms
+Winston average: 392.740ms
-Bole average: 313.767ms
+Bole average: 319.952ms
-Debug average: 280.826ms
+Debug average: 279.422ms
-LogLevel average: 268.985ms
+LogLevel average: 272.206ms
-Pino average: 301.609ms
+Pino average: 297.462ms
-PinoExtreme average: 87.520ms
+PinoExtreme average: 88.066ms
-PinoNodeStream average: 196.554ms
+PinoNodeStream average: 191.305ms

==========
System: Darwin/darwin x64 18.2.0 ~ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz (cores/threads: 8)
==========

OBJECT benchmark averages

-BunyanObj average: 524.645ms
+BunyanObj average: 540.844ms
-WinstonObj average: 431.712ms
+WinstonObj average: 420.543ms
-BoleObj average: 351.480ms
+BoleObj average: 345.684ms
-LogLevelObject average: 429.545ms
+LogLevelObject average: 443.248ms
-PinoObj average: 328.642ms
+PinoObj average: 327.296ms
-PinoExtremeObj average: 100.958ms
+PinoExtremeObj average: 98.388ms
-PinoNodeStreamObj average: 208.334ms
+PinoNodeStreamObj average: 210.976ms

==========
System: Darwin/darwin x64 18.2.0 ~ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz (cores/threads: 8)
==========

DEEP-OBJECT benchmark averages

-BunyanDeepObj average: 1495.525ms
+BunyanDeepObj average: 1480.543ms
-WinstonDeepObj average: 2161.901ms
+WinstonDeepObj average: 2141.664ms
-BoleDeepObj average: 2725.350ms
+BoleDeepObj average: 2712.814ms
-LogLevelDeepObj average: 4714.097ms
+LogLevelDeepObj average: 4668.844ms
-PinoDeepObj average: 1902.081ms
+PinoDeepObj average: 1865.365ms
-PinoExtremeDeepObj average: 1695.443ms
+PinoExtremeDeepObj average: 1688.687ms
-PinoNodeStreamDeepObj average: 1742.954ms
+PinoNodeStreamDeepObj average: 1728.711ms

==========
-System: Darwin/darwin x64 18.2.0 ~ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz (cores/threads: 8)
==========

MULTI-ARG benchmark averages

-BunyanMulti average: 537.545ms
+BunyanMulti average: 536.413ms
-WinstonMulti average: 434.385ms
+WinstonMulti average: 437.461ms
-BoleMulti average: 330.237ms
+BoleMulti average: 325.383ms
-LogLevelMulti average: 309.608ms
+LogLevelMulti average: 306.893ms
-DebugMulti average: 285.868ms
+DebugMulti average: 280.923ms
-PinoMulti average: 314.844ms
+PinoMulti average: 303.588ms
-PinoExtremeMulti average: 92.301ms
+PinoExtremeMulti average: 94.633ms
-PinoNodeStreamMulti average: 203.538ms
+PinoNodeStreamMulti average: 204.663ms
-BunyanInterpolate average: 509.839ms
+BunyanInterpolate average: 489.589ms
-WinstonInterpolate average: 402.831ms
+WinstonInterpolate average: 401.541ms
-BoleInterpolate average: 242.899ms
+BoleInterpolate average: 235.343ms
-PinoInterpolate average: 318.791ms
+PinoInterpolate average: 319.120ms
-PinoExtremeInterpolate average: 94.998ms
+PinoExtremeInterpolate average: 94.794ms
-PinoNodeStreamInterpolate average: 205.400ms
+PinoNodeStreamInterpolate average: 207.531ms
-BunyanInterpolateAll average: 582.387ms
+BunyanInterpolateAll average: 557.938ms
-WinstonInterpolateAll average: 402.993ms
+WinstonInterpolateAll average: 404.429ms
-BoleInterpolateAll average: 306.606ms
+BoleInterpolateAll average: 305.148ms
-PinoInterpolateAll average: 418.721ms
+PinoInterpolateAll average: 424.375ms
-PinoExtremeInterpolateAll average: 181.097ms
+PinoExtremeInterpolateAll average: 179.648ms
-PinoNodeStreamInterpolateAll average: 303.677ms
+PinoNodeStreamInterpolateAll average: 297.944ms
-BunyanInterpolateExtra average: 742.951ms
+BunyanInterpolateExtra average: 722.543ms
-WinstonInterpolateExtra average: 401.043ms
+WinstonInterpolateExtra average: 404.035ms
-BoleInterpolateExtra average: 443.751ms
+BoleInterpolateExtra average: 432.149ms
-PinoInterpolateExtra average: 485.584ms
+PinoInterpolateExtra average: 493.802ms
-PinoExtremeInterpolateExtra average: 251.757ms
+PinoExtremeInterpolateExtra average: 257.640ms
-PinoNodeStreamInterpolateExtra average: 370.491ms
+PinoNodeStreamInterpolateExtra average: 370.097ms
-BunyanInterpolateDeep average: 11921.400ms
+BunyanInterpolateDeep average: 11846.612ms
-WinstonInterpolateDeep average: 11175.917ms
+WinstonInterpolateDeep average: 11322.586ms
-BoleInterpolateDeep average: 11819.938ms
+BoleInterpolateDeep average: 11734.570ms
-PinoInterpolateDeep average: 11601.586ms
+PinoInterpolateDeep average: 11547.318ms
-PinoExtremeInterpolateDeep average: 11709.993ms
+PinoExtremeInterpolateDeep average: 11696.756ms
-PinoNodeStreamInterpolateDeep average: 11606.115ms
+PinoNodeStreamInterpolateDeep average: 11486.269ms

==========
System: Darwin/darwin x64 18.2.0 ~ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz (cores/threads: 8)
==========

LONG-STRING benchmark averages

-Bunyan average: 488.293ms
+Bunyan average: 467.995ms
-Winston average: 471.557ms
+Winston average: 461.145ms
-Bole average: 537.388ms
+Bole average: 527.039ms
-Pino average: 262.714ms
+Pino average: 257.704ms
-PinoExtreme average: 225.956ms
+PinoExtreme average: 221.538ms
-PinoNodeStream average: 432.127ms
+PinoNodeStream average: 414.533ms

==========
System: Darwin/darwin x64 18.2.0 ~ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz (cores/threads: 8)
==========

CHILD benchmark averages

-BunyanChild average: 535.591ms
+BunyanChild average: 553.861ms
-BoleChild average: 340.439ms
+BoleChild average: 338.793ms
-PinoChild average: 330.005ms
+PinoChild average: 327.900ms
-PinoExtremeChild average: 106.559ms
+PinoExtremeChild average: 107.423ms
-PinoNodeStreamChild average: 216.734ms
+PinoNodeStreamChild average: 217.245ms

==========
System: Darwin/darwin x64 18.2.0 ~ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz (cores/threads: 8)
==========

-CHILD-CHILD benchmark averages
+CHILD-CHILD benchmark averages
-BunyanChildChild average: 575.885ms
+BunyanChildChild average: 565.469ms
-PinoChildChild average: 330.176ms
+PinoChildChild average: 335.924ms
-PinoExtremeChildChild average: 110.349ms
+PinoExtremeChildChild average: 110.956ms
-PinoNodeStreamChildChild average: 212.702ms
+PinoNodeStreamChildChild average: 216.995ms

==========
System: Darwin/darwin x64 18.2.0 ~ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz (cores/threads: 8)
==========

CHILD-CREATION benchmark averages

-BunyanCreation average: 578.736ms
+BunyanCreation average: 559.182ms
-BoleCreation average: 355.438ms
+BoleCreation average: 358.960ms
-PinoCreation average: 354.031ms
+PinoCreation average: 346.533ms
-PinoExtremeCreation average: 126.315ms
+PinoExtremeCreation average: 125.577ms
-PinoNodeStreamCreation average: 235.735ms
+PinoNodeStreamCreation average: 232.449ms

==========
System: Darwin/darwin x64 18.2.0 ~ Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz (cores/threads: 8)
```