### PR TITLE
transports conversation starter [ RFC ] [ DO NOT MERGE ]

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -2,10 +2,15 @@
 
 const { Worker } = require('worker_threads')
 
-function transport (name, args = []) {
-  const filename = require.resolve(name)
-  const worker = new Worker(filename, {
-    execArgv: args,
+function transport (filePath, args = []) {
+  args.unshift(filePath)
+  const code = `
+    process.stdin.fd = 1
+    process.argv.push(...${JSON.stringify(args)})
+    require('${filePath}')
+  `
+  const worker = new Worker(code, {
+    eval: true,
     stdin: true
   })
   return worker.stdin

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const { Worker } = require('worker_threads')
+
+function transport (name, args = []) {
+  const filename = require.resolve(name)
+  const worker = new Worker(filename, {
+    execArgv: args,
+    stdin: true
+  })
+  return worker.stdin
+}
+
+module.exports = transport

--- a/pino.js
+++ b/pino.js
@@ -4,6 +4,7 @@ const stdSerializers = require('pino-std-serializers')
 const redaction = require('./lib/redaction')
 const time = require('./lib/time')
 const proto = require('./lib/proto')
+const transport = require('./lib/transport')
 const symbols = require('./lib/symbols')
 const { assertDefaultLevelFound, mappings, genLsCache } = require('./lib/levels')
 const {
@@ -121,7 +122,7 @@ function pino (...args) {
 
 pino.extreme = (dest = process.stdout.fd) => buildSafeSonicBoom(dest, 4096, false)
 pino.destination = (dest = process.stdout.fd) => buildSafeSonicBoom(dest, 0, true)
-
+pino.transport = transport
 pino.final = final
 pino.levels = mappings()
 pino.stdSerializers = serializers


### PR DESCRIPTION
This isn't a PR that should be seriously considered for merging at this point, but with Node 12 near release we have the opportunity to explore `worker_threads` as a means to keep the event loop free while also reducing complexity at the operations level.

This is the beginning of that exploration. It's not a suggestion at an API as yet, purely a conversation starter.

* given that we have an ecosystem of transports it would be useful to have some kind of adapter that can consume these transports
* worker_threads have a `process.stdout` and `process.stdin` settings however `process.stdin` may not have expected properties, like `fd` (hence the need patch, otherwise this line https://github.com/pinojs/pino-pretty/blob/master/bin.js#L43 causes a crash). 
* In any case, it turns out using a worker thread and it's process IO abstraction is more efficient than piping to a separate process 

Taking the benchmark at https://github.com/pinojs/pino-http/blob/master/benchmarks/pino-server.js and running with the following command:

```sh
node benchmarks/pino-server.js | pino-pretty > /dev/null
```

Load testing with autocannon defaults gives approx. 27k req/s on my machine.

If we adapt `pino-server` to the following, using this branch:

```js
var http = require('http')
var server = http.createServer(handle)
var pino = require('pino')
var logger = require('../')({
  logger: pino(pino.transport(require.resolve('pino-pretty/bin')))
})

function handle (req, res) {
  logger(req, res)
  res.end('hello world')
}

server.listen(3000)
```

We can then use the following to get the same output:

```sh
node benchmarks/pino-server.js > /dev/null
```

On my machine, I'm seeing an average of 29k req/s.

While this looks like a trivial no-brainer right now, for moving beyond this point I'm seeing a potentially steep cliff edge.

* If the user doesn't want to log to stdout and wants to set their own destination we need to work out how to inject this into the worker thread. This may lead to using a `SharedArrayBuffer` as an efficient way to pass state. Once we start doing that we need to start using `Atomics` for state synchronization. This could lead to a lot of code, effort and bugs. We could set the `stdout` option to `true` but the overhead of piping from the workers stdout to the dest might not be worth it (also, it means not being able to use SonicBoom I think). 
* The worker thread will keep the process open. If you unref it, the main thread will close the worker thread before it can finish logging. In order to avoid this situation we'll also have to communicate state between main thread and worker thread to determine the idleness of the worker thread (there is no API for this that I can see). 
* There needs to be some thought around API, for instance, what about chaining transports? Remember we can only log to process.stdout from the worker thread. If we set `stdout` to true we can get an `stdout` stream from the worker thread, but then we may be starting to head towards choking the event loop if we have a bunch of piping between worker threads in the main process. 
* A nice to have would be forging some kind of cohesion with a browser API for remote browser logging that fits in with all this. 






