### PR TITLE
Fixed stream metadata loss during prettification

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -173,12 +173,24 @@ function prettifierMetaWrapper (pretty, dest) {
     lastMsg: null,
     lastObj: null,
     lastLogger: null,
+    get destStreamContext () {
+      if (dest[needsMetadataGsym] === true) {
+        return Object.assign(dest, {
+          lastLevel: this.lastLevel,
+          lastMsg: this.lastMsg,
+          lastObj: this.lastObj,
+          lastTime: this.lastTime,
+          lastLogger: this.lastLogger
+        })
+      }
+      return dest
+    },
     flushSync () {
       if (warned) {
         return
       }
       warned = true
-      dest.write(pretty(Object.assign({
+      dest.write.call(this.destStreamContext, pretty(Object.assign({
         level: 40, // warn
         msg: 'pino.final with prettyPrint does not support flushing',
         time: Date.now()
@@ -237,7 +249,8 @@ function prettifierMetaWrapper (pretty, dest) {
 
       const formatted = pretty(typeof redact === 'function' ? redact(obj) : obj)
       if (formatted === undefined) return
-      dest.write(formatted)
+
+      dest.write.call(this.destStreamContext, formatted)
     }
   }
 }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -173,22 +173,13 @@ function prettifierMetaWrapper (pretty, dest) {
     lastMsg: null,
     lastObj: null,
     lastLogger: null,
-    get destStreamContext () {
-      if (dest[needsMetadataGsym] === true) {
-        dest.lastLevel = this.lastLevel
-        dest.lastMsg = this.lastMsg
-        dest.lastObj = this.lastObj
-        dest.lastTime = this.lastTime
-        dest.lastLogger = this.lastLogger
-      }
-      return dest
-    },
     flushSync () {
       if (warned) {
         return
       }
       warned = true
-      dest.write.call(this.destStreamContext, pretty(Object.assign({
+      setMetadataProps(dest, this)
+      dest.write(pretty(Object.assign({
         level: 40, // warn
         msg: 'pino.final with prettyPrint does not support flushing',
         time: Date.now()
@@ -248,7 +239,8 @@ function prettifierMetaWrapper (pretty, dest) {
       const formatted = pretty(typeof redact === 'function' ? redact(obj) : obj)
       if (formatted === undefined) return
 
-      dest.write.call(this.destStreamContext, formatted)
+      setMetadataProps(dest, this)
+      dest.write(formatted)
     }
   }
 }
@@ -359,6 +351,16 @@ function stringify (obj) {
     return JSON.stringify(obj)
   } catch (_) {
     return stringifySafe(obj)
+  }
+}
+
+function setMetadataProps (dest, that) {
+  if (dest[needsMetadataGsym] === true) {
+    dest.lastLevel = that.lastLevel
+    dest.lastMsg = that.lastMsg
+    dest.lastObj = that.lastObj
+    dest.lastTime = that.lastTime
+    dest.lastLogger = that.lastLogger
   }
 }
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -175,13 +175,11 @@ function prettifierMetaWrapper (pretty, dest) {
     lastLogger: null,
     get destStreamContext () {
       if (dest[needsMetadataGsym] === true) {
-        return Object.assign(dest, {
-          lastLevel: this.lastLevel,
-          lastMsg: this.lastMsg,
-          lastObj: this.lastObj,
-          lastTime: this.lastTime,
-          lastLogger: this.lastLogger
-        })
+        dest.lastLevel = this.lastLevel
+        dest.lastMsg = this.lastMsg
+        dest.lastObj = this.lastObj
+        dest.lastTime = this.lastTime
+        dest.lastLogger = this.lastLogger
       }
       return dest
     },

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -272,3 +272,41 @@ test('works as expected with an object with the msg prop', async ({ isNot }) => 
   await once(child, 'close')
   isNot(actual.match(/\(123456 on abcdefghijklmnopqr\): hello/), null)
 })
+
+test('should not lose stream metadata for streams with `needsMetadataGsym` flag', async ({ isNot }) => {
+  const dest = new Writable({
+    objectMode: true,
+    write () {
+      isNot(typeof this.lastLevel === 'undefined', true)
+      isNot(typeof this.lastMsg === 'undefined', true)
+      isNot(typeof this.lastObj === 'undefined', true)
+      isNot(typeof this.lastTime === 'undefined', true)
+      isNot(typeof this.lastLogger === 'undefined', true)
+    }
+  })
+
+  dest[pino.symbols.needsMetadataGsym] = true
+
+  const log = pino({
+    prettyPrint: true
+  }, dest)
+  log.info('foo')
+})
+
+test('should not add stream metadata for streams without `needsMetadataGsym` flag', async ({ is }) => {
+  const dest = new Writable({
+    objectMode: true,
+    write () {
+      is(typeof this.lastLevel === 'undefined', true)
+      is(typeof this.lastMsg === 'undefined', true)
+      is(typeof this.lastObj === 'undefined', true)
+      is(typeof this.lastTime === 'undefined', true)
+      is(typeof this.lastLogger === 'undefined', true)
+    }
+  })
+
+  const log = pino({
+    prettyPrint: true
+  }, dest)
+  log.info('foo')
+})


### PR DESCRIPTION
For streams with Symbol('metadata') true flag, pino metadata was lost during prettification.

RE: https://github.com/pinojs/pino-multi-stream/issues/31