### PR TITLE
Remove implicit appending of objects to message strings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -448,9 +448,8 @@ then be interpolated accordingly.
 #### `...interpolationValues` (Any)
 
 All arguments supplied after `message` are serialized and interpolated according
-to any supplied printf-style placeholders (`%s`, `%d`, `%o`|`%O`|`%j`)
-or else concatenated together with the `message` string to form the final
-output `msg` value for the JSON log line.
+to any supplied printf-style placeholders (`%s`, `%d`, `%o`|`%O`|`%j`) to form
+the final output `msg` value for the JSON log line.
 
 ```js
 logger.info('hello', 'world')

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -30,6 +30,7 @@ function noop () {}
 function genLog (z) {
   return function LOG (o, ...n) {
     if (typeof o === 'object') {
+      var msg = o
       if (o !== null) {
         if (o.method && o.headers && o.socket) {
           o = mapHttpRequest(o)
@@ -38,8 +39,14 @@ function genLog (z) {
         }
       }
       if (this[nestedKeySym]) o = { [this[nestedKeySym]]: o }
-      const formatParams = (o === null && n.length === 0) ? [null] : n
-      this[writeSym](o, format(null, formatParams, this[formatOptsSym]), z)
+      var formatParams
+      if (msg === null && n.length === 0) {
+        formatParams = [null]
+      } else {
+        msg = n.shift()
+        formatParams = n
+      }
+      this[writeSym](o, format(msg, formatParams, this[formatOptsSym]), z)
     } else {
       this[writeSym](null, format(o, n, this[formatOptsSym]), z)
     }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "fast-safe-stringify": "^2.0.7",
     "flatstr": "^1.0.12",
     "pino-std-serializers": "^2.4.2",
-    "quick-format-unescaped": "^3.0.3",
+    "quick-format-unescaped": "^4.0.1",
     "sonic-boom": "^1.0.0"
   }
 }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -160,7 +160,7 @@ function levelTest (name, level) {
     instance.level = name
 
     const sym = Symbol('foo')
-    instance[name]('hello', sym)
+    instance[name]('hello %s', sym)
 
     const result = await once(stream, 'data')
 
@@ -628,7 +628,7 @@ test('fast-safe-stringify must be used when interpolating', async (t) => {
 
   const o = { a: { b: {} } }
   o.a.b.c = o.a.b
-  instance.info('test', o)
+  instance.info('test %j', o)
 
   const { msg } = await once(stream, 'data')
   t.is(msg, 'test {"a":{"b":{"c":"[Circular]"}}}')

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -191,7 +191,7 @@ test('opts.browser.write func string joining', ({ end, ok, is }) => {
       }
     }
   })
-  instance.info('test', 'test2', 'test3')
+  instance.info('test %s %s', 'test2', 'test3')
 
   end()
 })
@@ -207,7 +207,7 @@ test('opts.browser.write func string joining when asObject is true', ({ end, ok,
       }
     }
   })
-  instance.info('test', 'test2', 'test3')
+  instance.info('test %s %s', 'test2', 'test3')
 
   end()
 })
@@ -223,7 +223,7 @@ test('opts.browser.write func string joining when asObject is true', ({ end, ok,
       }
     }
   })
-  instance.info('test', 'test2', 'test3')
+  instance.info('test %s %s', 'test2', 'test3')
 
   end()
 })
@@ -238,7 +238,7 @@ test('opts.browser.write func string object joining', ({ end, ok, is }) => {
       }
     }
   })
-  instance.info('test', { test: 'test2' }, { test: 'test3' })
+  instance.info('test %j %j', { test: 'test2' }, { test: 'test3' })
 
   end()
 })
@@ -254,7 +254,7 @@ test('opts.browser.write func string object joining when asObject is true', ({ e
       }
     }
   })
-  instance.info('test', { test: 'test2' }, { test: 'test3' })
+  instance.info('test %j %j', { test: 'test2' }, { test: 'test3' })
 
   end()
 })

--- a/test/fixtures/pretty/error.js
+++ b/test/fixtures/pretty/error.js
@@ -4,4 +4,4 @@ require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 var pino = require(require.resolve('./../../../'))
 var log = pino({ prettyPrint: true })
 log.error(new Error('kaboom'))
-log.error(new Error('kaboom'), 'with', 'a', 'message')
+log.error(new Error('kaboom'), 'with a message')

--- a/test/levels.test.js
+++ b/test/levels.test.js
@@ -456,7 +456,7 @@ test('log null value when message is null', async ({ is }) => {
   check(is, result, expected.level, expected.msg)
 })
 
-test('concatenate multiple params when base param is null', async ({ is }) => {
+test('formats when base param is null', async ({ is }) => {
   const expected = {
     msg: 'a string',
     level: 30
@@ -465,7 +465,7 @@ test('concatenate multiple params when base param is null', async ({ is }) => {
   const stream = sink()
   const instance = pino(stream)
   instance.level = 'info'
-  instance.info(null, 'a', 'string')
+  instance.info(null, 'a %s', 'string')
 
   const result = await once(stream, 'data')
   check(is, result, expected.level, expected.msg)

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -116,7 +116,7 @@ test('redact option – interpolated object', async ({ is }) => {
   const stream = sink()
   const instance = pino({ redact: ['req.headers.cookie'] }, stream)
 
-  instance.info('test', {
+  instance.info('test %j', {
     req: {
       id: 7915,
       method: 'GET',
@@ -180,7 +180,7 @@ test('redact.paths option – interpolated object', async ({ is }) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'] } }, stream)
 
-  instance.info('test', {
+  instance.info('test %j', {
     req: {
       id: 7915,
       method: 'GET',


### PR DESCRIPTION
This fixes issue #793. 

We will need to add a major call to notice for this in the release notes for v6. Something like:

> **Implicit formatting removed**
> Previously, Pino emulated Bunyan's behavior when interpreting logs like:
> 1. `log.info('a message', { an: 'object'})`
> 1. `log.info('a', 'silly', 'message')`
>
> The old behavior would result in 1 yielding `"msg":"a message {\"an\":\"object\"}"` and 2 yielding
> `"msg":"a silly message"`. As of this release, 1 will yield `"msg":"a message"` and 2 will yield `"msg":"a"`.
>
> To get the same results in Pino v6 as in previous releases actual format identifiers should be provided, e.g.:
> 1. `log.info('a message %j', { an: 'object' })`
> 1. `log.info('a %s %s', 'silly', 'message')`