### PR TITLE
CI : Github action improvement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,30 +20,19 @@ jobs:
       - name: Tests
         run: npm run test
   coverage:
-    name: coverage Node ${{ matrix.node-version }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        node-version: [6, 8, 10, 11, 12, 13]
+    name: coverage
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 12
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 12
       - name: Install
         run: npm i
       - name: run with coverage
         run: npm run cov-ci
-      - name: Coveralls Parallel
+      - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel: true
-      - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          parallel-finished: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install
         run: npm i
       - name: run with coverage
-        run: npm run ci
+        run: npm run cov-ci
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,33 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install
         run: npm i
-      - name: run with coverage
-        if: (!startsWith(matrix.os, 'windows'))
-        run: npm run ci
-      # Windows just pass the test without checking the Coverage
-      # Due to skipped tests
-      - name: run without coverage
-        if: startsWith(matrix.os, 'windows')
+      - name: Tests
         run: npm run test
+  coverage:
+    name: coverage Node ${{ matrix.node-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        node-version: [6, 8, 10, 11, 12, 13]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install
+        run: npm i
+      - name: run with coverage
+        run: npm run ci
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel-finished: true

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "browser-test": "airtap --local 8080 test/browser*test.js",
     "test": "standard | snazzy && cross-env NODE_OPTIONS=\"--no-warnings -r qodaa\" tap --no-esm -j 4 --no-cov test/*test.js",
     "ci": "standard | snazzy && cross-env TAP_TIMEOUT=480000 NODE_OPTIONS=\"--no-warnings -r qodaa\" tap --no-esm -j 4 --100 test/*test.js",
+    "cov-ci": "cross-env TAP_TIMEOUT=480000 NODE_OPTIONS=\"--no-warnings -r qodaa\" tap --no-esm -j 4 --100 --coverage-report=lcov test/*test.js",
     "cov-ui": "cross-env NODE_OPTIONS=\"--no-warnings -r qodaa\" tap --no-esm -j 4 --coverage-report=html test/*test.js",
     "bench": "node benchmarks/utils/runbench all",
     "bench-basic": "node benchmarks/utils/runbench basic",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -479,7 +479,7 @@ test('pino.destination', async ({ same }) => {
   )
   const instance = pino(pino.destination(tmp))
   instance.info('hello')
-  await sleep(250)
+  await sleep(300)
   const result = JSON.parse(readFileSync(tmp).toString())
   delete result.time
   same(result, {
@@ -498,7 +498,7 @@ test('auto pino.destination with a string', async ({ same }) => {
   )
   const instance = pino(tmp)
   instance.info('hello')
-  await sleep(250)
+  await sleep(300)
   const result = JSON.parse(readFileSync(tmp).toString())
   delete result.time
   same(result, {
@@ -517,7 +517,7 @@ test('auto pino.destination with a string as second argument', async ({ same }) 
   )
   const instance = pino(null, tmp)
   instance.info('hello')
-  await sleep(250)
+  await sleep(300)
   const result = JSON.parse(readFileSync(tmp).toString())
   delete result.time
   same(result, {
@@ -538,7 +538,7 @@ test('does not override opts with a string as second argument', async ({ same })
     timestamp: () => ',"time":"none"'
   }, tmp)
   instance.info('hello')
-  await sleep(250)
+  await sleep(300)
   const result = JSON.parse(readFileSync(tmp).toString())
   same(result, {
     pid: pid,


### PR DESCRIPTION
As discussed in https://github.com/pinojs/pino/pull/743#pullrequestreview-318291555 Adding the coverage job.

So it's on the same yml file because it's triggered by the same events: 
```yaml
on: [push, pull_request]
```
But it can be splitted. Also @jsumners in your example you do the matrix job but is it revelant to have it here? Because we want to test once the coverage and not the compatibility on each node version like in the `build` job. Do we keep it on only one node version like LTS ?

Note: Also increased the `sleep` in the `pino.destination` test because IO in the windows image seems to be slower and make the tests fail; with `300` it passes regularly.

Last run for ref : https://github.com/zekth/pino/commit/3aa8b0ff1a6110705638e3abeb786de44378da85/checks?check_suite_id=316635812