### PR TITLE
fix(redaction): fix corner cases with paths

### DIFF
--- a/lib/redaction.js
+++ b/lib/redaction.js
@@ -19,28 +19,30 @@ function redaction (opts, serialize) {
     rx.lastIndex = 0
     const first = rx.exec(str)
     const next = rx.exec(str)
-    // top level key:
-    if (next === null) {
-      if (str === '*') {
-        str = wildcardFirstSym
-      }
-      o[str] = null
-      return o
-    }
-    const { index } = next
-    const nextPath = `${str.substr(index, str.length - 1)}`
-    var ns = first[1]
-      ? first[1].replace(/^(?:"|'|`)(.+)(?:"|'|`)$/, '$1')
+
+    // ns is the top-level path segment, brackets + quoting removed.
+    let ns = first[1] !== undefined
+      ? first[1].replace(/^(?:"|'|`)(.*)(?:"|'|`)$/, '$1')
       : first[0]
 
     if (ns === '*') {
       ns = wildcardFirstSym
     }
 
+    // top level key:
+    if (next === null) {
+      o[ns] = null
+      return o
+    }
+
+    // path with at least two segments:
     // if ns is already redacted at the top level, ignore lower level redactions
     if (o[ns] === null) {
       return o
     }
+
+    const { index } = next
+    const nextPath = `${str.substr(index, str.length - 1)}`
 
     o[ns] = o[ns] || []
 

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -626,6 +626,17 @@ test('supports bracket notation with further nesting', async ({ is }) => {
   is(o.a['b.b'].c, '[Redacted]')
 })
 
+test('supports bracket notation with empty string as path segment', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: ['a[""].c'] }, stream)
+  const obj = {
+    a: { '': { c: 'd' } }
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o.a[''].c, '[Redacted]')
+})
+
 test('supports leading bracket notation (single quote)', async ({ is }) => {
   const stream = sink()
   const instance = pino({ redact: ['[\'a.a\'].b'] }, stream)
@@ -657,4 +668,26 @@ test('supports leading bracket notation (backtick quote)', async ({ is }) => {
   instance.info(obj)
   const o = await once(stream, 'data')
   is(o['a.a'].b, '[Redacted]')
+})
+
+test('supports leading bracket notation (single-segment path)', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: ['[`a.a`]'] }, stream)
+  const obj = {
+    'a.a': { b: 'c' }
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o['a.a'], '[Redacted]')
+})
+
+test('supports leading bracket notation (single-segment path, wilcard)', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: ['[*]'] }, stream)
+  const obj = {
+    'a.a': { b: 'c' }
+  }
+  instance.info(obj)
+  const o = await once(stream, 'data')
+  is(o['a.a'], '[Redacted]')
 })


### PR DESCRIPTION
In particular, this supports single-item paths where the first item is bracketed (e.g. `{ redact: ["['some-key']"] }`) and paths where one of the segments is the empty string [in brackets] (e.g., `{ redact: ["a[''].x"] }`).

Conceptually, the change is quite simple: it uses the namespace rather, than the string, even for single-segment paths, since the namespace has the brackets + quotes removed. It also changes the namespace `.replace` regex to allow 0 character (i.e., `.*` instead of `.+`) between the quotes.