### PR TITLE
Make log level methods return reasonable values for more succinct logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ This produces:
 {"level":30,"time":1531171082399,"msg":"hello child!","pid":657,"hostname":"Davids-MBP-3.fritz.box","a":"property","v":1}
 ```
 
+Also, the log level methods [return reasonable values](/docs/api.md#loggingmethodreturns):
+```js
+const logger = require('pino')()
+
+const hw = logger.info('hello world')
+// logs as above and hw is now 'hello world'
+
+if (hw === 'hello world') throw logger.error(new Error('BOOM'))
+// logs error then throws it
+```
+
 For using Pino with a web framework see:
 
 * [Pino with Fastify](docs/web.md#fastify)

--- a/benchmarks/basic.bench.js
+++ b/benchmarks/basic.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -44,49 +45,55 @@ const chill = winston.createLogger({
 const run = bench([
   function benchBunyan (cb) {
     for (var i = 0; i < max; i++) {
-      blog.info('hello world')
+      const msg = 'hello world'
+      blog.info(msg)
     }
     setImmediate(cb)
   },
   function benchWinston (cb) {
     for (var i = 0; i < max; i++) {
-      chill.log('info', 'hello world')
+      const msg = 'hello world'
+      chill.log('info', msg)
     }
     setImmediate(cb)
   },
   function benchBole (cb) {
     for (var i = 0; i < max; i++) {
-      bole.info('hello world')
+      const msg = 'hello world'
+      bole.info(msg)
     }
     setImmediate(cb)
   },
   function benchDebug (cb) {
     for (var i = 0; i < max; i++) {
-      dlog('hello world')
+      const msg = 'hello world'
+      dlog(msg)
     }
     setImmediate(cb)
   },
   function benchLogLevel (cb) {
     for (var i = 0; i < max; i++) {
-      loglevel.info('hello world')
+      const msg = 'hello world'
+      loglevel.info(msg)
     }
     setImmediate(cb)
   },
   function benchPino (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello world')
+      const msg = 'hello world'
+      plogDest.info(msg)
     }
     setImmediate(cb)
   },
   function benchPinoExtreme (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info('hello world')
+      const msg = plogExtreme.info('hello world')
     }
     setImmediate(cb)
   },
   function benchPinoNodeStream (cb) {
     for (var i = 0; i < max; i++) {
-      plogNodeStream.info('hello world')
+      const msg = plogNodeStream.info('hello world')
     }
     setImmediate(cb)
   }

--- a/benchmarks/child-child.bench.js
+++ b/benchmarks/child-child.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -25,25 +26,26 @@ const blog = bunyan.createLogger({
 const run = bench([
   function benchBunyanChildChild (cb) {
     for (var i = 0; i < max; i++) {
-      blog.info({ hello: 'world' })
+      const obj = { hello: 'world' }
+      blog.info(obj)
     }
     setImmediate(cb)
   },
   function benchPinoChildChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info({ hello: 'world' })
+      const obj = plogDest.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoExtremeChildChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info({ hello: 'world' })
+      const obj = plogExtreme.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoNodeStreamChildChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogNodeStream.info({ hello: 'world' })
+      const obj = plogNodeStream.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/child-creation.bench.js
+++ b/benchmarks/child-creation.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -29,35 +30,37 @@ const run = bench([
   function benchBunyanCreation (cb) {
     var child = blog.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
+      const obj = { hello: 'world' }
+      child.info(obj)
     }
     setImmediate(cb)
   },
   function benchBoleCreation (cb) {
     var child = bole('child')
     for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
+      const obj = { hello: 'world' }
+      child.info(obj)
     }
     setImmediate(cb)
   },
   function benchPinoCreation (cb) {
     var child = plogDest.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
+      const obj = child.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoExtremeCreation (cb) {
     var child = plogExtreme.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
+      const obj = child.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoNodeStreamCreation (cb) {
     var child = plogNodeStream.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
+      const obj = child.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/child.bench.js
+++ b/benchmarks/child.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -29,31 +30,33 @@ require('bole').output({
 const run = bench([
   function benchBunyanChild (cb) {
     for (var i = 0; i < max; i++) {
-      blog.info({ hello: 'world' })
+      const obj = { hello: 'world' }
+      blog.info(obj)
     }
     setImmediate(cb)
   },
   function benchBoleChild (cb) {
     for (var i = 0; i < max; i++) {
-      bole.info({ hello: 'world' })
+      const obj = { hello: 'world' }
+      bole.info(obj)
     }
     setImmediate(cb)
   },
   function benchPinoChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info({ hello: 'world' })
+      const obj = plogDest.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoExtremeChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info({ hello: 'world' })
+      const obj = plogExtreme.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoNodeStreamChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogNodeStream.info({ hello: 'world' })
+      const obj = plogNodeStream.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/deep-object.bench.js
+++ b/benchmarks/deep-object.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -67,19 +68,19 @@ const run = bench([
   },
   function benchPinoDeepObj (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info(deep)
+      const obj = plogDest.info(deep)
     }
     setImmediate(cb)
   },
   function benchPinoExtremeDeepObj (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info(deep)
+      const obj = plogExtreme.info(deep)
     }
     setImmediate(cb)
   },
   function benchPinoNodeStreamDeepObj (cb) {
     for (var i = 0; i < max; i++) {
-      plogNodeStream.info(deep)
+      const obj = plogNodeStream.info(deep)
     }
     setImmediate(cb)
   }

--- a/benchmarks/internal/custom-levels.js
+++ b/benchmarks/internal/custom-levels.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -18,38 +19,38 @@ const max = 100
 const run = bench([
   function benchPinoNoCustomLevel (cb) {
     for (var i = 0; i < max; i++) {
-      base.info({ hello: 'world' })
+      const obj = base.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoCustomLevel (cb) {
     for (var i = 0; i < max; i++) {
-      baseCl.foo({ hello: 'world' })
+      const obj = baseCl.foo({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchChildNoCustomLevel (cb) {
     for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
+      const obj = child.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoChildCustomLevel (cb) {
     for (var i = 0; i < max; i++) {
-      childCl.foo({ hello: 'world' })
+      const obj = childCl.foo({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoChildInheritedCustomLevel (cb) {
     for (var i = 0; i < max; i++) {
-      childOfBaseCl.foo({ hello: 'world' })
+      const obj = childOfBaseCl.foo({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoChildCreation (cb) {
     const child = base.child({})
     for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
+      const obj = child.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
@@ -58,7 +59,7 @@ const run = bench([
       customLevels: { foo: 31 }
     })
     for (var i = 0; i < max; i++) {
-      child.foo({ hello: 'world' })
+      const obj = child.foo({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/internal/just-pino-heavy.bench.js
+++ b/benchmarks/internal/just-pino-heavy.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -19,55 +20,55 @@ const max = 10
 const run = bench([
   function benchPinoLongString (cb) {
     for (var i = 0; i < max; i++) {
-      plog.info(longStr)
+      const s = plog.info(longStr)
     }
     setImmediate(cb)
   },
   function benchPinoDestLongString (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info(longStr)
+      const s = plogDest.info(longStr)
     }
     setImmediate(cb)
   },
   function benchPinoExtremeLongString (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info(longStr)
+      const s = plogExtreme.info(longStr)
     }
     setImmediate(cb)
   },
   function benchPinoDeepObj (cb) {
     for (var i = 0; i < max; i++) {
-      plog.info(deep)
+      const s = plog.info(deep)
     }
     setImmediate(cb)
   },
   function benchPinoDestDeepObj (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info(deep)
+      const s = plogDest.info(deep)
     }
     setImmediate(cb)
   },
   function benchPinoExtremeDeepObj (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info(deep)
+      const s = plogExtreme.info(deep)
     }
     setImmediate(cb)
   },
   function benchPinoInterpolateDeep (cb) {
     for (var i = 0; i < max; i++) {
-      plog.info('hello %j', deep)
+      const s = plog.info('hello %j', deep)
     }
     setImmediate(cb)
   },
   function benchPinoDestInterpolateDeep (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello %j', deep)
+      const s = plogDest.info('hello %j', deep)
     }
     setImmediate(cb)
   },
   function benchPinoExtremeInterpolateDeep (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info('hello %j', deep)
+      const s = plogExtreme.info('hello %j', deep)
     }
     setImmediate(cb)
   }

--- a/benchmarks/internal/just-pino.bench.js
+++ b/benchmarks/internal/just-pino.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -21,159 +22,159 @@ const max = 10
 const run = bench([
   function benchPino (cb) {
     for (var i = 0; i < max; i++) {
-      plog.info('hello world')
+      const s = plog.info('hello world')
     }
     setImmediate(cb)
   },
   function benchPinoDest (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello world')
+      const s = plogDest.info('hello world')
     }
     setImmediate(cb)
   },
   function benchPinoExtreme (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info('hello world')
+      const s = plogExtreme.info('hello world')
     }
     setImmediate(cb)
   },
   function benchPinoObj (cb) {
     for (var i = 0; i < max; i++) {
-      plog.info({ hello: 'world' })
+      const obj = plog.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoDestObj (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info({ hello: 'world' })
+      const obj = plogDest.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoExtremeObj (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info({ hello: 'world' })
+      const obj = plogExtreme.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogChild.info({ hello: 'world' })
+      const obj = plogChild.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoDestChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogDestChild.info({ hello: 'world' })
+      const obj = plogDestChild.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoExtremeChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtremeChild.info({ hello: 'world' })
+      const obj = plogExtremeChild.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoChildChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogChildChild.info({ hello: 'world' })
+      const obj = plogChildChild.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoDestChildChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogDestChildChild.info({ hello: 'world' })
+      const obj = plogDestChildChild.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoExtremeChildChild (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtremeChildChild.info({ hello: 'world' })
+      const obj = plogExtremeChildChild.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoChildCreation (cb) {
     var child = plog.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
+      const obj = child.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoDestChildCreation (cb) {
     var child = plogDest.child({ a: 'property' })
     for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
+      const obj = child.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoMulti (cb) {
     for (var i = 0; i < max; i++) {
-      plog.info('hello', 'world')
+      const s = plog.info('hello', 'world')
     }
     setImmediate(cb)
   },
   function benchPinoDestMulti (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello', 'world')
+      const s = plogDest.info('hello', 'world')
     }
     setImmediate(cb)
   },
   function benchPinoExtremeMulti (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info('hello', 'world')
+      const s = plogExtreme.info('hello', 'world')
     }
     setImmediate(cb)
   },
   function benchPinoInterpolate (cb) {
     for (var i = 0; i < max; i++) {
-      plog.info('hello %s', 'world')
+      const s = plog.info('hello %s', 'world')
     }
     setImmediate(cb)
   },
   function benchPinoDestInterpolate (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello %s', 'world')
+      const s = plogDest.info('hello %s', 'world')
     }
     setImmediate(cb)
   },
   function benchPinoDestInterpolate (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello %s', 'world')
+      const s = plogDest.info('hello %s', 'world')
     }
     setImmediate(cb)
   },
   function benchPinoInterpolateAll (cb) {
     for (var i = 0; i < max; i++) {
-      plog.info('hello %s %j %d', 'world', { obj: true }, 4)
+      const s = plog.info('hello %s %j %d', 'world', { obj: true }, 4)
     }
     setImmediate(cb)
   },
   function benchPinoDestInterpolateAll (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello %s %j %d', 'world', { obj: true }, 4)
+      const s = plogDest.info('hello %s %j %d', 'world', { obj: true }, 4)
     }
     setImmediate(cb)
   },
   function benchPinoExtremeInterpolateAll (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info('hello %s %j %d', 'world', { obj: true }, 4)
+      const s = plogExtreme.info('hello %s %j %d', 'world', { obj: true }, 4)
     }
     setImmediate(cb)
   },
   function benchPinoInterpolateExtra (cb) {
     for (var i = 0; i < max; i++) {
-      plog.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
+      const s = plog.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
     }
     setImmediate(cb)
   },
   function benchPinoDestInterpolateExtra (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
+      const s = plogDest.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
     }
     setImmediate(cb)
   },
   function benchPinoExtremeInterpolateExtra (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
+      const s = plogExtreme.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/internal/parent-vs-child.bench.js
+++ b/benchmarks/internal/parent-vs-child.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -18,55 +19,55 @@ const max = 100
 const run = bench([
   function benchPinoBase (cb) {
     for (var i = 0; i < max; i++) {
-      base.info({ hello: 'world' })
+      const obj = base.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoChild (cb) {
     for (var i = 0; i < max; i++) {
-      child.info({ hello: 'world' })
+      const obj = child.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoChildChild (cb) {
     for (var i = 0; i < max; i++) {
-      childChild.info({ hello: 'world' })
+      const obj = childChild.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoChildChildChild (cb) {
     for (var i = 0; i < max; i++) {
-      childChildChild.info({ hello: 'world' })
+      const obj = childChildChild.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoChildChildChildChild (cb) {
     for (var i = 0; i < max; i++) {
-      childChildChildChild.info({ hello: 'world' })
+      const obj = childChildChildChild.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoChild2 (cb) {
     for (var i = 0; i < max; i++) {
-      child2.info({ hello: 'world' })
+      const obj = child2.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoBaseSerilalizers (cb) {
     for (var i = 0; i < max; i++) {
-      baseSerializers.info({ hello: 'world' })
+      const obj = baseSerializers.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoBaseSerilalizersChild (cb) {
     for (var i = 0; i < max; i++) {
-      baseSerializersChild.info({ hello: 'world' })
+      const obj = baseSerializersChild.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoBaseSerilalizersChildSeriazliers (cb) {
     for (var i = 0; i < max; i++) {
-      baseSerializersChildSerializers.info({ hello: 'world' })
+      const obj = baseSerializersChildSerializers.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/benchmarks/internal/redact.bench.js
+++ b/benchmarks/internal/redact.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -35,49 +36,49 @@ const max = 10
 const run = bench([
   function benchPinoNoRedact (cb) {
     for (var i = 0; i < max; i++) {
-      plog.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
+      const obj = plog.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
     }
     setImmediate(cb)
   },
   function benchPinoRedact (cb) {
     for (var i = 0; i < max; i++) {
-      plogRedact.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
+      const obj = plogRedact.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
     }
     setImmediate(cb)
   },
   function benchPinoUnsafeNoRedact (cb) {
     for (var i = 0; i < max; i++) {
-      plogUnsafe.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
+      const obj = plogUnsafe.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
     }
     setImmediate(cb)
   },
   function benchPinoUnsafeRedact (cb) {
     for (var i = 0; i < max; i++) {
-      plogUnsafeRedact.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
+      const obj = plogUnsafeRedact.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
     }
     setImmediate(cb)
   },
   function benchPinoExtremeNoRedact (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
+      const obj = plogExtreme.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
     }
     setImmediate(cb)
   },
   function benchPinoExtremeRedact (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtremeRedact.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
+      const obj = plogExtremeRedact.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
     }
     setImmediate(cb)
   },
   function benchPinoUnsafeExtremeNoRedact (cb) {
     for (var i = 0; i < max; i++) {
-      plogUnsafeExtreme.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
+      const obj = plogUnsafeExtreme.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
     }
     setImmediate(cb)
   },
   function benchPinoUnsafeExtremeRedact (cb) {
     for (var i = 0; i < max; i++) {
-      plogUnsafeExtremeRedact.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
+      const obj = plogUnsafeExtremeRedact.info({ a: { b: { c: 'redact me.', d: 'leave me' } } })
     }
     setImmediate(cb)
   }

--- a/benchmarks/long-string.bench.js
+++ b/benchmarks/long-string.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -60,19 +61,19 @@ var run = bench([
   },
   function benchPino (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info(longStr)
+      const s = plogDest.info(longStr)
     }
     setImmediate(cb)
   },
   function benchPinoExtreme (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info(longStr)
+      const s = plogExtreme.info(longStr)
     }
     setImmediate(cb)
   },
   function benchPinoNodeStream (cb) {
     for (var i = 0; i < max; i++) {
-      plogNodeStream.info(longStr)
+      const s = plogNodeStream.info(longStr)
     }
     setImmediate(cb)
   }

--- a/benchmarks/multi-arg.bench.js
+++ b/benchmarks/multi-arg.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -51,49 +52,59 @@ const max = 10
 const run = bench([
   function benchBunyanMulti (cb) {
     for (var i = 0; i < max; i++) {
-      blog.info('hello', 'world')
+      const hello = 'hello'
+      const world = 'world'
+      blog.info(hello, world)
     }
     setImmediate(cb)
   },
   function benchWinstonMulti (cb) {
     for (var i = 0; i < max; i++) {
-      chill.log('info', 'hello', 'world')
+      const hello = 'hello'
+      const world = 'world'
+      chill.log('info', hello, world)
     }
     setImmediate(cb)
   },
   function benchBoleMulti (cb) {
     for (var i = 0; i < max; i++) {
-      bole.info('hello', 'world')
+      const hello = 'hello'
+      const world = 'world'
+      bole.info(hello, world)
     }
     setImmediate(cb)
   },
   function benchLogLevelMulti (cb) {
     for (var i = 0; i < max; i++) {
-      loglevel.info('hello', 'world')
+      const hello = 'hello'
+      const world = 'world'
+      loglevel.info(hello, world)
     }
     setImmediate(cb)
   },
   function benchDebugMulti (cb) {
     for (var i = 0; i < max; i++) {
-      dlog('hello', 'world')
+      const hello = 'hello'
+      const world = 'world'
+      dlog(hello, world)
     }
     setImmediate(cb)
   },
   function benchPinoMulti (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello', 'world')
+      const hw = plogDest.info('hello', 'world')
     }
     setImmediate(cb)
   },
   function benchPinoExtremeMulti (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info('hello', 'world')
+      const hw = plogExtreme.info('hello', 'world')
     }
     setImmediate(cb)
   },
   function benchPinoNodeStreamMulti (cb) {
     for (var i = 0; i < max; i++) {
-      plogNodeStream.info('hello', 'world')
+      const hw = plogNodeStream.info('hello', 'world')
     }
     setImmediate(cb)
   },
@@ -117,19 +128,19 @@ const run = bench([
   },
   function benchPinoInterpolate (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello %s', 'world')
+      const hw = plogDest.info('hello %s', 'world')
     }
     setImmediate(cb)
   },
   function benchPinoExtremeInterpolate (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info('hello %s', 'world')
+      const hw = plogExtreme.info('hello %s', 'world')
     }
     setImmediate(cb)
   },
   function benchPinoNodeStreamInterpolate (cb) {
     for (var i = 0; i < max; i++) {
-      plogNodeStream.info('hello %s', 'world')
+      const hw = plogNodeStream.info('hello %s', 'world')
     }
     setImmediate(cb)
   },
@@ -154,19 +165,19 @@ const run = bench([
   },
   function benchPinoInterpolateAll (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello %s %j %d', 'world', { obj: true }, 4)
+      const all = plogDest.info('hello %s %j %d', 'world', { obj: true }, 4)
     }
     setImmediate(cb)
   },
   function benchPinoExtremeInterpolateAll (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info('hello %s %j %d', 'world', { obj: true }, 4)
+      const all = plogExtreme.info('hello %s %j %d', 'world', { obj: true }, 4)
     }
     setImmediate(cb)
   },
   function benchPinoNodeStreamInterpolateAll (cb) {
     for (var i = 0; i < max; i++) {
-      plogNodeStream.info('hello %s %j %d', 'world', { obj: true }, 4)
+      const all = plogNodeStream.info('hello %s %j %d', 'world', { obj: true }, 4)
     }
     setImmediate(cb)
   },
@@ -190,19 +201,19 @@ const run = bench([
   },
   function benchPinoInterpolateExtra (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
+      const extra = plogDest.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
     }
     setImmediate(cb)
   },
   function benchPinoExtremeInterpolateExtra (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
+      const extra = plogExtreme.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
     }
     setImmediate(cb)
   },
   function benchPinoNodeStreamInterpolateExtra (cb) {
     for (var i = 0; i < max; i++) {
-      plogNodeStream.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
+      const extra = plogNodeStream.info('hello %s %j %d', 'world', { obj: true }, 4, { another: 'obj' })
     }
     setImmediate(cb)
   },
@@ -226,19 +237,19 @@ const run = bench([
   },
   function benchPinoInterpolateDeep (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info('hello %j', deep)
+      const interp = plogDest.info('hello %j', deep)
     }
     setImmediate(cb)
   },
   function benchPinoExtremeInterpolateDeep (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info('hello %j', deep)
+      const interp = plogExtreme.info('hello %j', deep)
     }
     setImmediate(cb)
   },
   function benchPinoNodeStreamInterpolateDeep (cb) {
     for (var i = 0; i < max; i++) {
-      plogNodeStream.info('hello %j', deep)
+      const interp = plogNodeStream.info('hello %j', deep)
     }
     setImmediate(cb)
   }

--- a/benchmarks/object.bench.js
+++ b/benchmarks/object.bench.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 'use strict'
 
 const bench = require('fastbench')
@@ -37,43 +38,47 @@ const max = 10
 const run = bench([
   function benchBunyanObj (cb) {
     for (var i = 0; i < max; i++) {
-      blog.info({ hello: 'world' })
+      const obj = { hello: 'world' }
+      blog.info(obj)
     }
     setImmediate(cb)
   },
   function benchWinstonObj (cb) {
     for (var i = 0; i < max; i++) {
-      chill.info({ hello: 'world' })
+      const obj = { hello: 'world' }
+      chill.info(obj)
     }
     setImmediate(cb)
   },
   function benchBoleObj (cb) {
     for (var i = 0; i < max; i++) {
-      bole.info({ hello: 'world' })
+      const obj = { hello: 'world' }
+      bole.info(obj)
     }
     setImmediate(cb)
   },
   function benchLogLevelObject (cb) {
     for (var i = 0; i < max; i++) {
-      loglevel.info({ hello: 'world' })
+      const obj = { hello: 'world' }
+      loglevel.info(obj)
     }
     setImmediate(cb)
   },
   function benchPinoObj (cb) {
     for (var i = 0; i < max; i++) {
-      plogDest.info({ hello: 'world' })
+      const obj = plogDest.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoExtremeObj (cb) {
     for (var i = 0; i < max; i++) {
-      plogExtreme.info({ hello: 'world' })
+      const obj = plogExtreme.info({ hello: 'world' })
     }
     setImmediate(cb)
   },
   function benchPinoNodeStreamObj (cb) {
     for (var i = 0; i < max; i++) {
-      plogNodeStream.info({ hello: 'world' })
+      const obj = plogNodeStream.info({ hello: 'world' })
     }
     setImmediate(cb)
   }

--- a/docs/api.md
+++ b/docs/api.md
@@ -335,18 +335,9 @@ The parameters are explained below using the `logger.info` method but the same a
 
 ### Logging Method Parameters
 
-<a id=mergingobject></a>
-#### `mergingObject` (Object)
+<a id=loggingmethodreturns></a>
 
-An object can optionally be supplied as the first parameter. Each enumerable key and value
-of the `mergingObject` is copied in to the JSON log line.
-
-```js
-logger.info({MIX: {IN: true}})
-// {"level":30,"time":1531254555820,"pid":55956,"hostname":"x","MIX":{"IN":true},"v":1}
-```
-
-If the `mergingObject` is a non-null object and is not a formatting string, it is returned, allowing for more succinct inline logging:
+The logging level methods return reasonable values, allowing for more succinct logging:
 ```js
 const s = logger.info('some string')
 // {"level":30,"time":1531254555820,"pid":55956,"hostname":"x","msg":"some string","v":1}
