### PR TITLE
CI : Move from sleep to watch exists

### DIFF
--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -479,7 +479,7 @@ test('pino.destination', async ({ same }) => {
   )
   const instance = pino(pino.destination(tmp))
   instance.info('hello')
-  await sleep(300)
+  await sleep(500)
   const result = JSON.parse(readFileSync(tmp).toString())
   delete result.time
   same(result, {
@@ -498,7 +498,7 @@ test('auto pino.destination with a string', async ({ same }) => {
   )
   const instance = pino(tmp)
   instance.info('hello')
-  await sleep(300)
+  await sleep(500)
   const result = JSON.parse(readFileSync(tmp).toString())
   delete result.time
   same(result, {
@@ -517,7 +517,7 @@ test('auto pino.destination with a string as second argument', async ({ same }) 
   )
   const instance = pino(null, tmp)
   instance.info('hello')
-  await sleep(300)
+  await sleep(500)
   const result = JSON.parse(readFileSync(tmp).toString())
   delete result.time
   same(result, {
@@ -538,7 +538,7 @@ test('does not override opts with a string as second argument', async ({ same })
     timestamp: () => ',"time":"none"'
   }, tmp)
   instance.info('hello')
-  await sleep(300)
+  await sleep(500)
   const result = JSON.parse(readFileSync(tmp).toString())
   same(result, {
     pid: pid,

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -1,7 +1,7 @@
 'use strict'
 const os = require('os')
 const { join } = require('path')
-const { readFileSync, existsSync } = require('fs')
+const { readFileSync, existsSync, statSync } = require('fs')
 const { test } = require('tap')
 const { sink, check, once } = require('./helper')
 const pino = require('../')
@@ -11,12 +11,14 @@ const hostname = os.hostname()
 const watchFileCreated = (filename) => new Promise((resolve, reject) => {
   const TIMEOUT = 800
   const INTERVAL = 100
+  const threshold = TIMEOUT / INTERVAL
   let counter = 0
   const interval = setInterval(() => {
-    if (existsSync(filename)) {
+    // On some CI runs file is created but not filled
+    if (existsSync(filename) && statSync(filename).size !== 0) {
       clearInterval(interval)
       resolve()
-    } else if (counter <= TIMEOUT / INTERVAL) {
+    } else if (counter <= threshold) {
       counter++
     } else {
       clearInterval(interval)


### PR DESCRIPTION
As mentionned here https://github.com/pinojs/pino/pull/744#issuecomment-558634866

Windows CI seems a bit flaky on the IO. I've extended the sleep time for `pino.destination` tests.

Hope this time it will be stable on all the runs.