### PR TITLE
fix(deps): pino-pretty should be an optional peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,13 @@
     "pino-std-serializers": "^2.3.0",
     "quick-format-unescaped": "^3.0.2",
     "sonic-boom": "^0.7.5"
+  },
+  "peerDependencies": {
+    "pino-pretty": "^2.4.0"
+  },
+  "peerDependenciesMeta": {
+    "pino-pretty": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
This fixes https://github.com/pnpm/pnpm/issues/1791

pnpm, yarn and npm (from v6.11) are not printing warnings if optional peers are not found.