### PR TITLE
V6 clean ups

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -84,6 +84,7 @@ PR's to this document are welcome for any new transports!
 + [pino-syslog](#pino-syslog)
 + [pino-websocket](#pino-websocket)
 + [pino-http-send](#pino-http-send)
++ [pino-pg](#pino-pg)
 
 <a id="pino-applicationinsights"></a>
 ### pino-applicationinsights
@@ -385,3 +386,8 @@ transport that will batch logs and send to a specified URL.
 ```console
 $ node app.js | pino-http-send -u http://localhost:8080/logs
 ```
+
+<a id="pino-pg"></a>
+### pino-pg
+[pino-pg](https://www.npmjs.com/package/pino-pg) stores logs into PostgreSQL.
+Full documentation in the [readme](https://github.com/Xstoudi/pino-pg).

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -74,17 +74,20 @@ PR's to this document are welcome for any new transports!
 + [pino-couch](#pino-couch)
 + [pino-datadog](#pino-datadog)
 + [pino-elasticsearch](#pino-elasticsearch)
++ [pino-http-send](#pino-http-send)
++ [pino-logflare](#pino-logflare)
 + [pino-mq](#pino-mq)
 + [pino-mysql](#pino-mysql)
 + [pino-papertrail](#pino-papertrail)
++ [pino-pg](#pino-pg)
 + [pino-redis](#pino-redis)
 + [pino-sentry](#pino-sentry)
 + [pino-socket](#pino-socket)
 + [pino-stackdriver](#pino-stackdriver)
 + [pino-syslog](#pino-syslog)
 + [pino-websocket](#pino-websocket)
-+ [pino-http-send](#pino-http-send)
-+ [pino-pg](#pino-pg)
+
+
 
 <a id="pino-applicationinsights"></a>
 ### pino-applicationinsights
@@ -183,6 +186,25 @@ Then [create an index pattern](https://www.elastic.co/guide/en/kibana/current/se
 [elasticsearch]: https://www.elastic.co/products/elasticsearch
 [kibana]: https://www.elastic.co/products/kibana
 
+<a id="pino-http-send"></a>
+### pino-http-send
+
+[pino-http-send](https://npmjs.com/package/pino-http-send) is a configurable and low overhead
+transport that will batch logs and send to a specified URL.
+
+```console
+$ node app.js | pino-http-send -u http://localhost:8080/logs
+```
+
+<a id="pino-logflare"></a>
+### pino-logflare
+
+[pino-logflare](https://github.com/Logflare/pino-logflare) transport to send logs to a [Logflare](https://logflare.app) `source`.
+
+```sh
+$ node index.js | pino-logflare --key YOUR_KEY --source YOUR_SOURCE
+```
+
 <a id="pino-mq"></a>
 ### pino-mq
 
@@ -224,6 +246,11 @@ node yourapp.js | pino-papertrail --host bar.papertrailapp.com --port 12345 --ap
 
 
 for full documentation of command line switches read [readme](https://github.com/ovhemert/pino-papertrail#readme)
+
+<a id="pino-pg"></a>
+### pino-pg
+[pino-pg](https://www.npmjs.com/package/pino-pg) stores logs into PostgreSQL.
+Full documentation in the [readme](https://github.com/Xstoudi/pino-pg).
 
 <a id="pino-mysql"></a>
 ### pino-mysql
@@ -376,18 +403,3 @@ $ node app.js | pino-websocket -a my-websocket-server.example.com -p 3004
 ```
 
 For full documentation of command line switches read [readme](https://github.com/abeai/pino-webscoket#README)
-
-<a id="pino-http-send"></a>
-### pino-http-send
-
-[pino-http-send](https://npmjs.com/package/pino-http-send) is a configurable and low overhead
-transport that will batch logs and send to a specified URL.
-
-```console
-$ node app.js | pino-http-send -u http://localhost:8080/logs
-```
-
-<a id="pino-pg"></a>
-### pino-pg
-[pino-pg](https://www.npmjs.com/package/pino-pg) stores logs into PostgreSQL.
-Full documentation in the [readme](https://github.com/Xstoudi/pino-pg).

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -162,9 +162,6 @@ function write (_obj, msg, num) {
   const stream = this[streamSym]
   if (stream[needsMetadataGsym] === true) {
     stream.lastLevel = num
-    // TODO remove in the next major release,
-    // it is not needed anymore
-    stream.lastMsg = msg
     stream.lastObj = obj
     stream.lastTime = t.slice(this[timeSliceIndexSym])
     stream.lastLogger = this // for child loggers

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -14,7 +14,6 @@ test('metadata works', async ({ ok, same, is }) => {
     write (chunk) {
       is(instance, this.lastLogger)
       is(30, this.lastLevel)
-      is('a msg', this.lastMsg)
       ok(Number(this.lastTime) >= now)
       same(this.lastObj, { hello: 'world', msg: 'a msg' })
       const result = JSON.parse(chunk)
@@ -39,7 +38,6 @@ test('child loggers works', async ({ ok, same, is }) => {
     write (chunk) {
       is(child, this.lastLogger)
       is(30, this.lastLevel)
-      is('a msg', this.lastMsg)
       same(this.lastObj, { from: 'child', msg: 'a msg' })
       const result = JSON.parse(chunk)
       ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
@@ -65,7 +63,6 @@ test('without object', async ({ ok, same, is }) => {
     write (chunk) {
       is(instance, this.lastLogger)
       is(30, this.lastLevel)
-      is('a msg', this.lastMsg)
       same({ msg: 'a msg' }, this.lastObj)
       const result = JSON.parse(chunk)
       ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')


### PR DESCRIPTION
+ Removes a deprecated metadata field
+ Cherry picks latest `master` commits into `next`

@mcollina and @davidmarkclements do you see anything else that would block issuing a full v6 release?