### PR TITLE
Pino browser fixes

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -162,7 +162,6 @@ pino.levels = {
 }
 
 pino.stdSerializers = stdSerializers
-pino.symbols = require('./lib/symbols')
 
 function set (opts, logger, level, fallback) {
   var proto = Object.getPrototypeOf(logger)

--- a/browser.js
+++ b/browser.js
@@ -4,7 +4,7 @@ var format = require('quick-format-unescaped')
 
 module.exports = pino
 
-var _console = global.console || {}
+var _console = polyfillGlobalThis().console || {}
 var stdSerializers = {
   mapHttpRequest: mock,
   mapHttpResponse: mock,
@@ -304,3 +304,18 @@ function asErrValue (err) {
 function mock () { return {} }
 function passthrough (a) { return a }
 function noop () {}
+
+/* eslint-disable */
+/* istanbul ignore next */
+function polyfillGlobalThis () {
+  if (typeof globalThis !== 'undefined') return globalThis
+  Object.defineProperty(Object.prototype, 'globalThis', {
+    get: function () {
+      delete Object.prototype.globalThis
+      return (this.globalThis = this)
+    },
+    configurable: true
+  })
+  return globalThis
+}
+/* eslint-enable */

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -2,7 +2,6 @@
 const test = require('tape')
 const fresh = require('import-fresh')
 const pinoStdSerializers = require('pino-std-serializers')
-const pinoSymbols = require('../lib/symbols')
 const pino = require('../browser')
 
 levelTest('fatal')
@@ -122,17 +121,6 @@ test('exposes faux stdSerializers', ({ end, ok, same }) => {
 test('exposes err stdSerializer', ({ end, ok }) => {
   ok(pino.stdSerializers.err)
   ok(pino.stdSerializers.err(Error()))
-  end()
-})
-
-test('exposes real symbols', ({ end, ok, same }) => {
-  ok(pino.symbols)
-  // confirm every symbol is present
-  for (let symbol in pinoSymbols) {
-    ok(pino.symbols[symbol], `pino.symbols.${symbol}`)
-  }
-  // confirm real symbols are used
-  same(pino.symbols, pinoSymbols)
   end()
 })
 


### PR DESCRIPTION
fixes #647 and #649 

NOTE: MERGE and RELEASE https://github.com/pinojs/hapi-pino/pull/79  *FIRST*

In #612 we added symbols to browser pino. 

This is breaking backward compatibility, and rather than add additional bytes for a polyfill to the payload overhead that was already added by including all symbols I think we should remove the symbols from the browser as they were only included for a "very niche use case" in #612.

We can instead update hapi-pino to use Symbol.for since the serializers symbol is a global symbol.

This also includes the smallest possible polyfill for `globalThis` for a standard-compliant cross platform global, see https://github.com/pinojs/pino/issues/649#issuecomment-491525080

