### PR TITLE
Fix two broken links in the documentation

### DIFF
--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -93,7 +93,7 @@ This will output
 {"level":30,"time":1527782356751,"pid":5758,"hostname":"Davids-MacBook-Pro-3.local","path":{"to":{"another":"thing"}},"stuff":{"thats":[{"logme":"will be logged"},{"logme":"as will this"}]},"v":1}
 ```
 
-See [pino options in API](api.md#pino) for `redact` API details.
+See [pino options in API](/docs/api.md#redact-array-object) for `redact` API details.
 
 <a name="paths"></a>
 ## Path Syntax

--- a/docs/web.md
+++ b/docs/web.md
@@ -29,7 +29,7 @@ fastify.get('/', async (request, reply) => {
 ```
 
 The `logger` option can also be set to an object, which will be passed through directly
-as the [`pino` options object](api.md#options).
+as the [`pino` options object](/docs/api.md#options-object).
 
 See the [fastify documentation](https://www.fastify.io/docs/latest/Logging/) for more information.
 


### PR DESCRIPTION
These two links currently result in 404 pages: see #689 
I'm not familiar with how to generate the documentation for local testing of the links, but I think I've got the syntax right, based on other currently working links.