### PR TITLE
Add a basic LTS doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 * [Ecosystem ⇗](/docs/ecosystem.md)
 * [Legacy](/docs/legacy.md)
 * [Help ⇗](/docs/help.md)
+* [Long Term Support Policy ⇗](/docs/lts.md)
 
 ## Install
 

--- a/docs/lts.md
+++ b/docs/lts.md
@@ -7,3 +7,6 @@ Pino, "X" releases in X.Y.Z of [semantic versioning][semver] nomenclature, will
 be issued as close as possible to the release of a new major LTS release of
 Node.js (subject to the Pino maintainers's capcity). Pino makes no guarantees
 as to the operability of the library on unsupported releases of Node.js.
+
+Pino will not remove support for a deprecated Node.js release via a minor,
+or patch, release of Pino.

--- a/docs/lts.md
+++ b/docs/lts.md
@@ -1,0 +1,9 @@
+## Long Term Support
+<a id="lts"></a>
+
+Pino's Long Term Support (LTS) is tied to the
+[Node.js LTS policy](https://github.com/nodejs/Release). Major versions of
+Pino, "X" releases in X.Y.Z of [semantic versioning][semver] nomenclature, will
+be issued as close as possible to the release of a new major LTS release of
+Node.js (subject to the Pino maintainers's capcity). Pino makes no guarantees
+as to the operability of the library on unsupported releases of Node.js.


### PR DESCRIPTION
This PR adds a very simple document describing our LTS policy. In short, it says we only support LTS releases of core and that we will synchronize with core as our schedules allow.