### PR TITLE
fix(serializers): properly transfer Symbol based serializers

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -72,11 +72,17 @@ function child (bindings) {
   const instance = Object.create(this)
   if (bindings.hasOwnProperty('serializers') === true) {
     instance[serializersSym] = Object.create(null)
-    for (var k of [...Object.getOwnPropertySymbols(serializers), ...Object.keys(serializers)]) {
+    for (var k in serializers) {
       instance[serializersSym][k] = serializers[k]
     }
-    for (var bk of [...Object.getOwnPropertySymbols(bindings.serializers), ...Object.keys(bindings.serializers)]) {
+    for (var ks of Object.getOwnPropertySymbols(serializers)) {
+      instance[serializersSym][ks] = serializers[ks]
+    }
+    for (var bk in bindings.serializers) {
       instance[serializersSym][bk] = bindings.serializers[bk]
+    }
+    for (var bks of Object.getOwnPropertySymbols(bindings.serializers)) {
+      instance[serializersSym][bks] = bindings.serializers[bks]
     }
   } else instance[serializersSym] = serializers
   if (bindings.hasOwnProperty('customLevels') === true) {

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -72,10 +72,10 @@ function child (bindings) {
   const instance = Object.create(this)
   if (bindings.hasOwnProperty('serializers') === true) {
     instance[serializersSym] = Object.create(null)
-    for (var k in serializers) {
+    for (var k of [...Object.getOwnPropertySymbols(serializers), ...Object.keys(serializers)]) {
       instance[serializersSym][k] = serializers[k]
     }
-    for (var bk in bindings.serializers) {
+    for (var bk of [...Object.getOwnPropertySymbols(bindings.serializers), ...Object.keys(bindings.serializers)]) {
       instance[serializersSym][bk] = bindings.serializers[bk]
     }
   } else instance[serializersSym] = serializers

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -72,16 +72,22 @@ function child (bindings) {
   const instance = Object.create(this)
   if (bindings.hasOwnProperty('serializers') === true) {
     instance[serializersSym] = Object.create(null)
+
     for (var k in serializers) {
       instance[serializersSym][k] = serializers[k]
     }
-    for (var ks of Object.getOwnPropertySymbols(serializers)) {
+    const parentSymbols = Object.getOwnPropertySymbols(serializers)
+    for (var i = 0; i < parentSymbols.length; i++) {
+      const ks = parentSymbols[i]
       instance[serializersSym][ks] = serializers[ks]
     }
+
     for (var bk in bindings.serializers) {
       instance[serializersSym][bk] = bindings.serializers[bk]
     }
-    for (var bks of Object.getOwnPropertySymbols(bindings.serializers)) {
+    const bindingsSymbols = Object.getOwnPropertySymbols(bindings.serializers)
+    for (var bi = 0; bi < bindingsSymbols.length; bi++) {
+      const bks = bindingsSymbols[bi]
       instance[serializersSym][bks] = bindings.serializers[bks]
     }
   } else instance[serializersSym] = serializers

--- a/test/serializers.test.js
+++ b/test/serializers.test.js
@@ -124,6 +124,30 @@ test('children inherit parent serializers', async ({ is }) => {
   is(o.test, 'parent')
 })
 
+test('children inherit parent Symbol serializers', async ({ is, isNot }) => {
+  const stream = sink()
+  const symbolSerializers = {
+    [Symbol.for('pino.*')]: parentSerializers.test
+  }
+  const parent = pino({ serializers: symbolSerializers }, stream)
+
+  is(parent[Symbol.for('pino.serializers')], symbolSerializers)
+
+  const child = parent.child({
+    serializers: {
+      a
+    }
+  })
+
+  function a () {
+    return 'hello'
+  }
+
+  isNot(child[Symbol.for('pino.serializers')], symbolSerializers)
+  is(child[Symbol.for('pino.serializers')].a, a)
+  is(child[Symbol.for('pino.serializers')][Symbol.for('pino.*')], parentSerializers.test)
+})
+
 test('children serializers get called', async ({ is }) => {
   const stream = sink()
   const parent = pino({

--- a/test/serializers.test.js
+++ b/test/serializers.test.js
@@ -135,6 +135,7 @@ test('children inherit parent Symbol serializers', async ({ is, isNot }) => {
 
   const child = parent.child({
     serializers: {
+      [Symbol.for('a')]: a,
       a
     }
   })
@@ -145,6 +146,7 @@ test('children inherit parent Symbol serializers', async ({ is, isNot }) => {
 
   isNot(child[Symbol.for('pino.serializers')], symbolSerializers)
   is(child[Symbol.for('pino.serializers')].a, a)
+  is(child[Symbol.for('pino.serializers')][Symbol.for('a')], a)
   is(child[Symbol.for('pino.serializers')][Symbol.for('pino.*')], parentSerializers.test)
 })
 


### PR DESCRIPTION
When adding serializers through `.child`, the Symbol based serializers were not transferred. For example: https://github.com/pinojs/pino/blob/master/docs/api.md#serializerssymbolforpino-function

Thanks to @ZwaarContrast for helping with debugging!