### PR TITLE
Fixes and tests for top level key corner cases

### DIFF
--- a/lib/redaction.js
+++ b/lib/redaction.js
@@ -21,6 +21,9 @@ function redaction (opts, serialize) {
     const next = rx.exec(str)
     // top level key:
     if (next === null) {
+      if (str === '*') {
+        str = wildcardFirstSym
+      }
       o[str] = null
       return o
     }
@@ -32,6 +35,12 @@ function redaction (opts, serialize) {
     if (ns === '*') {
       ns = wildcardFirstSym
     }
+
+    // if ns is already redacted at the top level, ignore lower level redactions
+    if (o[ns] === null) {
+      return o
+    }
+
     o[ns] = o[ns] || []
 
     // shape is a mix of paths beginning with literal values and wildcard
@@ -47,7 +56,9 @@ function redaction (opts, serialize) {
     if (ns === wildcardFirstSym) {
       // new * path gets added to all previously registered literal ns's.
       Object.keys(o).forEach(function (k) {
-        o[k].push(nextPath)
+        if (o[k]) {
+          o[k].push(nextPath)
+        }
       })
     }
 


### PR DESCRIPTION
1. BUG: Wildcard code did not play nice with top level keys -- redaction paths of `['key', '*.foo']` would result in a `TypeError: Cannot read property 'push' of null` error.  This is fixed, with tests.

2. Noticed case where a redaction of `['key', 'key.foo']` resulted in only `key.foo` being redacted because the `key.foo` was overwriting the (null) entry for `key`.  This is fixed with tests.  Now `key` is redacted, along with all its properties (if any), including "foo".

3. Added support for `*` as a top level key.  Not too much useful in practice.  It redacts everything, leaving only the key names in the log.  But now works as one would expect.
