### PR TITLE
CI : Add GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install
         run: npm i
-      - name: run
-        if: !startsWith(matrix.os, 'windows')
+      - name: run with coverage
+        if: (!startsWith(matrix.os, 'windows'))
         run: npm run ci
       # Windows just pass the test without checking the Coverage
       # Due to skipped tests
-      - name: run
+      - name: run without coverage
         if: startsWith(matrix.os, 'windows')
         run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,10 @@ jobs:
       - name: Install
         run: npm i
       - name: run
+        if: !startsWith(matrix.os, 'windows')
         run: npm run ci
+      # Windows just pass the test without checking the Coverage
+      # Due to skipped tests
+      - name: run
+        if: startsWith(matrix.os, 'windows')
+        run: npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04]
+        os: [macOS-10.14, windows-latest, ubuntu-latest]
         node-version: [6, 8, 10, 11, 12, 13]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-10.14, windows-latest, ubuntu-latest]
+        os: [macOS-latest, windows-latest, ubuntu-latest]
         node-version: [6, 8, 10, 11, 12, 13]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    name: ${{ matrix.node-version }} ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-16.04]
+        node-version: [6,8,10,11]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: run
+        run: npm run ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-16.04]
-        node-version: [6,8,10,11]
+        node-version: [6, 8, 10, 11]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-16.04]
-        node-version: [6, 8, 10, 11]
+        node-version: [6, 8, 10, 11, 12, 13]
     steps:
       - uses: actions/checkout@v1
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install
+        run: npm i
       - name: run
         run: npm run ci

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -84,7 +84,7 @@ test('http request support via serializer', async ({ ok, same, error, teardown }
   server.close()
 })
 
-test('http request support via serializer without request connection', async ({ ok, same, error, teardown }) => {
+test('http request support via serializer without request connection', async ({ ok, isLike, error, teardown }) => {
   var originalReq
   const instance = pino({
     serializers: {
@@ -93,7 +93,7 @@ test('http request support via serializer without request connection', async ({ 
   }, sink((chunk, enc) => {
     ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
     delete chunk.time
-    same(chunk, {
+    isLike(chunk, {
       pid: pid,
       hostname: hostname,
       level: 30,


### PR DESCRIPTION
Duration of the matrix build is around 2minutes.
Example : https://github.com/zekth/pino/commit/1bd66552bd64c78585c83596ad11829be3eae497/checks?check_suite_id=314800692

So i've simply moved everything to Github action CI. I see there is a secure env var in the `travis.yml` but the CI is not failing without it; is it not used anymore in the CI process? Otherwise we can use `Secrets` vars in the project setting : https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets

Also do i delete the `travis.yml` ?