### PR TITLE
Bind pino instance to prettifier

### DIFF
--- a/docs/pretty.md
+++ b/docs/pretty.md
@@ -23,13 +23,12 @@ The API requires modules provide a factory function which returns a prettifier
 function. This prettifier function must accept either a string of NDJSON or
 a Pino log object. A psuedo-example of such a prettifier is:
 
-Pino instance is passed as `this` into prettifier factory function. But it 
-not initialized yet, so if you need it you may pass it via closure to `prettifier`
-function.
+The uninitialized Pino instance is passed as `this` into prettifier factory function,
+so it can be accessed via closure by the returned prettifier function.
 
 ```js
 module.exports = function myPrettifier (options) {
-  // `this` is bind to pino instance (but not yet initialized).
+  // `this` is bound to the pino instance
   // Deal with whatever options are supplied.
   return function prettifier (inputData) {
     let logObject

--- a/docs/pretty.md
+++ b/docs/pretty.md
@@ -23,8 +23,13 @@ The API requires modules provide a factory function which returns a prettifier
 function. This prettifier function must accept either a string of NDJSON or
 a Pino log object. A psuedo-example of such a prettifier is:
 
+Pino instance is passed as `this` into prettifier factory function. But it 
+not initialized yet, so if you need it you may pass it via closure to `prettifier`
+function.
+
 ```js
 module.exports = function myPrettifier (options) {
+  // `this` is bind to pino instance (but not yet initialized).
   // Deal with whatever options are supplied.
   return function prettifier (inputData) {
     let logObject

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -153,7 +153,8 @@ function asChindings (instance, bindings) {
 
 function getPrettyStream (opts, prettifier, dest) {
   if (prettifier && typeof prettifier === 'function') {
-    return prettifierMetaWrapper(prettifier.call(this, opts), dest)
+    prettifier = prettifier.bind(this)
+    return prettifierMetaWrapper(prettifier(opts), dest)
   }
   try {
     var prettyFactory = require('pino-pretty')

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -153,7 +153,7 @@ function asChindings (instance, bindings) {
 
 function getPrettyStream (opts, prettifier, dest) {
   if (prettifier && typeof prettifier === 'function') {
-    return prettifierMetaWrapper(prettifier(opts), dest)
+    return prettifierMetaWrapper(prettifier.call(this, opts), dest)
   }
   try {
     var prettyFactory = require('pino-pretty')
@@ -294,7 +294,7 @@ function createArgsNormalizer (defaultOptions) {
     }
     if (prettyPrint) {
       const prettyOpts = Object.assign({ messageKey }, prettyPrint)
-      stream = getPrettyStream(prettyOpts, prettifier, stream)
+      stream = getPrettyStream.call(this, prettyOpts, prettifier, stream)
     }
     return { opts, stream }
   }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -151,9 +151,9 @@ function asChindings (instance, bindings) {
   return data
 }
 
-function getPrettyStream (opts, prettifier, dest) {
+function getPrettyStream (opts, prettifier, dest, instance) {
   if (prettifier && typeof prettifier === 'function') {
-    prettifier = prettifier.bind(this)
+    prettifier = prettifier.bind(instance)
     return prettifierMetaWrapper(prettifier(opts), dest)
   }
   try {
@@ -269,7 +269,7 @@ function buildSafeSonicBoom (dest, buffer = 0, sync = true) {
 }
 
 function createArgsNormalizer (defaultOptions) {
-  return function normalizeArgs (opts = {}, stream) {
+  return function normalizeArgs (instance, opts = {}, stream) {
     // support stream as a string
     if (typeof opts === 'string') {
       stream = buildSafeSonicBoom(opts)
@@ -295,7 +295,7 @@ function createArgsNormalizer (defaultOptions) {
     }
     if (prettyPrint) {
       const prettyOpts = Object.assign({ messageKey }, prettyPrint)
-      stream = getPrettyStream.call(this, prettyOpts, prettifier, stream)
+      stream = getPrettyStream(prettyOpts, prettifier, stream, instance)
     }
     return { opts, stream }
   }

--- a/pino.js
+++ b/pino.js
@@ -58,8 +58,8 @@ const normalize = createArgsNormalizer(defaultOptions)
 const serializers = Object.assign(Object.create(null), stdSerializers)
 
 function pino (...args) {
-  const instance = {};
-  const { opts, stream } = normalize.apply(instance, args);
+  const instance = {}
+  const { opts, stream } = normalize.apply(instance, args)
   const {
     redact,
     crlf,

--- a/pino.js
+++ b/pino.js
@@ -58,7 +58,8 @@ const normalize = createArgsNormalizer(defaultOptions)
 const serializers = Object.assign(Object.create(null), stdSerializers)
 
 function pino (...args) {
-  const { opts, stream } = normalize(...args)
+  const instance = {};
+  const { opts, stream } = normalize.apply(instance, args);
   const {
     redact,
     crlf,
@@ -96,7 +97,7 @@ function pino (...args) {
   assertDefaultLevelFound(level, customLevels, useOnlyCustomLevels)
   const levels = mappings(customLevels, useOnlyCustomLevels)
 
-  const instance = {
+  Object.assign(instance, {
     levels,
     [useLevelLabelsSym]: useLevelLabels,
     [changeLevelNameSym]: changeLevelName,
@@ -111,7 +112,7 @@ function pino (...args) {
     [messageKeySym]: messageKey,
     [serializersSym]: serializers,
     [chindingsSym]: chindings
-  }
+  })
   Object.setPrototypeOf(instance, proto)
 
   if (customLevels || useLevelLabels || changeLevelName !== defaultOptions.changeLevelName) genLsCache(instance)

--- a/pino.js
+++ b/pino.js
@@ -59,7 +59,7 @@ const serializers = Object.assign(Object.create(null), stdSerializers)
 
 function pino (...args) {
   const instance = {}
-  const { opts, stream } = normalize.apply(instance, args)
+  const { opts, stream } = normalize(instance, ...args)
   const {
     redact,
     crlf,

--- a/test/custom-levels.test.js
+++ b/test/custom-levels.test.js
@@ -265,3 +265,44 @@ test('custom level does not affect changeLevelName', async ({ is }) => {
   const { priority } = await once(stream, 'data')
   is(priority, 35)
 })
+
+test('custom levels accesible in prettifier function', async ({ plan, same }) => {
+  plan(1)
+  const logger = pino({
+    prettyPrint: true,
+    prettifier: function prettifierFactory () {
+      const instance = this
+      return function () {
+        same(instance.levels, {
+          labels: {
+            10: 'trace',
+            20: 'debug',
+            30: 'info',
+            35: 'foo',
+            40: 'warn',
+            45: 'bar',
+            50: 'error',
+            60: 'fatal'
+          },
+          values: {
+            trace: 10,
+            debug: 20,
+            info: 30,
+            warn: 40,
+            error: 50,
+            fatal: 60,
+            foo: 35,
+            bar: 45
+          }
+        })
+      }
+    },
+    customLevels: {
+      foo: 35,
+      bar: 45
+    },
+    changeLevelName: 'priority'
+  })
+
+  logger.foo('test')
+})


### PR DESCRIPTION
This PR passes pino instance to prettifier function.

It can be used to access configured levels, for example, here https://github.com/pinojs/pino-pretty/blob/master/lib/colors.js#L32 levels are hardcoded and if there are `customLevels` setup, then it will not work correctly.

Closes #720.

PS: I'm not a fan of `tap`, so tests might look not right.