### PR TITLE
bump fast redact

### DIFF
--- a/lib/redaction.js
+++ b/lib/redaction.js
@@ -17,7 +17,7 @@ function redaction (opts, serialize) {
 
   const shape = paths.reduce((o, str) => {
     rx.lastIndex = 0
-    rx.exec(str)
+    const first = rx.exec(str)
     const next = rx.exec(str)
     // top level key:
     if (next === null) {
@@ -28,10 +28,11 @@ function redaction (opts, serialize) {
       return o
     }
     const { index } = next
-    const firstPosBracket = str[index - 1] === '['
-    const leadingChar = firstPosBracket ? '[' : ''
-    const nextPath = `${leadingChar}${str.substr(index, str.length - 1)}`
-    var ns = str.substr(0, index - 1).replace(/^\["(.+)"\]$/, '$1')
+    const nextPath = `${str.substr(index, str.length - 1)}`
+    var ns = first[1]
+      ? first[1].replace(/^(?:"|'|`)(.+)(?:"|'|`)$/, '$1')
+      : first[0]
+
     if (ns === '*') {
       ns = wildcardFirstSym
     }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "winston": "^3.2.1"
   },
   "dependencies": {
-    "fast-redact": "^1.4.4",
+    "fast-redact": "^2.0.0",
     "fast-safe-stringify": "^2.0.7",
     "flatstr": "^1.0.9",
     "pino-std-serializers": "^2.3.0",

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -606,22 +606,55 @@ test('redacts null at the top level', async ({ is }) => {
 
 test('supports bracket notation', async ({ is }) => {
   const stream = sink()
-  const instance = pino({ redact: ['a["b-b"]'] }, stream)
+  const instance = pino({ redact: ['a["b.b"]'] }, stream)
   const obj = {
-    a: { 'b-b': 'c' }
+    a: { 'b.b': 'c' }
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  is(o.a['b-b'], '[Redacted]')
+  is(o.a['b.b'], '[Redacted]')
 })
 
-test('supports leading bracket notation', async ({ is }) => {
+test('supports bracket notation with further nesting', async ({ is }) => {
   const stream = sink()
-  const instance = pino({ redact: ['["a-a"].b'] }, stream)
+  const instance = pino({ redact: ['a["b.b"].c'] }, stream)
   const obj = {
-    'a-a': { b: 'c' }
+    a: { 'b.b': { c: 'd' } }
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  is(o['a-a'].b, '[Redacted]')
+  is(o.a['b.b'].c, '[Redacted]')
+})
+
+test('supports leading bracket notation (single quote)', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: ['[\'a.a\'].b'] }, stream)
+  const obj = {
+    'a.a': { b: 'c' }
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o['a.a'].b, '[Redacted]')
+})
+
+test('supports leading bracket notation (double quote)', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: ['["a.a"].b'] }, stream)
+  const obj = {
+    'a.a': { b: 'c' }
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o['a.a'].b, '[Redacted]')
+})
+
+test('supports leading bracket notation (backtick quote)', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: ['[`a.a`].b'] }, stream)
+  const obj = {
+    'a.a': { b: 'c' }
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o['a.a'].b, '[Redacted]')
 })


### PR DESCRIPTION
bug fix for: https://github.com/davidmarkclements/fast-redact/issues/20

fast redact had to go v2 because calling `rx.exec` on fast redacts exported `rx` regular expression yields slightly different results which would cause breaking changes here if it was just published as a patch