### PR TITLE
Add GitHub action to benchmark PRs

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,47 @@
+name: Benchmarks
+on:
+  - push
+  - pull_request
+
+jobs:
+  benchmark_current:
+    name: benchmark current
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install Modules
+        run: npm i
+      - name: Run Benchmark
+        run: npm run bench | tee current.txt
+      - name: Upload Current Results
+        uses: actions/upload-artifact@v1
+        with:
+          name: current
+          path: current.txt
+
+  benchmark_branch:
+    name: benchmark branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install Modules
+        run: npm i
+      - name: Run Benchmark
+        run: npm run bench | tee branch.txt
+      - name: Upload Branch Results
+        uses: actions/upload-artifact@v1
+        with:
+          name: branch
+          path: branch.txt


### PR DESCRIPTION
This adds a GitHub action that will run our benchmark suite against the incoming PR's code and the branch that PR targets. The results will be uploaded as artifacts on the action results. These artifacts are kept around by GH for a period of 40 days. We should also be able to review the action logs to see the result after that time.