### PR TITLE
feat(bindings): allow setting of bindings

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -47,6 +47,7 @@ const prototype = {
   constructor,
   child,
   bindings,
+  setBindings,
   flush,
   isLevelEnabled,
   version,
@@ -111,6 +112,11 @@ function bindings () {
   delete bindingsFromJson.pid
   delete bindingsFromJson.hostname
   return bindingsFromJson
+}
+
+function setBindings (newBindings) {
+  const chindings = asChindings(this, newBindings)
+  this[chindingsSym] = chindings
 }
 
 function write (_obj, msg, num) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -69,6 +69,20 @@ test('set bindings on child instance', async ({ same }) => {
   same(child.bindings(), { name: 'basicTest', foo: 'bar' })
 })
 
+test('child should have bindings set by parent', async ({ same }) => {
+  const instance = pino({ name: 'basicTest', level: 'info' })
+  instance.setBindings({ foo: 'bar' })
+  const child = instance.child({})
+  same(child.bindings(), { name: 'basicTest', foo: 'bar' })
+})
+
+test('child should not share bindings of parent set after child creation', async ({ same }) => {
+  const instance = pino({ name: 'basicTest', level: 'info' })
+  const child = instance.child({})
+  instance.setBindings({ foo: 'bar' })
+  same(child.bindings(), { name: 'basicTest' })
+})
+
 function levelTest (name, level) {
   test(`${name} logs as ${level}`, async ({ is }) => {
     const stream = sink()

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -80,6 +80,7 @@ test('child should not share bindings of parent set after child creation', async
   const instance = pino({ name: 'basicTest', level: 'info' })
   const child = instance.child({})
   instance.setBindings({ foo: 'bar' })
+  same(instance.bindings(), { name: 'basicTest', foo: 'bar' })
   same(child.bindings(), { name: 'basicTest' })
 })
 

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -51,6 +51,24 @@ test('bindings contain the name and the child bindings', async ({ same }) => {
   same(instance.bindings(), { name: 'basicTest', foo: 'bar', a: 2 })
 })
 
+test('set bindings on instance', async ({ same }) => {
+  const instance = pino({ name: 'basicTest', level: 'info' })
+  instance.setBindings({ foo: 'bar' })
+  same(instance.bindings(), { name: 'basicTest', foo: 'bar' })
+})
+
+test('newly set bindings overwrite old bindings', async ({ same }) => {
+  const instance = pino({ name: 'basicTest', level: 'info', base: { foo: 'bar' } })
+  instance.setBindings({ foo: 'baz' })
+  same(instance.bindings(), { name: 'basicTest', foo: 'baz' })
+})
+
+test('set bindings on child instance', async ({ same }) => {
+  const child = pino({ name: 'basicTest', level: 'info' }).child({})
+  child.setBindings({ foo: 'bar' })
+  same(child.bindings(), { name: 'basicTest', foo: 'bar' })
+})
+
 function levelTest (name, level) {
   test(`${name} logs as ${level}`, async ({ is }) => {
     const stream = sink()


### PR DESCRIPTION
I'm in the process of replacing a node-bunyan logger, and pino fits perfectly. Only issue is that we have a use case for dynamically setting bindings. Let me know if this or something like it (or something completely different that gets the job done) would be a good fit for pino. Thanks!