### PR TITLE
readme: the log object is on the request object

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -22,7 +22,7 @@ const fastify = require('fastify')({
   logger: true
 })
 fastify.get('/', async (request, reply) => {
-  reply.log.info('something')
+  request.log.info('something')
   return { hello: 'world' }
 })
 ```


### PR DESCRIPTION
According to the documentation — the `log` object is on the `reply` object; apparently it's on the `request` one instead.