### PR TITLE
Remove log version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ child.info('hello child!')
 This produces:
 
 ```
-{"level":30,"time":1531171074631,"msg":"hello world","pid":657,"hostname":"Davids-MBP-3.fritz.box","v":1}
-{"level":30,"time":1531171082399,"msg":"hello child!","pid":657,"hostname":"Davids-MBP-3.fritz.box","a":"property","v":1}
+{"level":30,"time":1531171074631,"msg":"hello world","pid":657,"hostname":"Davids-MBP-3.fritz.box"}
+{"level":30,"time":1531171082399,"msg":"hello child!","pid":657,"hostname":"Davids-MBP-3.fritz.box","a":"property"}
 ```
 
 For using Pino with a web framework see:

--- a/browser.js
+++ b/browser.js
@@ -139,8 +139,6 @@ function pino (opts) {
   return logger
 }
 
-pino.LOG_VERSION = 1
-
 pino.levels = {
   values: {
     fatal: 60,

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,7 +19,6 @@
   * [logger\[Symbol.for('pino.serializers')\]](#serializers)
   * [Event: 'level-change'](#level-change)
   * [logger.version](#version)
-  * [logger.LOG_VERSION](#log_version)
 * [Statics](#statics)
   * [pino.destination()](#pino-destination)
   * [pino.extreme()](#pino-extreme)
@@ -28,7 +27,6 @@
   * [pino.stdTimeFunctions](#pino-stdtimefunctions)
   * [pino.symbols](#pino-symbols)
   * [pino.version](#pino-version)
-  * [pino.LOG_VERSION](#pino-LOG_VERSION)
 
 <a id="export"></a>
 ## `pino([options], [destination]) => logger`
@@ -215,7 +213,7 @@ const logger = pino({
   changeLevelName: 'priority'
 })
 logger.info('hello world')
-// {"priority":30,"time":1531257112193,"msg":"hello world","pid":55956,"hostname":"x","v":1}
+// {"priority":30,"time":1531257112193,"msg":"hello world","pid":55956,"hostname":"x"}
 ```
 
 #### `browser` (Object)
@@ -320,7 +318,7 @@ of the `mergingObject` is copied in to the JSON log line.
 
 ```js
 logger.info({MIX: {IN: true}})
-// {"level":30,"time":1531254555820,"pid":55956,"hostname":"x","MIX":{"IN":true},"v":1}
+// {"level":30,"time":1531254555820,"pid":55956,"hostname":"x","MIX":{"IN":true}}
 ```
 
 <a id=message></a>
@@ -334,7 +332,7 @@ JSON log line under the `msg` key:
 
 ```js
 logger.info('hello world')
-// {"level":30,"time":1531257112193,"msg":"hello world","pid":55956,"hostname":"x","v":1}
+// {"level":30,"time":1531257112193,"msg":"hello world","pid":55956,"hostname":"x"}
 ```
 
 The `message` parameter takes precedence over the `mergedObject`.
@@ -368,17 +366,17 @@ output `msg` value for the JSON log line.
 
 ```js
 logger.info('hello', 'world')
-// {"level":30,"time":1531257618044,"msg":"hello world","pid":55956,"hostname":"x","v":1}
+// {"level":30,"time":1531257618044,"msg":"hello world","pid":55956,"hostname":"x"}
 ```
 
 ```js
 logger.info('hello', {worldly: 1})
-// {"level":30,"time":1531257797727,"msg":"hello {\"worldly\":1}","pid":55956,"hostname":"x","v":1}
+// {"level":30,"time":1531257797727,"msg":"hello {\"worldly\":1}","pid":55956,"hostname":"x"}
 ```
 
 ```js
 logger.info('%o hello', {worldly: 1})
-// {"level":30,"time":1531257826880,"msg":"{\"worldly\":1} hello","pid":55956,"hostname":"x","v":1}
+// {"level":30,"time":1531257826880,"msg":"{\"worldly\":1} hello","pid":55956,"hostname":"x"}
 ```
 
 * See [`message` log method parameter](#message)
@@ -460,9 +458,9 @@ via the returned child logger.
 ```js
 const child = logger.child({ MIX: {IN: 'always'} })
 child.info('hello')
-// {"level":30,"time":1531258616689,"msg":"hello","pid":64849,"hostname":"x","MIX":{"IN":"always"},"v":1}
+// {"level":30,"time":1531258616689,"msg":"hello","pid":64849,"hostname":"x","MIX":{"IN":"always"}}
 child.info('child!')
-// {"level":30,"time":1531258617401,"msg":"child!","pid":64849,"hostname":"x","MIX":{"IN":"always"},"v":1}
+// {"level":30,"time":1531258617401,"msg":"child!","pid":64849,"hostname":"x","MIX":{"IN":"always"}}
 ```
 
 The `bindings` object may contain any key except for reserved configuration keys `level` and `serializers`.
@@ -489,10 +487,10 @@ any configured parent serializers.
 ```js
 const logger = require('pino')()
 logger.info({test: 'will appear'})
-// {"level":30,"time":1531259759482,"pid":67930,"hostname":"x","test":"will appear","v":1}
+// {"level":30,"time":1531259759482,"pid":67930,"hostname":"x","test":"will appear"}
 const child = logger.child({serializers: {test: () => `child-only serializer`}})
 child.info({test: 'will be overwritten'})
-// {"level":30,"time":1531259784008,"pid":67930,"hostname":"x","test":"child-only serializer","v":1}
+// {"level":30,"time":1531259784008,"pid":67930,"hostname":"x","test":"child-only serializer"}
 ```
 
 * See [`serializers` option](#opt-serializers)
@@ -646,14 +644,6 @@ Exposes the Pino package version. Also available on the exported `pino` function
 
 * See [`pino.version`](#pino-version)
 
-<a id="log_version"></a>
-### `logger.LOG_VERSION` (Number)
-
-Holds the current log format version as output in the `v` property of each log record.
-Also available on the exported `pino` function.
-
-* See [`pino.LOG_VERSION`](#pino-LOG_VERSION)
-
 ## Statics
 
 <a id="pino-destination"></a>
@@ -798,10 +788,3 @@ for general use.
 Exposes the Pino package version. Also available on the logger instance.
 
 * See [`logger.version`](#version)
-
-<a id="pino-log_version"></a>
-### `pino.LOG_VERSION` (Number)
-
-Holds the current log format version as output in the `v` property of each log record. Also available on the logger instance.
-
-* See [`logger.LOG_VERSION`](#log_version)

--- a/docs/child-loggers.md
+++ b/docs/child-loggers.md
@@ -68,7 +68,7 @@ pino(pino.destination('./my-log'))
 
 ```sh
 $ cat my-log
-{"pid":95469,"hostname":"MacBook-Pro-3.home","level":30,"msg":"howdy","time":1459534114473,"a":"property","a":"prop","v":1}
+{"pid":95469,"hostname":"MacBook-Pro-3.home","level":30,"msg":"howdy","time":1459534114473,"a":"property","a":"prop"}
 ```
 
 Notice how there's two key's named `a` in the JSON output. The sub-childs properties
@@ -80,7 +80,7 @@ namespace holds the final value assigned to it:
 
 ```sh
 $ cat my-log | node -e "process.stdin.once('data', (line) => console.log(JSON.stringify(JSON.parse(line))))"
-{"pid":95469,"hostname":"MacBook-Pro-3.home","level":30,"msg":"howdy","time":"2016-04-01T18:08:34.473Z","a":"prop","v":1}
+{"pid":95469,"hostname":"MacBook-Pro-3.home","level":30,"msg":"howdy","time":"2016-04-01T18:08:34.473Z","a":"prop"}
 ```
 
 Ultimately the conflict is resolved by taking the last value, which aligns with Bunyans child logging

--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -25,7 +25,7 @@ logger.info({
 This will output:
 
 ```JSON
-{"level":30,"time":1527777350011,"pid":3186,"hostname":"Davids-MacBook-Pro-3.local","key":"[Redacted]","path":{"to":{"key":"[Redacted]","another":"thing"}},"stuff":{"thats":[{"secret":"[Redacted]","logme":"will be logged"},{"secret":"[Redacted]","logme":"as will this"}]},"v":1}
+{"level":30,"time":1527777350011,"pid":3186,"hostname":"Davids-MacBook-Pro-3.local","key":"[Redacted]","path":{"to":{"key":"[Redacted]","another":"thing"}},"stuff":{"thats":[{"secret":"[Redacted]","logme":"will be logged"},{"secret":"[Redacted]","logme":"as will this"}]}}
 ```
 
 The `redact` option can take an array (as shown in the above example) or
@@ -58,7 +58,7 @@ logger.info({
 This will output:
 
 ```JSON
-{"level":30,"time":1527778563934,"pid":3847,"hostname":"Davids-MacBook-Pro-3.local","key":"**GDPR COMPLIANT**","path":{"to":{"key":"**GDPR COMPLIANT**","another":"thing"}},"stuff":{"thats":[{"secret":"**GDPR COMPLIANT**","logme":"will be logged"},{"secret":"**GDPR COMPLIANT**","logme":"as will this"}]},"v":1}
+{"level":30,"time":1527778563934,"pid":3847,"hostname":"Davids-MacBook-Pro-3.local","key":"**GDPR COMPLIANT**","path":{"to":{"key":"**GDPR COMPLIANT**","another":"thing"}},"stuff":{"thats":[{"secret":"**GDPR COMPLIANT**","logme":"will be logged"},{"secret":"**GDPR COMPLIANT**","logme":"as will this"}]}}
 ```
 
 The `redact.remove` option also allows for the key and value to be removed from output:
@@ -88,7 +88,7 @@ logger.info({
 This will output
 
 ```JSON
-{"level":30,"time":1527782356751,"pid":5758,"hostname":"Davids-MacBook-Pro-3.local","path":{"to":{"another":"thing"}},"stuff":{"thats":[{"logme":"will be logged"},{"logme":"as will this"}]},"v":1}
+{"level":30,"time":1527782356751,"pid":5758,"hostname":"Davids-MacBook-Pro-3.local","path":{"to":{"another":"thing"}},"stuff":{"thats":[{"logme":"will be logged"},{"logme":"as will this"}]}}
 ```
 
 See [pino options in API](api.md#pino) for `redact` API details.

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -308,7 +308,7 @@ $ node app.js | pino-syslog | pino-socket -a syslog.example.com
 Example output for the "hello world" log:
 
 ```
-<134>Apr  1 16:44:58 MacBook-Pro-3 none[94473]: {"pid":94473,"hostname":"MacBook-Pro-3","level":30,"msg":"hello world","time":1459529098958,"v":1}
+<134>Apr  1 16:44:58 MacBook-Pro-3 none[94473]: {"pid":94473,"hostname":"MacBook-Pro-3","level":30,"msg":"hello world","time":1459529098958}
 ```
 
 [pino-syslog]: https://www.npmjs.com/package/pino-syslog

--- a/lib/meta.js
+++ b/lib/meta.js
@@ -2,6 +2,4 @@
 
 const { version } = require('../package.json')
 
-const LOG_VERSION = 1
-
-module.exports = { version, LOG_VERSION }
+module.exports = { version }

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -30,8 +30,7 @@ const {
   asJson
 } = require('./tools')
 const {
-  version,
-  LOG_VERSION
+  version
 } = require('./meta')
 
 // note: use of class is satirical
@@ -52,8 +51,7 @@ const prototype = {
   [writeSym]: write,
   [asJsonSym]: asJson,
   [getLevelSym]: getLevel,
-  [setLevelSym]: setLevel,
-  LOG_VERSION
+  [setLevelSym]: setLevel
 }
 
 Object.setPrototypeOf(prototype, EventEmitter.prototype)

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -222,7 +222,7 @@ function prettifierMetaWrapper (pretty, dest) {
       if (lastLogger.hasOwnProperty(parsedChindingsSym)) {
         chindings = lastLogger[parsedChindingsSym]
       } else {
-        chindings = JSON.parse('{"v":1' + lastLogger[chindingsSym] + '}')
+        chindings = JSON.parse('{' + lastLogger[chindingsSym].substr(1) + '}')
         lastLogger[parsedChindingsSym] = chindings
       }
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "import-fresh": "^3.0.0",
     "log": "^5.0.0",
     "loglevel": "^1.6.1",
-    "pino-pretty": "^2.4.0",
+    "pino-pretty": "^3.0.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.0",
     "pump": "^3.0.0",

--- a/pino.js
+++ b/pino.js
@@ -13,7 +13,7 @@ const {
   stringify,
   buildSafeSonicBoom
 } = require('./lib/tools')
-const { version, LOG_VERSION } = require('./lib/meta')
+const { version } = require('./lib/meta')
 const {
   chindingsSym,
   redactFmtSym,
@@ -77,7 +77,7 @@ function pino (...args) {
   const formatOpts = redact
     ? { stringify: stringifiers[redactFmtSym] }
     : { stringify }
-  const end = ',"v":' + LOG_VERSION + '}' + (crlf ? '\r\n' : '\n')
+  const end = '}' + (crlf ? '\r\n' : '\n')
   const coreChindings = asChindings.bind(null, {
     [chindingsSym]: '',
     [serializersSym]: serializers,
@@ -127,6 +127,5 @@ pino.stdSerializers = serializers
 pino.stdTimeFunctions = Object.assign({}, time)
 pino.symbols = symbols
 pino.version = version
-pino.LOG_VERSION = LOG_VERSION
 
 module.exports = pino

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -56,7 +56,6 @@ function levelTest (name, level) {
     is(result.hostname, hostname)
     is(result.level, level)
     is(result.hello, 'world')
-    is(result.v, 1)
     same(Object.keys(obj), [ 'hello' ])
   })
 
@@ -74,8 +73,7 @@ function levelTest (name, level) {
       hostname: hostname,
       level: level,
       msg: 'a string',
-      hello: 'world',
-      v: 1
+      hello: 'world'
     })
     same(Object.keys(obj), [ 'hello' ])
   })
@@ -93,8 +91,7 @@ function levelTest (name, level) {
       hostname: hostname,
       level: level,
       msg: 'string',
-      hello: 'world',
-      v: 1
+      hello: 'world'
     })
   })
 
@@ -128,8 +125,7 @@ function levelTest (name, level) {
         type: 'Error',
         message: err.message,
         stack: err.stack
-      },
-      v: 1
+      }
     })
   })
 
@@ -147,8 +143,7 @@ function levelTest (name, level) {
       hostname: hostname,
       level: level,
       msg: 'hello world',
-      hello: 'world',
-      v: 1
+      hello: 'world'
     })
   })
 }
@@ -198,8 +193,7 @@ test('set the name', async ({ is, same }) => {
     hostname: hostname,
     level: 60,
     name: 'hello',
-    msg: 'this is fatal',
-    v: 1
+    msg: 'this is fatal'
   })
 })
 
@@ -218,8 +212,7 @@ test('set the messageKey', async ({ is, same }) => {
     pid: pid,
     hostname: hostname,
     level: 30,
-    fooMessage: message,
-    v: 1
+    fooMessage: message
   })
 })
 
@@ -234,8 +227,7 @@ test('set undefined properties', async ({ is, same }) => {
     pid: pid,
     hostname: hostname,
     level: 30,
-    hello: 'world',
-    v: 1
+    hello: 'world'
   })
 })
 
@@ -262,8 +254,7 @@ test('set the base', async ({ is, same }) => {
   same(result, {
     a: 'b',
     level: 60,
-    msg: 'this is fatal',
-    v: 1
+    msg: 'this is fatal'
   })
 })
 
@@ -278,8 +269,7 @@ test('set the base to null', async ({ is, same }) => {
   delete result.time
   same(result, {
     level: 60,
-    msg: 'this is fatal',
-    v: 1
+    msg: 'this is fatal'
   })
 })
 
@@ -300,8 +290,7 @@ test('set the base to null and use a serializer', async ({ is, same }) => {
   same(result, {
     level: 60,
     msg: 'this is fatal too',
-    additionalMessage: 'using pino',
-    v: 1
+    additionalMessage: 'using pino'
   })
 })
 
@@ -325,8 +314,7 @@ test('correctly escapes msg strings with stray double quote at end', async ({ sa
     hostname: hostname,
     level: 60,
     name: 'hello',
-    msg: 'this contains "',
-    v: 1
+    msg: 'this contains "'
   })
 })
 
@@ -343,8 +331,7 @@ test('correctly escape msg strings with unclosed double quote', async ({ same })
     hostname: hostname,
     level: 60,
     name: 'hello',
-    msg: '" this contains',
-    v: 1
+    msg: '" this contains'
   })
 })
 
@@ -360,8 +347,7 @@ test('object and format string', async ({ same }) => {
     pid: pid,
     hostname: hostname,
     level: 30,
-    msg: 'foo bar',
-    v: 1
+    msg: 'foo bar'
   })
 })
 
@@ -376,8 +362,7 @@ test('object and format string property', async ({ same }) => {
     hostname: hostname,
     level: 30,
     msg: 'foo bar',
-    answer: 42,
-    v: 1
+    answer: 42
   })
 })
 
@@ -402,8 +387,7 @@ test('correctly supports stderr', async ({ same }) => {
         pid: pid,
         hostname: hostname,
         level: 60,
-        msg: 'a message',
-        v: 1
+        msg: 'a message'
       })
     }
   }
@@ -421,8 +405,7 @@ test('normalize number to string', async ({ same }) => {
     pid: pid,
     hostname: hostname,
     level: 30,
-    msg: '1',
-    v: 1
+    msg: '1'
   })
 })
 
@@ -437,8 +420,7 @@ test('normalize number to string with an object', async ({ same }) => {
     hostname: hostname,
     level: 30,
     msg: '1',
-    answer: 42,
-    v: 1
+    answer: 42
   })
 })
 
@@ -454,8 +436,7 @@ test('handles objects with null prototype', async ({ same }) => {
     pid: pid,
     hostname: hostname,
     level: 30,
-    test: 'test',
-    v: 1
+    test: 'test'
   })
 })
 
@@ -473,8 +454,7 @@ test('pino.destination', async ({ same }) => {
     pid: pid,
     hostname: hostname,
     level: 30,
-    msg: 'hello',
-    v: 1
+    msg: 'hello'
   })
 })
 
@@ -492,8 +472,7 @@ test('auto pino.destination with a string', async ({ same }) => {
     pid: pid,
     hostname: hostname,
     level: 30,
-    msg: 'hello',
-    v: 1
+    msg: 'hello'
   })
 })
 
@@ -511,8 +490,7 @@ test('auto pino.destination with a string as second argument', async ({ same }) 
     pid: pid,
     hostname: hostname,
     level: 30,
-    msg: 'hello',
-    v: 1
+    msg: 'hello'
   })
 })
 
@@ -532,8 +510,7 @@ test('does not override opts with a string as second argument', async ({ same })
     hostname: hostname,
     level: 30,
     time: 'none',
-    msg: 'hello',
-    v: 1
+    msg: 'hello'
   })
 })
 

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -95,12 +95,6 @@ test('exposes levels object', ({ end, same }) => {
   end()
 })
 
-test('exposes LOG_VERSION', ({ end, is }) => {
-  is(pino.LOG_VERSION, 1)
-
-  end()
-})
-
 test('exposes faux stdSerializers', ({ end, ok, same }) => {
   ok(pino.stdSerializers)
   // make sure faux stdSerializers match pino-std-serializers

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -25,8 +25,7 @@ test('err is serialized with additional properties set on the Error object', asy
     type: 'Error',
     msg: err.message,
     stack: err.stack,
-    foo: err.foo,
-    v: 1
+    foo: err.foo
   })
 })
 
@@ -45,8 +44,7 @@ test('type should be retained, even if type is a property', async ({ ok, same })
     level: level,
     type: 'bar',
     msg: err.message,
-    stack: err.stack,
-    v: 1
+    stack: err.stack
   })
 })
 
@@ -67,8 +65,7 @@ test('type, message and stack should be first level properties', async ({ ok, sa
     type: 'Error',
     msg: err.message,
     stack: err.stack,
-    foo: err.foo,
-    v: 1
+    foo: err.foo
   })
 })
 
@@ -95,8 +92,7 @@ test('err serializer', async ({ ok, same }) => {
       message: err.message,
       stack: err.stack,
       foo: err.foo
-    },
-    v: 1
+    }
   })
 })
 
@@ -118,8 +114,7 @@ test('an error with statusCode property is not confused for a http response', as
     type: 'Error',
     msg: err.message,
     stack: err.stack,
-    statusCode: err.statusCode,
-    v: 1
+    statusCode: err.statusCode
   })
 })
 
@@ -170,7 +165,6 @@ test('correctly ignores toString on errors', async ({ same }) => {
     level: 60,
     type: 'Error',
     msg: err.message,
-    stack: err.stack,
-    v: 1
+    stack: err.stack
   })
 })

--- a/test/escaping.test.js
+++ b/test/escaping.test.js
@@ -22,8 +22,7 @@ function testEscape (ch, key) {
       hostname: hostname,
       level: 60,
       name: 'hello',
-      msg: 'this contains ' + key,
-      v: 1
+      msg: 'this contains ' + key
     })
   })
 }
@@ -87,7 +86,6 @@ test('correctly escape `hello \\u001F world \\n \\u0022`', async ({ same }) => {
     hostname: hostname,
     level: 60,
     name: 'hello',
-    msg: 'hello \u001F world \n \u0022',
-    v: 1
+    msg: 'hello \u001F world \n \u0022'
   })
 })

--- a/test/helper.js
+++ b/test/helper.js
@@ -5,7 +5,6 @@ const writer = require('flush-write-stream')
 const split = require('split2')
 const pid = process.pid
 const hostname = os.hostname()
-const v = 1
 
 const isWin = process.platform === 'win32'
 
@@ -43,7 +42,6 @@ function check (is, chunk, level, msg) {
   is(chunk.hostname, hostname)
   is(chunk.level, level)
   is(chunk.msg, msg)
-  is(chunk.v, v)
 }
 
 function sleep (ms) {

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -19,7 +19,6 @@ test('http request support', async ({ ok, same, error, teardown }) => {
       hostname: hostname,
       level: 30,
       msg: 'my request',
-      v: 1,
       req: {
         method: originalReq.method,
         url: originalReq.url,
@@ -58,7 +57,6 @@ test('http request support via serializer', async ({ ok, same, error, teardown }
       hostname: hostname,
       level: 30,
       msg: 'my request',
-      v: 1,
       req: {
         method: originalReq.method,
         url: originalReq.url,
@@ -98,7 +96,6 @@ test('http request support via serializer without request connection', async ({ 
       hostname: hostname,
       level: 30,
       msg: 'my request',
-      v: 1,
       req: {
         method: originalReq.method,
         url: originalReq.url,
@@ -133,7 +130,6 @@ test('http response support', async ({ ok, same, error, teardown }) => {
       hostname: hostname,
       level: 30,
       msg: 'my response',
-      v: 1,
       res: {
         statusCode: originalRes.statusCode,
         headers: originalRes._headers
@@ -170,7 +166,6 @@ test('http response support via a serializer', async ({ ok, same, error, teardow
       hostname: hostname,
       level: 30,
       msg: 'my response',
-      v: 1,
       res: {
         statusCode: 200,
         headers: {
@@ -212,7 +207,6 @@ test('http request support via serializer in a child', async ({ ok, same, error,
       hostname: hostname,
       level: 30,
       msg: 'my request',
-      v: 1,
       req: {
         method: originalReq.method,
         url: originalReq.url,

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -25,8 +25,7 @@ test('metadata works', async ({ ok, same, is }) => {
         hostname: hostname,
         level: 30,
         hello: 'world',
-        msg: 'a msg',
-        v: 1
+        msg: 'a msg'
       })
     }
   })
@@ -51,8 +50,7 @@ test('child loggers works', async ({ ok, same, is }) => {
         level: 30,
         hello: 'world',
         from: 'child',
-        msg: 'a msg',
-        v: 1
+        msg: 'a msg'
       })
     }
   })
@@ -76,8 +74,7 @@ test('without object', async ({ ok, same, is }) => {
         pid: pid,
         hostname: hostname,
         level: 30,
-        msg: 'a msg',
-        v: 1
+        msg: 'a msg'
       })
     }
   })
@@ -100,8 +97,7 @@ test('without msg', async ({ ok, same, is }) => {
         pid: pid,
         hostname: hostname,
         level: 30,
-        hello: 'world',
-        v: 1
+        hello: 'world'
       })
     }
   })


### PR DESCRIPTION
Fixes #620 

Removing `v1` breaks a test in `pretty.test.js`. To fix it I have to update `pino-pretty`. I wanted to do so, but it seems there is a circular dependency when running tests `pino` -> `pino-pretty` -> `pino`.
How do you usually handle update both packages at the same time?

How should `pino-pretty` handle it? Removing this check

```
function isPinoLog (log) {
  return log && (log.hasOwnProperty('v') && log.v === 1)
}
```

seems to be the easiest way, but then `pino-pretty` will print logs not coming from `pino` like that

```
USERLVL:           
    hello: "world"
```