@@ -367,6 +358,17 @@ const foobar = logger.info('foo', 'bar')
 throw new logger.error(new Error('BOOM'))
 // {"level":50,"time":1578350985467,"pid":83246,"hostname":"x","msg":"BOOM","stack":"...","type":"Error","v":1}
 // and the error is thrown
+```
+
+<a id=mergingobject></a>
+#### `mergingObject` (Object)
+
+An object can optionally be supplied as the first parameter. Each enumerable key and value
+of the `mergingObject` is copied in to the JSON log line.
+
+```js
+logger.info({MIX: {IN: true}})
+// {"level":30,"time":1531254555820,"pid":55956,"hostname":"x","MIX":{"IN":true},"v":1}
 ```
 
 <a id=message></a>

--- a/docs/api.md
+++ b/docs/api.md
@@ -346,6 +346,29 @@ logger.info({MIX: {IN: true}})
 // {"level":30,"time":1531254555820,"pid":55956,"hostname":"x","MIX":{"IN":true},"v":1}
 ```
 
+If the `mergingObject` is a non-null object and is not a formatting string, it is returned, allowing for more succinct inline logging:
+```js
+const s = logger.info('some string')
+// {"level":30,"time":1531254555820,"pid":55956,"hostname":"x","msg":"some string","v":1}
+// and s === 'some string'
+
+const obj = logger.info({my: 'object'}, 'not returned')
+// {"level":30,"time":1578352370038,"pid":84486,"hostname":"x","my":"object","msg":"not returned","v":1}
+// and obj === {my: 'object'}
+
+const foobar42 = logger.info('foobar %d', 42)
+// {"level":30,"time":1578351238980,"pid":83246,"hostname":"x","msg":"foobar {\"foo\":\"bar\"}","v":1}
+// and foobar42 === 'foobar 42'
+
+const foobar = logger.info('foo', 'bar')
+// {"level":30,"time":1578351238980,"pid":83246,"hostname":"x","msg":"foobar {\"foo\":\"bar\"}","v":1}
+// and foobar === 'foo bar'
+
+throw new logger.error(new Error('BOOM'))
+// {"level":50,"time":1578350985467,"pid":83246,"hostname":"x","msg":"BOOM","stack":"...","type":"Error","v":1}
+// and the error is thrown
+```
+
 <a id=message></a>
 #### `message` (String)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -332,12 +332,15 @@ Each logging method has the following signature:
 `([mergingObject], [message], [...interpolationValues])`.
 
 The parameters are explained below using the `logger.info` method but the same applies to all logging methods.
