### PR TITLE
docs(api): remove Lambda note in pino-destination

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -254,7 +254,6 @@ const fileLogger = require('pino')('/log/path')
 However, there are some special instances where `pino.destination` is not used as the default:
 
 + When something, e.g a process manager, has monkey-patched `process.stdout.write`.
-+ When running on AWS Lambda.
 
 In these cases `process.stdout` is used instead.
 


### PR DESCRIPTION
In #566, the Lambda hack was removed. Seems this was missed from the
docs. AFAICT, the [Lambda reference][1] in `pino-extreme` is still
relevant.

[1]: https://github.com/pinojs/pino/blob/43d398800fc8b0de189ccd9b11bc2afdb28524d9/docs/api.md#pinoextremetarget--sonicboom