### PR TITLE
Require 100% code coverage. Remove coveralls.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on: [push, pull_request]
 jobs:
-  build:
+  test:
     name: ${{ matrix.node-version }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -10,7 +10,7 @@ jobs:
         os: [macOS-latest, windows-latest, ubuntu-latest]
         node-version: [10, 12, 13]
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -18,21 +18,4 @@ jobs:
       - name: Install
         run: npm i
       - name: Tests
-        run: npm run test
-  coverage:
-    name: coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Use Node.js 12
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - name: Install
-        run: npm i
-      - name: run with coverage
-        run: npm run cov-ci
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        run: npm test

--- a/.taprc
+++ b/.taprc
@@ -1,4 +1,5 @@
 esm: false
 ts: false
 jsx: false
+coverage: true
 timeout: 480

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ There are a few basic ground-rules for contributors:
 1. **External API changes and significant modifications** ought to be subject to an **internal pull-request** to solicit feedback from other contributors.
 1. Internal pull-requests to solicit feedback are *encouraged* for any other non-trivial contribution but left to the discretion of the contributor.
 1. Contributors should attempt to adhere to the prevailing code-style.
+1. 100% code coverage
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 # pino
 [![Build Status](https://img.shields.io/github/workflow/status/pinojs/pino/CI)](https://github.com/pinojs/pino/actions)
-&nbsp;[![Coverage Status](https://img.shields.io/coveralls/github/pinojs/pino)](https://coveralls.io/github/pinojs/pino?branch=master)
 &nbsp;[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
 &nbsp;[![TypeScript definitions on DefinitelyTyped](https://img.shields.io/badge/DefinitelyTyped-.d.ts-brightgreen.svg?style=flat)](https://definitelytyped.org)
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
   "scripts": {
     "docs": "docsify serve",
     "browser-test": "airtap --local 8080 test/browser*test.js",
-    "test": "standard | snazzy && tap --no-cov test/*test.js",
-    "ci": "standard | snazzy && tap --100 test/*test.js",
-    "cov-ci": "tap --100 --coverage-report=lcov test/*test.js",
+    "test": "standard | snazzy && tap --100 test/*test.js",
     "cov-ui": "tap --coverage-report=html test/*test.js",
     "bench": "node benchmarks/utils/runbench all",
     "bench-basic": "node benchmarks/utils/runbench basic",

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -7,14 +7,7 @@ const execa = require('execa')
 const writer = require('flush-write-stream')
 const { once } = require('./helper')
 const pino = require('../')
-const tap = require('tap')
 const strip = require('strip-ansi')
-
-const isWin = process.platform === 'win32'
-if (isWin) {
-  tap.comment('Skipping pretty printing tests on Windows as colour codes are different and tests fail')
-  process.exit(0)
-}
 
 test('can be enabled via exported pino function', async ({ isNot }) => {
   var actual = ''


### PR DESCRIPTION
Coveralls is flaky from time to time, and we don't really need to track coverage anymore. It's 100%.
This simplifies our build quite a bit.