### PR TITLE
fix: browser-transmit messages array when asObject is true

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -203,18 +203,18 @@ function wrap (opts, logger, level) {
 
 function asObject (logger, level, args, ts) {
   if (logger._serialize) applySerializers(args, logger._serialize, logger.serializers, logger._stdErrSerialize)
-  var msg = args[0]
+  var argsCloned = args.slice()
+  var msg = argsCloned[0]
   var o = { time: ts, level: pino.levels.values[level] }
   var lvl = (logger._childLevel | 0) + 1
   if (lvl < 1) lvl = 1
   // deliberate, catching objects, arrays
   if (msg !== null && typeof msg === 'object') {
-    args = args.slice()
-    while (lvl-- && typeof args[0] === 'object') {
-      Object.assign(o, args.shift())
+    while (lvl-- && typeof argsCloned[0] === 'object') {
+      Object.assign(o, argsCloned.shift())
     }
-    msg = args.length ? format(args.shift(), args) : undefined
-  } else if (typeof msg === 'string') msg = format(args.shift(), args)
+    msg = argsCloned.length ? format(argsCloned.shift(), argsCloned) : undefined
+  } else if (typeof msg === 'string') msg = format(argsCloned.shift(), argsCloned)
   if (msg !== undefined) o.msg = msg
   return o
 }

--- a/test/browser-transmit.test.js
+++ b/test/browser-transmit.test.js
@@ -50,7 +50,38 @@ test('passes send function the logged level', ({ end, is }) => {
 })
 
 test('passes send function messages in logEvent object', ({ end, same, is }) => {
-  const logger = pino({
+  // in order to cover all possible scenarios, need to test messages with/without objects, and with/without the `asObject` option set
+
+  const logger1 = pino({
+    browser: {
+      write: noop,
+      transmit: {
+        send (level, { messages }) {
+          is(messages[0], 'test')
+          is(messages[1], 'another test')
+        }
+      }
+    }
+  })
+
+  logger1.fatal('test', 'another test')
+
+  const logger2 = pino({
+    browser: {
+      asObject: true,
+      write: noop,
+      transmit: {
+        send (level, { messages }) {
+          is(messages[0], 'test')
+          is(messages[1], 'another test')
+        }
+      }
+    }
+  })
+
+  logger2.fatal('test', 'another test')
+
+  const logger3 = pino({
     browser: {
       write: noop,
       transmit: {
@@ -62,7 +93,23 @@ test('passes send function messages in logEvent object', ({ end, same, is }) => 
     }
   })
 
-  logger.fatal({ test: 'test' }, 'another test')
+  logger3.fatal({ test: 'test' }, 'another test')
+
+  const logger4 = pino({
+    browser: {
+      asObject: true,
+      write: noop,
+      transmit: {
+        send (level, { messages }) {
+          same(messages[0], { test: 'test' })
+          is(messages[1], 'another test')
+        }
+      }
+    }
+  })
+
+  logger4.fatal({ test: 'test' }, 'another test')
+
   end()
 })
 

--- a/test/browser-transmit.test.js
+++ b/test/browser-transmit.test.js
@@ -49,10 +49,8 @@ test('passes send function the logged level', ({ end, is }) => {
   end()
 })
 
-test('passes send function messages in logEvent object', ({ end, same, is }) => {
-  // in order to cover all possible scenarios, need to test messages with/without objects, and with/without the `asObject` option set
-
-  const logger1 = pino({
+test('passes send function message strings in logEvent object when asObject is not set', ({ end, same, is }) => {
+  const logger = pino({
     browser: {
       write: noop,
       transmit: {
@@ -64,9 +62,31 @@ test('passes send function messages in logEvent object', ({ end, same, is }) => 
     }
   })
 
-  logger1.fatal('test', 'another test')
+  logger.fatal('test', 'another test')
 
-  const logger2 = pino({
+  end()
+})
+
+test('passes send function message objects in logEvent object when asObject is not set', ({ end, same, is }) => {
+  const logger = pino({
+    browser: {
+      write: noop,
+      transmit: {
+        send (level, { messages }) {
+          same(messages[0], { test: 'test' })
+          is(messages[1], 'another test')
+        }
+      }
+    }
+  })
+
+  logger.fatal({ test: 'test' }, 'another test')
+
+  end()
+})
+
+test('passes send function message strings in logEvent object when asObject is set', ({ end, same, is }) => {
+  const logger = pino({
     browser: {
       asObject: true,
       write: noop,
@@ -79,23 +99,13 @@ test('passes send function messages in logEvent object', ({ end, same, is }) => 
     }
   })
 
-  logger2.fatal('test', 'another test')
+  logger.fatal('test', 'another test')
 
-  const logger3 = pino({
-    browser: {
-      write: noop,
-      transmit: {
-        send (level, { messages }) {
-          same(messages[0], { test: 'test' })
-          is(messages[1], 'another test')
-        }
-      }
-    }
-  })
+  end()
+})
 
-  logger3.fatal({ test: 'test' }, 'another test')
-
-  const logger4 = pino({
+test('passes send function message objects in logEvent object when asObject is set', ({ end, same, is }) => {
+  const logger = pino({
     browser: {
       asObject: true,
       write: noop,
@@ -108,7 +118,7 @@ test('passes send function messages in logEvent object', ({ end, same, is }) => 
     }
   })
 
-  logger4.fatal({ test: 'test' }, 'another test')
+  logger.fatal({ test: 'test' }, 'another test')
 
   end()
 })

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -198,9 +198,57 @@ test('opts.browser.write func string joining', ({ end, ok, is }) => {
   end()
 })
 
+test('opts.browser.write func string joining when asObject is true', ({ end, ok, is }) => {
+  const instance = pino({
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.level, 30)
+        is(o.msg, 'test test2 test3')
+        ok(o.time)
+      }
+    }
+  })
+  instance.info('test', 'test2', 'test3')
+
+  end()
+})
+
+test('opts.browser.write func string joining when asObject is true', ({ end, ok, is }) => {
+  const instance = pino({
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.level, 30)
+        is(o.msg, 'test test2 test3')
+        ok(o.time)
+      }
+    }
+  })
+  instance.info('test', 'test2', 'test3')
+
+  end()
+})
+
 test('opts.browser.write func string object joining', ({ end, ok, is }) => {
   const instance = pino({
     browser: {
+      write: function (o) {
+        is(o.level, 30)
+        is(o.msg, 'test {"test":"test2"} {"test":"test3"}')
+        ok(o.time)
+      }
+    }
+  })
+  instance.info('test', { test: 'test2' }, { test: 'test3' })
+
+  end()
+})
+
+test('opts.browser.write func string object joining when asObject is true', ({ end, ok, is }) => {
+  const instance = pino({
+    browser: {
+      asObject: true,
       write: function (o) {
         is(o.level, 30)
         is(o.msg, 'test {"test":"test2"} {"test":"test3"}')


### PR DESCRIPTION
Fixes #582 

When `asObject` is `true`, and logging with _just_ strings, the `messages` array does not contain all of the messages.

`args.slice()` creates a clone of `args`, but it was only happening in the case of log messages with objects.

This fixes the issue and expands the test case to include all 4 permutations.

