### PR TITLE
Better describe `pino-pretty` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,5 +91,13 @@
     "pino-std-serializers": "^2.3.0",
     "quick-format-unescaped": "^3.0.2",
     "sonic-boom": "^0.7.5"
+  },
+  "peerDependencies": {
+    "pino-pretty": "^2.4.0"
+  },
+  "peerDependenciesMeta": {
+    "pino-pretty": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
`pino-pretty` is currently specified in `devDependencies` only, although it's required at run time . If I understand correctly, the aim is to not increase dependency footprint with `pino-pretty` when it tends to be used for development purposes only.

If my understanding is correct, then I think it makes sense that we specify `pino-pretty` as an optional peer dependency, allowing `pino-pretty` to be optionally provided - this may help with resolving `pino-pretty` when using pnpm (strict non-flat node_modules).