### PR TITLE
express-pino-logger should be deprecated

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -37,12 +37,14 @@ See the [fastify documentation](https://www.fastify.io/docs/latest/Logging/) for
 ## Pino with Express
 
 ```sh
-npm install express-pino-logger
+npm install pino-http
 ```
 
 ```js
-const app = require('express')()
-const pino = require('express-pino-logger')()
+import express from 'express'
+const app = express()
+import PinoExpressLogger from 'pino-http'
+const pino = PinoExpressLogger()
 
 app.use(pino)
 
@@ -54,7 +56,7 @@ app.get('/', function (req, res) {
 app.listen(3000)
 ```
 
-See the [express-pino-logger readme](http://npm.im/express-pino-logger) for more info.
+See the [pino-http readme](http://npm.im/pino-http) for more info.
 
 <a id="hapi"></a>
 ## Pino with Hapi

--- a/docs/web.md
+++ b/docs/web.md
@@ -9,7 +9,6 @@ web framework ecosystem.
   - [Pino with Hapi](#pino-with-hapi)
   - [Pino with Restify](#pino-with-restify)
   - [Pino with Koa](#pino-with-koa)
-    - [Koa](#koa)
   - [Pino with Node core `http`](#pino-with-node-core-http)
   - [Pino with Nest](#pino-with-nest)
 
@@ -145,8 +144,6 @@ See the [restify-pino-logger readme](http://npm.im/restify-pino-logger) for more
 
 <a id="koa"></a>
 ## Pino with Koa
-
-### Koa
 
 ```sh
 npm install koa-pino-logger

--- a/docs/web.md
+++ b/docs/web.md
@@ -3,13 +3,15 @@
 Since HTTP logging is a primary use case, Pino has first class support for the Node.js
 web framework ecosystem.
 
-+ [Pino with Fastify](#fastify)
-+ [Pino with Express](#express)
-+ [Pino with Hapi](#hapi)
-+ [Pino with Restify](#restify)
-+ [Pino with Koa](#koa)
-+ [Pino with Node core `http`](#http)
-+ [Pino with Nest](#nest)
+- [Web Frameworks](#web-frameworks)
+  - [Pino with Fastify](#pino-with-fastify)
+  - [Pino with Express](#pino-with-express)
+  - [Pino with Hapi](#pino-with-hapi)
+  - [Pino with Restify](#pino-with-restify)
+  - [Pino with Koa](#pino-with-koa)
+    - [Koa](#koa)
+  - [Pino with Node core `http`](#pino-with-node-core-http)
+  - [Pino with Nest](#pino-with-nest)
 
 <a id="fastify"></a>
 ## Pino with Fastify
@@ -41,10 +43,8 @@ npm install pino-http
 ```
 
 ```js
-import express from 'express'
-const app = express()
-import PinoExpressLogger from 'pino-http'
-const pino = PinoExpressLogger()
+const app = require('express')()
+const pino = require('pino-http')()
 
 app.use(pino)
 


### PR DESCRIPTION
It is 2 years old and still uses pino-http 4.0.0 and it doesn't actually contain any code