### PR TITLE
Handle formatting a Symbol

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "fast-safe-stringify": "^2.0.7",
     "flatstr": "^1.0.9",
     "pino-std-serializers": "^2.3.0",
-    "quick-format-unescaped": "^3.0.2",
+    "quick-format-unescaped": "^3.0.3",
     "sonic-boom": "^0.7.5"
   }
 }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -107,6 +107,19 @@ function levelTest (name, level) {
     check(is, result, level, 'hello 42')
   })
 
+  test(`formatting a symbol at level ${name}`, async ({ is }) => {
+    const stream = sink()
+    const instance = pino(stream)
+    instance.level = name
+
+    const sym = Symbol('foo')
+    instance[name]('hello', sym)
+
+    const result = await once(stream, 'data')
+
+    check(is, result, level, 'hello Symbol(foo)')
+  })
+
   test(`passing error with a serializer at level ${name}`, async ({ is, same }) => {
     const stream = sink()
     const err = new Error('myerror')


### PR DESCRIPTION
Bump up the minimum `quick-format-unescaped` version, and test passing a
Symbol as a format argument.

Fix #715.