### PR TITLE
redact produces unquoted strings

### DIFF
--- a/lib/redaction.js
+++ b/lib/redaction.js
@@ -75,7 +75,7 @@ function redaction (opts, serialize) {
   }
   const serializedCensor = serialize(censor)
   const topCensor = () => serializedCensor
-  const rc = [...Object.keys(shape), ...Object.getOwnPropertySymbols(shape)].reduce((o, k) => {
+  return [...Object.keys(shape), ...Object.getOwnPropertySymbols(shape)].reduce((o, k) => {
     // top level key:
     if (shape[k] === null) o[k] = topCensor
     else {
@@ -84,7 +84,6 @@ function redaction (opts, serialize) {
     }
     return o
   }, result)
-  return rc
 }
 
 function handle (opts) {

--- a/lib/redaction.js
+++ b/lib/redaction.js
@@ -2,6 +2,7 @@
 
 const fastRedact = require('fast-redact')
 const { redactFmtSym, wildcardFirstSym } = require('./symbols')
+const { asString } = require('./tools.js')
 const { rx, validator } = fastRedact
 
 const validate = validator({
@@ -74,12 +75,16 @@ function redaction (opts, serialize) {
   }
   const serializedCensor = serialize(censor)
   const topCensor = () => serializedCensor
-  return [...Object.keys(shape), ...Object.getOwnPropertySymbols(shape)].reduce((o, k) => {
+  const rc = [...Object.keys(shape), ...Object.getOwnPropertySymbols(shape)].reduce((o, k) => {
     // top level key:
     if (shape[k] === null) o[k] = topCensor
-    else o[k] = fastRedact({ paths: shape[k], censor, serialize, strict })
+    else {
+      const fr = fastRedact({ paths: shape[k], censor, serialize, strict })
+      o[k] = value => (typeof value === 'string' ? asString(value) : fr(value))
+    }
     return o
   }, result)
+  return rc
 }
 
 function handle (opts) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -378,6 +378,7 @@ module.exports = {
   buildSafeSonicBoom,
   getPrettyStream,
   asChindings,
+  asString,
   asJson,
   genLog,
   createArgsNormalizer,

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -556,7 +556,7 @@ test('redacts strings at the top level', async ({ is }) => {
   is(o.s, '[Redacted]')
 })
 
-test('does not redact primitives if not objects', async ({ is }) => {
+test('does not redact numbers if not objects', async ({ is }) => {
   const stream = sink()
   const instance = pino({ redact: ['a.b'] }, stream)
   const obj = {
@@ -565,6 +565,39 @@ test('does not redact primitives if not objects', async ({ is }) => {
   instance.info(obj)
   const o = await once(stream, 'data')
   is(o.a, 42)
+})
+
+test('does not redact strings if not objects', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: ['a.b'] }, stream)
+  const obj = {
+    a: 's'
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o.a, 's')
+})
+
+test('does not redact booleans if not objects', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: ['a.b'] }, stream)
+  const obj = {
+    a: true
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o.a, true)
+})
+
+test('does not redact nulls if not objects', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: ['a.b'] }, stream)
+  const obj = {
+    a: null
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o.a, null)
 })
 
 test('redacts null at the top level', async ({ is }) => {


### PR DESCRIPTION
pino has a bug where it can produce invalid JSON.  Here's an example:

```
$ cat ./test.js
'use strict'

var pino = require('./pino')({ redact: { paths: [ 'foo.bar' ] } })
pino.info({ foo: 'abc' }, 'msg')
```
```
$ node test.js | pino-pretty
{"level":30,"time":1549754571633,"msg":"msg","pid":10427,"hostname":"xxx","foo":abc,"v":1}
$
```

The bug happens when pino is called with a string property that matches the root of one of the redact paths.  In the example above, we have a redact path of "foo.bar", but pino is called with an object that has a string for "foo".  pino outputs that string value without quotes. `"foo":abc` should be `"foo":"abc"`.

This bug is troublesome if the redact path starts with a wildcard, such as "*.password".  It causes pino to output, without quotes, every string in the logged object.

With this bug, pino is susceptible to JSON injection.  Change the call above to:
```
pino.info({ foo: '{"a":false}' }, 'msg')
```
and the output is:
```
$ node test.js | pino-pretty
[1549755468666] INFO (10869 on xxx): msg
    foo: {
      "a": false
    }
```
Fake messages can be injected with:
```
pino.info({ foo: '0}\n{"a":false' }, 'msg')
```
```
$ node test.js | pino-pretty
{"level":30,"time":1549755810950,"msg":"msg","pid":11206,"hostname":"xxx","foo":0}
[undefined] USERLVL:
    a: false
```
 
 
Why does this happen?
It happens because the non-strict fast-redact simply returns primitive objects. (https://github.com/davidmarkclements/fast-redact#strict-boolean---true)  Strings are returned, without quotes and without escapes.  So when the redactor gets called with a string, it simply echos the string value back.

What's the fix?
Add a test before the redactor is called.  If it would be called with a string, make a call to `tools.asString` instead.

Note: There was a test case that pino worked properly with primitives and paths.  But the test was checking numbers and not strings, so this bug wasn't caught.  I've added individual test cases for string, boolean and null.