-
+  
 ### Logging Method Parameters
 
 <a id=loggingmethodreturns></a>
 
-The logging level methods return reasonable values, allowing for more succinct logging:
+The logging level methods return reasonable values, allowing for more succinct logging.
+More precisely, if `typeof` the first argument is `object` and it's non-`null`,
+it returns that object, else it returns the first string argument,
+unless there are multiple arguments, in which case it returns the interpolated string:
 ```js
 const s = logger.info('some string')
 // {"level":30,"time":1531254555820,"pid":55956,"hostname":"x","msg":"some string","v":1}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,58 +1,55 @@
+
 # Benchmarks
 
 `pino.info('hello world')`:
 
 ```
+
 BASIC benchmark averages
-Bunyan average: 549.042ms
-Winston average: 467.873ms
-Bole average: 201.529ms
-Debug average: 253.724ms
-LogLevel average: 282.653ms
-Pino average: 188.956ms
-PinoExtreme average: 108.809ms
+Bunyan average: 466.070ms
+Winston average: 428.970ms
+Bole average: 169.615ms
+Debug average: 207.668ms
+LogLevel average: 229.964ms
+Pino average: 384.526ms
+PinoExtreme average: 185.094ms
+PinoNodeStream average: 156.762ms
+
 ```
 
 `pino.info({'hello': 'world'})`:
 
 ```
