### PR TITLE
Update docs interpolation values examples to match v6

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -488,7 +488,7 @@ logger.info('%o hello %s', {worldly: 1}, 'world')
 ```
 
 Since pino v6, we do not automatically concatenate and cast to string
-in the interpolation values:
+consecutive parameters:
 
 ```js
 logger.info('hello', 'world')

--- a/docs/api.md
+++ b/docs/api.md
@@ -484,7 +484,7 @@ the final output `msg` value for the JSON log line.
 
 ```js
 logger.info('%o hello %s', {worldly: 1}, 'world')
-// {"level":30,"time":1531257826880,"msg":"{\"worldly\":1} hello","pid":55956,"hostname":"x"}
+// {"level":30,"time":1531257826880,"msg":"{\"worldly\":1} hello world","pid":55956,"hostname":"x"}
 ```
 
 Since pino v6, we do not automatically concatenate and cast to string

--- a/docs/api.md
+++ b/docs/api.md
@@ -143,6 +143,7 @@ If an object is supplied, three options can be specified:
 An object mapping to hook functions. Hook functions allow for customizing
 internal logger operations. Hook functions ***must*** be synchronous functions.
 
+<a id="logmethod"></a>
 ##### `logMethod`
 
 Allows for manipulating the parameters passed to logger methods. The signature
@@ -496,7 +497,25 @@ logger.info('hello', 'world')
 // world is missing
 ```
 
+However, it's possible to inject a hook to modify this behavior:
+
+```js
+const pinoOptions = {
+  hooks: { logMethod }
+}
+
+function logMethod (args, method) {
+  if (args.length === 2) {
+    args[0] = `${args[0]} %j`
+  }
+  method.apply(this, args)
+}
+
+const logger = pino(pinoOptions)
+```
+
 * See [`message` log method parameter](#message)
+* See [`logMethod` hook](#logmethod)
 
 <a id="trace"></a>
 ### `logger.trace([mergingObject], [message], [...interpolationValues])`

--- a/docs/api.md
+++ b/docs/api.md
@@ -483,18 +483,17 @@ to any supplied printf-style placeholders (`%s`, `%d`, `%o`|`%O`|`%j`) to form
 the final output `msg` value for the JSON log line.
 
 ```js
-logger.info('hello', 'world')
-// {"level":30,"time":1531257618044,"msg":"hello world","pid":55956,"hostname":"x"}
-```
-
-```js
-logger.info('hello', {worldly: 1})
-// {"level":30,"time":1531257797727,"msg":"hello {\"worldly\":1}","pid":55956,"hostname":"x"}
-```
-
-```js
-logger.info('%o hello', {worldly: 1})
+logger.info('%o hello %s', {worldly: 1}, 'world')
 // {"level":30,"time":1531257826880,"msg":"{\"worldly\":1} hello","pid":55956,"hostname":"x"}
+```
+
+Since pino v6, we do not automatically concatenate and cast to string
+in the interpolation values:
+
+```js
+logger.info('hello', 'world')
+// {"level":30,"time":1531257618044,"msg":"hello","pid":55956,"hostname":"x"}
+// world is missing
 ```
 
 * See [`message` log method parameter](#message)


### PR DESCRIPTION
Fixes: https://github.com/pinojs/pino/issues/817
See: https://github.com/pinojs/pino/pull/795
See: https://github.com/pinojs/pino/issues/793