### PR TITLE
fix(redaction): remove undefined entries for removed number and boolean values

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -105,8 +105,7 @@ function asJson (obj, num, time) {
         // this case explicity falls through to the next one
         case 'boolean':
           if (stringifier) value = stringifier(value)
-          data += ',"' + key + '":' + value
-          continue
+          break
         case 'string':
           value = (stringifier || asString)(value)
           break

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -240,11 +240,31 @@ test('redact.remove option – removes both key and value', async ({ is }) => {
   is('cookie' in req.headers, false)
 })
 
-test('redact.remove – top level key', async ({ is }) => {
+test('redact.remove – top level key - object value', async ({ is }) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['key'], remove: true } }, stream)
   instance.info({
     key: { redact: 'me' }
+  })
+  const o = await once(stream, 'data')
+  is('key' in o, false)
+})
+
+test('redact.remove – top level key - number value', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: { paths: ['key'], remove: true } }, stream)
+  instance.info({
+    key: 1
+  })
+  const o = await once(stream, 'data')
+  is('key' in o, false)
+})
+
+test('redact.remove – top level key - boolean value', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: { paths: ['key'], remove: true } }, stream)
+  instance.info({
+    key: false
   })
   const o = await once(stream, 'data')
   is('key' in o, false)


### PR DESCRIPTION
This fixes an issue where removing a number or boolean value at a top-level path results in an `undefined` value instead of fully removing the entry.

`hapi-pino` issue for context: https://github.com/pinojs/hapi-pino/issues/94

