### PR TITLE
always sync flush fatal log messages

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -53,7 +53,7 @@ Default: `'info'`
 
 One of `'fatal'`, `'error'`, `'warn'`, `'info`', `'debug'`, `'trace'` or `'silent'`.
 
-Additional levels can be added to the instance via the `customLevels` option. 
+Additional levels can be added to the instance via the `customLevels` option.
 
 * See [`customLevels` option](#opt-customlevels)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -53,7 +53,7 @@ Default: `'info'`
 
 One of `'fatal'`, `'error'`, `'warn'`, `'info`', `'debug'`, `'trace'` or `'silent'`.
 
-Additional levels can be added to the instance via the `customLevels` option.
+Additional levels can be added to the instance via the `customLevels` option. 
 
 * See [`customLevels` option](#opt-customlevels)
 
@@ -433,6 +433,13 @@ Write a `'error'` level log, if the configured `level` allows for it.
 ### `logger.fatal([mergingObject], [message], [...interpolationValues])`
 
 Write a `'fatal'` level log, if the configured `level` allows for it.
+
+Since `'fatal'` level messages are intended to be logged just prior to the process exiting the `fatal`
+method will always sync flush the destination.
+Therefore it's important not to misuse `fatal` since
+it will cause performance overhead if used for any
+other purpose than writing final log messages before
+the process crashes or exits.
 
 * See [`mergingObject` log method parameter](#mergingobject)
 * See [`message` log method parameter](#message)

--- a/lib/levels.js
+++ b/lib/levels.js
@@ -1,6 +1,13 @@
 'use strict'
 const flatstr = require('flatstr')
-const { lsCacheSym, levelValSym, useLevelLabelsSym, changeLevelNameSym, useOnlyCustomLevelsSym } = require('./symbols')
+const {
+  lsCacheSym,
+  levelValSym,
+  useLevelLabelsSym,
+  changeLevelNameSym,
+  useOnlyCustomLevelsSym,
+  streamSym
+} = require('./symbols')
 const { noop, genLog } = require('./tools')
 
 const levels = {
@@ -11,9 +18,15 @@ const levels = {
   error: 50,
   fatal: 60
 }
-
+const logFatal = genLog(levels.fatal)
 const levelMethods = {
-  fatal: genLog(levels.fatal),
+  fatal (...args) {
+    const stream = this[streamSym]
+    logFatal.call(this, ...args)
+    if (typeof stream.flushSync === 'function') {
+      stream.flushSync()
+    }
+  },
   error: genLog(levels.error),
   warn: genLog(levels.warn),
   info: genLog(levels.info),

--- a/test/levels.test.js
+++ b/test/levels.test.js
@@ -402,3 +402,18 @@ test('passes when creating a default value that exists in logger levels', async 
     level: 30
   })
 })
+
+test('fatal method sync-flushes the destination if sync flushing is available', async ({ pass, doesNotThrow, plan }) => {
+  plan(2)
+  const stream = sink()
+  stream.flushSync = () => {
+    pass('destination flushed')
+  }
+  const instance = pino(stream)
+  instance.fatal('this is fatal')
+  await once(stream, 'data')
+  doesNotThrow(() => {
+    stream.flushSync = undefined
+    instance.fatal('this is fatal')
+  })
+})


### PR DESCRIPTION
it occurred to me today that if you ever write a fatal log, it's because the server is crashing or because you need to crash the server.

e.g.

```js
if (thisIsAnImpossibleSituation) {
  pino.fatal(`there's no where to go, we have to crash`)
  process.exit(1)
}
```

In this scenario, we *always* want to sync flush, and there's no legit scenarios where fatal would be used other than in a death spiral.
