### PR TITLE
Add pino-browser support for hapi-pino

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -6,6 +6,8 @@ module.exports = pino
 
 var _console = global.console || {}
 var stdSerializers = {
+  wrapRequestSerializer: passthrough,
+  wrapResponseSerializer: passthrough,
   req: mock,
   res: mock,
   err: asErrValue
@@ -157,6 +159,7 @@ pino.levels = {
 }
 
 pino.stdSerializers = stdSerializers
+pino.symbols = require('./lib/symbols')
 
 function set (opts, logger, level, fallback) {
   var proto = Object.getPrototypeOf(logger)
@@ -296,4 +299,5 @@ function asErrValue (err) {
 }
 
 function mock () { return {} }
+function passthrough (a) { return a }
 function noop () {}

--- a/browser.js
+++ b/browser.js
@@ -6,6 +6,8 @@ module.exports = pino
 
 var _console = global.console || {}
 var stdSerializers = {
+  mapHttpRequest: mock,
+  mapHttpResponse: mock,
   wrapRequestSerializer: passthrough,
   wrapResponseSerializer: passthrough,
   req: mock,


### PR DESCRIPTION
This PR updates `browser.js` to expose/stub symbols and serializer methods expected by `hapi-pino`.

Without this, TypeError happens [here](https://github.com/pinojs/hapi-pino/blob/d50a86766932b0d7b5b168c963f4cc66d4be2aa7/index.js#L6) and [here](https://github.com/pinojs/hapi-pino/blob/d50a86766932b0d7b5b168c963f4cc66d4be2aa7/index.js#L23-L24). 

This is useful in extremely niche use case when one wants to run code with embedded Hapi (HTTP server) in browser context enriched with [chrome.sockets APIs](https://developer.chrome.com/apps/sockets_tcpServer) (such as Chrome Apps or blessed extensions in Chromium-based browsers).

In my case, to run js-ipfs (with embedded hapi) in WebExtension context: https://github.com/ipfs-shipyard/ipfs-companion/issues/664

