### PR TITLE
docs: clarify that pino can be accessed on both request and reply

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -15,7 +15,7 @@ web framework ecosystem.
 ## Pino with Fastify
 
 The Fastify web framework comes bundled with Pino by default, simply set Fastify's
-`logger` option to `true` and use `reply.log` for log messages that correspond
+`logger` option to `true` and use `request.log` or `reply.log` for log messages that correspond
 to each individual request:
 
 ```js


### PR DESCRIPTION
The text in the documentation says `reply.log` and the code uses `request.log`. Clarify that both can be used.