### PR TITLE
Remove objError from asJson call

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -137,7 +137,7 @@ function write (_obj, msg, num) {
     }
   }
 
-  const s = this[asJsonSym](obj, num, t, objError)
+  const s = this[asJsonSym](obj, num, t)
 
   const stream = this[streamSym]
   if (stream[needsMetadataGsym] === true) {


### PR DESCRIPTION
The forth parameters `objError` is not necessary, since the `asJson (obj, num, time)` function signature only requires three params.

See https://github.com/pinojs/pino/blob/master/lib/tools.js#L71.