+
 OBJECT benchmark averages
-BunyanObj average: 564.363ms
-WinstonObj average: 464.824ms
-BoleObj average: 230.220ms
-LogLevelObject average: 474.857ms
-PinoObj average: 201.442ms
-PinoUnsafeObj average: 202.687ms
-PinoExtremeObj average: 108.689ms
-PinoUnsafeExtremeObj average: 106.718ms
+BunyanObj average: 465.168ms
+WinstonObj average: 371.508ms
+BoleObj average: 190.275ms
+LogLevelObject average: 415.969ms
+PinoObj average: 406.029ms
+PinoExtremeObj average: 199.252ms
+PinoNodeStreamObj average: 182.846ms
+
 ```
 
 `pino.info(aBigDeeplyNestedObject)`:
 
 ```
-DEEPOBJECT benchmark averages
-BunyanDeepObj average: 5293.279ms
-WinstonDeepObj average: 9020.292ms
-BoleDeepObj average: 9169.043ms
-LogLevelDeepObj average: 15260.917ms
-PinoDeepObj average: 8467.807ms
-PinoUnsafeDeepObj average: 6159.227ms
-PinoExtremeDeepObj average: 8354.557ms
-PinoUnsafeExtremeDeepObj average: 6214.073ms
+
+DEEP-OBJECT benchmark averages
+BunyanDeepObj average: 1805.163ms
+WinstonDeepObj average: 1967.332ms
+BoleDeepObj average: 2206.577ms
+LogLevelDeepObj average: 6083.014ms
+PinoDeepObj average: 2805.583ms
+PinoExtremeDeepObj average: 2244.956ms
+PinoNodeStreamDeepObj average: 2290.287ms
+
 ```
 
 `pino.info('hello %s %j %d', 'world', {obj: true}, 4, {another: 'obj'})`:
 
-```
-BunyanInterpolateExtra average: 778.408ms
-WinstonInterpolateExtra average: 627.956ms
-BoleInterpolateExtra average: 429.757ms
-PinoInterpolateExtra average: 316.043ms
-PinoUnsafeInterpolateExtra average: 316.809ms
-PinoExtremeInterpolateExtra average: 218.468ms
-PinoUnsafeExtremeInterpolateExtra average: 215.040ms
-```
-
 For a fair comparison, [LogLevel](http://npm.im/loglevel) was extended
 to include a timestamp and [bole](http://npm.im/bole) had
 `fastTime` mode switched on.
+

--- a/lib/levels.js
+++ b/lib/levels.js
@@ -22,7 +22,7 @@ const logFatal = genLog(levels.fatal)
 const levelMethods = {
   fatal (...args) {
     const stream = this[streamSym]
-    logFatal.call(this, ...args)
+    const rv = logFatal.call(this, ...args)
     if (typeof stream.flushSync === 'function') {
       try {
         stream.flushSync()
@@ -30,6 +30,7 @@ const levelMethods = {
         // https://github.com/pinojs/pino/pull/740#discussion_r346788313
       }
     }
+    return rv
   },
   error: genLog(levels.error),
   warn: genLog(levels.warn),

--- a/lib/levels.js
+++ b/lib/levels.js
@@ -22,7 +22,7 @@ const logFatal = genLog(levels.fatal)
 const levelMethods = {
   fatal (...args) {
     const stream = this[streamSym]
-    const rv = logFatal.call(this, ...args)
+    const value = logFatal.call(this, ...args)
     if (typeof stream.flushSync === 'function') {
       try {
         stream.flushSync()
@@ -30,7 +30,7 @@ const levelMethods = {
         // https://github.com/pinojs/pino/pull/740#discussion_r346788313
       }
     }
-    return rv
+    return value
   },
   error: genLog(levels.error),
   warn: genLog(levels.warn),

--- a/lib/levels.js
+++ b/lib/levels.js
@@ -8,7 +8,7 @@ const {
   useOnlyCustomLevelsSym,
   streamSym
 } = require('./symbols')
-const { noop, genLog } = require('./tools')
+const { nowrite, genLog } = require('./tools')
 
 const levels = {
   trace: 10,
@@ -91,7 +91,7 @@ function setLevel (level) {
 
   for (var key in values) {
     if (levelVal > values[key]) {
-      this[key] = noop
+      this[key] = nowrite
       continue
     }
     this[key] = isStandardLevel(key, useOnlyCustomLevelsVal) ? levelMethods[key] : genLog(values[key])

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -25,6 +25,13 @@ const {
 
 function noop () {}
 
+function nowrite (o, ...n) {
+  if (typeof o === 'object' && o !== null) return o
+
+  const f = format(o, n, this[formatOptsSym])
+  return o === null ? null : f
+}
+
 function genLog (z) {
   return function LOG (o, ...n) {
     if (typeof o === 'object' && o !== null) {
@@ -358,6 +365,7 @@ function stringify (obj) {
 
 module.exports = {
   noop,
+  nowrite,
   buildSafeSonicBoom,
   getPrettyStream,
   asChindings,

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -28,13 +28,19 @@ function noop () {}
 function genLog (z) {
   return function LOG (o, ...n) {
     if (typeof o === 'object' && o !== null) {
+      const orig = o
       if (o.method && o.headers && o.socket) {
         o = mapHttpRequest(o)
       } else if (typeof o.setHeader === 'function') {
         o = mapHttpResponse(o)
       }
       this[writeSym](o, format(null, n, this[formatOptsSym]), z)
-    } else this[writeSym](null, format(o, n, this[formatOptsSym]), z)
+      return orig
+    }
+
+    const f = format(o, n, this[formatOptsSym])
+    this[writeSym](null, f, z)
+    return o === null ? null : f
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pino",
-  "version": "5.15.0",
+  "version": "5.16.0",
   "description": "super fast, all natural json logger",
   "main": "pino.js",
   "browser": "./browser.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pino",
-  "version": "5.16.0",
+  "version": "5.15.0",
   "description": "super fast, all natural json logger",
   "main": "pino.js",
   "browser": "./browser.js",

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -2,7 +2,7 @@
 const os = require('os')
 const { join } = require('path')
 const { readFileSync, existsSync, statSync } = require('fs')
-const { test, equal, only } = require('tap')
+const { test, equal } = require('tap')
 const { sink, check, once } = require('./helper')
 const pino = require('../')
 const { version } = require('../package.json')
@@ -232,7 +232,7 @@ function levelTest (name, level) {
     })
   })
 
-  only(`child logger for level ${name}`, async ({ is, same }) => {
+  test(`child logger for level ${name}`, async ({ is, same }) => {
     const stream = sink()
     const instance = pino(stream)
     instance.level = name

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -719,3 +719,14 @@ test('correctly log NaN', async (t) => {
   const { num } = await once(stream, 'data')
   t.is(num, null)
 })
+
+test('return a value when called level less than configured level', async ({ same }) => {
+  const stream = sink()
+  const instance = pino({
+    level: 'warn'
+  }, stream)
+
+  const obj = { hello: 'world' }
+  const value = instance.debug(obj)
+  same(value, obj)
+})

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -2,7 +2,7 @@
 const os = require('os')
 const { join } = require('path')
 const { readFileSync, existsSync, statSync } = require('fs')
-const { test, equal } = require('tap')
+const { test } = require('tap')
 const { sink, check, once } = require('./helper')
 const pino = require('../')
 const { version } = require('../package.json')
@@ -90,7 +90,7 @@ function levelTest (name, level) {
     const instance = pino(stream)
     instance.level = name
     const m = 'hello world'
-    equal(instance[name](m), m)
+    is(instance[name](m), m)
     check(is, await once(stream, 'data'), level, m)
   })
 
@@ -100,7 +100,7 @@ function levelTest (name, level) {
     instance.level = name
     const m = null
     const result = instance[name](m) === m
-    equal(result, true)
+    is(result, true)
   })
 
   test(`${name} logs undefined as ${level}`, async ({ is }) => {
@@ -109,7 +109,7 @@ function levelTest (name, level) {
     instance.level = name
     const m = undefined
     const result = instance[name](m) === m
-    equal(result, true)
+    is(result, true)
   })
 
   test(`passing objects at level ${name}`, async ({ is, same }) => {
@@ -117,7 +117,7 @@ function levelTest (name, level) {
     const instance = pino(stream)
     instance.level = name
     const obj = { hello: 'world' }
-    equal(instance[name](obj), obj)
+    is(instance[name](obj), obj)
 
     const result = await once(stream, 'data')
     is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
@@ -134,7 +134,7 @@ function levelTest (name, level) {
     const instance = pino(stream)
     instance.level = name
     const obj = { hello: 'world' }
-    equal(instance[name](obj, 'a string'), obj)
+    is(instance[name](obj, 'a string'), obj)
     const result = await once(stream, 'data')
     is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
     delete result.time
@@ -154,7 +154,7 @@ function levelTest (name, level) {
     const instance = pino(stream)
     instance.level = name
     const obj = { hello: 'world', msg: 'object' }
-    equal(instance[name](obj, 'string'), obj)
+    is(instance[name](obj, 'string'), obj)
     const result = await once(stream, 'data')
     is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
     delete result.time
@@ -173,7 +173,7 @@ function levelTest (name, level) {
     const instance = pino(stream)
     instance.level = name
     const msg = 'hello 42'
-    equal(instance[name]('hello %d', 42), msg)
+    is(instance[name]('hello %d', 42), msg)
     const result = await once(stream, 'data')
     check(is, result, level, msg)
   })
@@ -185,7 +185,7 @@ function levelTest (name, level) {
     const hello = 'hello'
     const world = 'world'
     const helloWorld = `${hello} ${world}`
-    equal(instance[name](hello, world), helloWorld)
+    is(instance[name](hello, world), helloWorld)
     const result = await once(stream, 'data')
     check(is, result, level, helloWorld)
   })
@@ -198,7 +198,7 @@ function levelTest (name, level) {
     const sym = Symbol('foo')
     const msg = 'hello'
     const expected = `${msg} ${sym.toString()}`
-    equal(instance[name](msg, sym), expected)
+    is(instance[name](msg, sym), expected)
 
     const result = await once(stream, 'data')
 
@@ -215,7 +215,7 @@ function levelTest (name, level) {
     }, stream)
     instance.level = name
     const obj = { err }
-    equal(instance[name](obj), obj)
+    is(instance[name](obj), obj)
     const result = await once(stream, 'data')
     is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
     delete result.time
@@ -240,7 +240,7 @@ function levelTest (name, level) {
     const obj = { hello: world }
     const child = instance.child(obj)
     const helloWorld = 'hello world'
-    equal(child[name](helloWorld), helloWorld)
+    is(child[name](helloWorld), helloWorld)
     const result = await once(stream, 'data')
     is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
     delete result.time

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -730,3 +730,25 @@ test('return a value when called level less than configured level', async ({ sam
   const value = instance.debug(obj)
   same(value, obj)
 })
+
+test('return interpolated value when called level less than configured level', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({
+    level: 'warn'
+  }, stream)
+
+  const fmt = 'hello %s'
+  const world = 'world'
+  const value = instance.debug(fmt, world)
+  is(value, 'hello world')
+})
+
+test('return null value when called level less than configured level', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({
+    level: 'warn'
+  }, stream)
+
+  const value = instance.debug(null)
+  is(value, null)
+})


### PR DESCRIPTION
The log level methods should return reasonable values to make logging statements less intrusive.  Instead of the old way,
```js
const hw = 'hello world'
logger.info(hw)
```
this PR allows you to write
```js
const hw = logger.info('hello world')
```
It's especially nice when throwing.  Instead of
```js
const e = new Error('BOOM')
logger.error(e)
throw e
```
this PR allows you to write
```js
throw logger.error(new Error('BOOM'))
```
See the changes in `/docs/api.md` in particular for the description of the reasonable behavior.