### PR TITLE
add `bindings` method to logger instances

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,7 @@
   * [logger.error()](#error)
   * [logger.fatal()](#fatal)
   * [logger.child()](#child)
-  * [logger.childBindings()](#childBindings)
+  * [logger.bindings()](#bindings)
   * [logger.flush()](#flush)
   * [logger.level](#level)
   * [logger.isLevelEnabled()](#islevelenabled)
@@ -498,16 +498,16 @@ child.info({test: 'will be overwritten'})
 * See [`serializers` option](#opt-serializers)
 * See [pino.stdSerializers](#pino-stdSerializers)
 
-<a id="childBindings"></a>
-### `logger.childBindings()`
+<a id="bindings"></a>
+### `logger.bindings()`
 
 Returns an object containing all the current bindings, cloned from the ones passed in via `logger.child()`.
 ```js
 const child = logger.child({ foo: 'bar' })
-console.log(child.childBindings())
+console.log(child.bindings())
 // { foo: 'bar' }
 const anotherChild = child.child({ MIX: { IN: 'always' } })
-console.log(child.childBindings())
+console.log(child.bindings())
 // { foo: 'bar', MIX: { IN: 'always' } }
 ```
 

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -40,7 +40,7 @@ const constructor = class Pino {}
 const prototype = {
   constructor,
   child,
-  childBindings,
+  bindings,
   flush,
   isLevelEnabled,
   version,
@@ -86,13 +86,13 @@ function child (bindings) {
   return instance
 }
 
-function childBindings () {
+function bindings () {
   const chindings = this[chindingsSym]
   var chindingsJson = `{${chindings.substr(1)}}` // at least contains ,"pid":7068,"hostname":"myMac"
-  var bindings = JSON.parse(chindingsJson)
-  delete bindings['pid']
-  delete bindings['hostname']
-  return bindings
+  var bindingsFromJson = JSON.parse(chindingsJson)
+  delete bindingsFromJson['pid']
+  delete bindingsFromJson['hostname']
+  return bindingsFromJson
 }
 
 function write (obj, msg, num) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -24,14 +24,14 @@ test('child instance exposes pino version', async ({ is }) => {
   is(child.version, version)
 })
 
-test('childBindings are exposed on every instance', async ({ same }) => {
+test('bindings are exposed on every instance', async ({ same }) => {
   const instance = pino()
-  same(instance.childBindings(), {})
+  same(instance.bindings(), {})
 })
 
-test('childBindings contain the name and the child bindings', async ({ same }) => {
+test('bindings contain the name and the child bindings', async ({ same }) => {
   const instance = pino({ name: 'basicTest', level: 'info' }).child({ foo: 'bar' }).child({ a: 2 })
-  same(instance.childBindings(), { name: 'basicTest', foo: 'bar', a: 2 })
+  same(instance.bindings(), { name: 'basicTest', foo: 'bar', a: 2 })
 })
 
 function levelTest (name, level) {


### PR DESCRIPTION
Step 1:
Expose tools.getChindings()
Register a symbol for the method
Reference the method in prototype.
