### PR TITLE
Add pretty write stream creator

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -21,6 +21,7 @@
   * [logger.version](#version)
   * [logger.LOG_VERSION](#log_version)
 * [Statics](#statics)
+  * [pino.createPrettyWriteStream()](#pino-createprettywritestream)
   * [pino.destination()](#pino-destination)
   * [pino.extreme()](#pino-extreme)
   * [pino.final()](#pino-final)
@@ -655,6 +656,21 @@ Also available on the exported `pino` function.
 * See [`pino.LOG_VERSION`](#pino-LOG_VERSION)
 
 ## Statics
+
+<a id="pino-createprettywritestream"></a>
+### `pino.createPrettyWriteStream({ [prettifier], [dest] }) => WriteStream`
+
+Create a writestream with a prettifier applied to it. This can then be used with  [`pino-multi-stream` ⇗](https://github.com/pinojs/pino-multi-stream)
+module.
+
+```js
+const pino = require('pino')
+const stream = pino.createPrettyWriteStream()
+```
+
+The options object may additionally contain a `prettifier` property to define which prettifier module to use. When not present, `prettifier` defaults to [`pino-pretty` ⇗](https://github.com/pinojs/pino-pretty) (must be installed as a separate dependency).
+
+The method may be passed a write destination, which defaults to `process.stdout`.
 
 <a id="pino-destination"></a>
 ### `pino.destination([target]) => SonicBoom`

--- a/pino.js
+++ b/pino.js
@@ -11,7 +11,8 @@ const {
   asChindings,
   final,
   stringify,
-  buildSafeSonicBoom
+  buildSafeSonicBoom,
+  getPrettyStream
 } = require('./lib/tools')
 const { version, LOG_VERSION } = require('./lib/meta')
 const {
@@ -120,6 +121,10 @@ function pino (...args) {
 
 pino.extreme = (dest = process.stdout.fd) => buildSafeSonicBoom(dest, 4096, false)
 pino.destination = (dest = process.stdout.fd) => buildSafeSonicBoom(dest, 0, true)
+pino.createPrettyWriteStream = (...args) => {
+  const { prettifier, dest = process.stdout } = args
+  return getPrettyStream({}, prettifier, dest)
+}
 
 pino.final = final
 pino.levels = mappings()

--- a/pino.js
+++ b/pino.js
@@ -121,7 +121,7 @@ function pino (...args) {
 
 pino.extreme = (dest = process.stdout.fd) => buildSafeSonicBoom(dest, 4096, false)
 pino.destination = (dest = process.stdout.fd) => buildSafeSonicBoom(dest, 0, true)
-pino.createPrettyWriteStream = (...args) => {
+pino.createPrettyWriteStream = (args = {}) => {
   const { prettifier, dest = process.stdout } = args
   return getPrettyStream({}, prettifier, dest)
 }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -516,6 +516,11 @@ test('auto pino.destination with a string as second argument', async ({ same }) 
   })
 })
 
+test('creates pretty write stream', async ({ is }) => {
+  const prettyStream = pino.createPrettyWriteStream()
+  is(typeof prettyStream.write, 'function')
+})
+
 test('does not override opts with a string as second argument', async ({ same }) => {
   const tmp = join(
     os.tmpdir(),

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,4 +1,5 @@
 'use strict'
+
 const os = require('os')
 const { join } = require('path')
 const { readFileSync } = require('fs')
@@ -514,11 +515,6 @@ test('auto pino.destination with a string as second argument', async ({ same }) 
     msg: 'hello',
     v: 1
   })
-})
-
-test('creates pretty write stream', async ({ is }) => {
-  const prettyStream = pino.createPrettyWriteStream()
-  is(typeof prettyStream.write, 'function')
 })
 
 test('does not override opts with a string as second argument', async ({ same }) => {

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -260,3 +260,37 @@ test('works as expected with an object with the msg prop', async ({ isNot }) => 
   await once(child, 'close')
   isNot(actual.match(/\(123456 on abcdefghijklmnopqr\): hello/), null)
 })
+
+test('creates pretty write stream', async ({ is }) => {
+  const prettyStream = pino.createPrettyWriteStream()
+  is(typeof prettyStream.write, 'function')
+})
+
+test('creates pretty write stream with default pino-pretty', async ({ is }) => {
+  const dest = new Writable({
+    objectMode: true,
+    write (formatted, enc) {
+      is(/^.*INFO.*foo\n$/.test(formatted), true)
+    }
+  })
+  const prettyStream = pino.createPrettyWriteStream({ dest })
+  const log = pino({}, prettyStream)
+  log.info('foo')
+})
+
+test('creates pretty write stream with custom prettifier', async ({ is }) => {
+  const prettifier = function () {
+    return function () {
+      return 'FOO bar'
+    }
+  }
+  const dest = new Writable({
+    objectMode: true,
+    write (formatted, enc) {
+      is(formatted, 'FOO bar')
+    }
+  })
+  const prettyStream = pino.createPrettyWriteStream({ prettifier, dest })
+  const log = pino({}, prettyStream)
+  log.info('foo')
+})


### PR DESCRIPTION
Makes it easier to create a pretty-print stream.

This will prevent ugly client code to get a separate pretty print stream using pino-multi-stream.

See PR pinojs/pino-multi-stream#20 and issue pinojs/pino#534