### PR TITLE
test(pretty): add failing test for serializers in children

### DIFF
--- a/test/fixtures/pretty/child-serializers.js
+++ b/test/fixtures/pretty/child-serializers.js
@@ -1,0 +1,18 @@
+global.process = { __proto__: process, pid: 123456 }
+Date.now = function () { return 1459875739796 }
+require('os').hostname = function () { return 'abcdefghijklmnopqr' }
+var pino = require(require.resolve('./../../../'))
+var log = pino({
+  prettyPrint: true,
+  serializers: {
+    foo (obj) {
+      if (obj.an !== 'object') {
+        throw new Error('kaboom')
+      }
+
+      return 'bar'
+    }
+  }
+})
+var child = log.child({ foo: { an: 'object' } })
+child.info('h')

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -131,6 +131,19 @@ test('applies serializers', async ({ is, isNot }) => {
   isNot(actual.match(/foo: "bar"/), null)
 })
 
+test('applies serializers once for children', async ({ is, isNot }) => {
+  var actual = ''
+  const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'pretty', 'child-serializers.js')])
+
+  child.stdout.pipe(writer((s, enc, cb) => {
+    actual += s
+    cb()
+  }))
+  await once(child, 'close')
+  isNot(actual.match(/\(123456 on abcdefghijklmnopqr\): h/), null)
+  isNot(actual.match(/foo: "bar"/), null)
+})
+
 test('applies redaction rules', async ({ is, isNot }) => {
   var actual = ''
   const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'pretty', 'redact.js')])


### PR DESCRIPTION
Hello,

I was recently trying to fix an issue with weird serialization in Pino + Fastify when I actually uncovered that it's an issue with the prettifying stream when developing. Not sure as to what was the intent here but the `prettifierMetaWrapper` in `tools.js` re-serializes every attributes (line 227), even though some of them were serialized by the child. Not sure how to fix this, removing those lines fix my use case but breaks the current tests as well. Let me know how I can help :)

Thanks for the great library!