### PR TITLE
Use object shorthand for properties

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -58,10 +58,10 @@ function pino (opts) {
   })
 
   var setOpts = {
-    transmit: transmit,
-    serialize: serialize,
+    transmit,
+    serialize,
     asObject: opts.browser.asObject,
-    levels: levels
+    levels
   }
   logger.levels = pino.levels
   logger.level = level
@@ -191,10 +191,10 @@ function wrap (opts, logger, level) {
         var methodValue = pino.levels.values[level]
         if (methodValue < transmitValue) return
         transmit(this, {
-          ts: ts,
+          ts,
           methodLevel: level,
-          methodValue: methodValue,
-          transmitLevel: transmitLevel,
+          methodValue,
+          transmitLevel,
           transmitValue: pino.levels.values[opts.transmit.level || logger.level],
           send: opts.transmit.send,
           val: logger.levelVal

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -119,9 +119,9 @@ function levelTest (name, level) {
     is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
     delete result.time
     same(result, {
-      pid: pid,
-      hostname: hostname,
-      level: level,
+      pid,
+      hostname,
+      level,
       msg: 'a string',
       hello: 'world'
     })
@@ -137,9 +137,9 @@ function levelTest (name, level) {
     is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
     delete result.time
     same(result, {
-      pid: pid,
-      hostname: hostname,
-      level: level,
+      pid,
+      hostname,
+      level,
       msg: 'string',
       hello: 'world'
     })
@@ -181,9 +181,9 @@ function levelTest (name, level) {
     is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
     delete result.time
     same(result, {
-      pid: pid,
-      hostname: hostname,
-      level: level,
+      pid,
+      hostname,
+      level,
       err: {
         type: 'Error',
         message: err.message,
@@ -202,9 +202,9 @@ function levelTest (name, level) {
     is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
     delete result.time
     same(result, {
-      pid: pid,
-      hostname: hostname,
-      level: level,
+      pid,
+      hostname,
+      level,
       msg: 'hello world',
       hello: 'world'
     })
@@ -252,8 +252,8 @@ test('set the name', async ({ is, same }) => {
   is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 60,
     name: 'hello',
     msg: 'this is fatal'
@@ -272,8 +272,8 @@ test('set the messageKey', async ({ is, same }) => {
   is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     fooMessage: message
   })
@@ -291,8 +291,8 @@ test('set the nestedKey', async ({ is, same }) => {
   is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     stuff: object
   })
@@ -306,8 +306,8 @@ test('set undefined properties', async ({ is, same }) => {
   is(new Date(result.time) <= new Date(), true, 'time is greater than Date.now()')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     hello: 'world'
   })
@@ -397,8 +397,8 @@ test('correctly escapes msg strings with stray double quote at end', async ({ sa
   const result = await once(stream, 'data')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 60,
     name: 'hello',
     msg: 'this contains "'
@@ -414,8 +414,8 @@ test('correctly escape msg strings with unclosed double quote', async ({ same })
   const result = await once(stream, 'data')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 60,
     name: 'hello',
     msg: '" this contains'
@@ -431,8 +431,8 @@ test('object and format string', async ({ same }) => {
   const result = await once(stream, 'data')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     msg: 'foo bar'
   })
@@ -445,8 +445,8 @@ test('object and format string property', async ({ same }) => {
   const result = await once(stream, 'data')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     msg: 'foo bar',
     answer: 42
@@ -471,8 +471,8 @@ test('correctly supports stderr', async ({ same }) => {
       result = JSON.parse(result)
       delete result.time
       same(result, {
-        pid: pid,
-        hostname: hostname,
+        pid,
+        hostname,
         level: 60,
         msg: 'a message'
       })
@@ -489,8 +489,8 @@ test('normalize number to string', async ({ same }) => {
   const result = await once(stream, 'data')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     msg: '1'
   })
@@ -503,8 +503,8 @@ test('normalize number to string with an object', async ({ same }) => {
   const result = await once(stream, 'data')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     msg: '1',
     answer: 42
@@ -520,8 +520,8 @@ test('handles objects with null prototype', async ({ same }) => {
   const result = await once(stream, 'data')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     test: 'test'
   })
@@ -538,8 +538,8 @@ test('pino.destination', async ({ same }) => {
   const result = JSON.parse(readFileSync(tmp).toString())
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     msg: 'hello'
   })
@@ -556,8 +556,8 @@ test('auto pino.destination with a string', async ({ same }) => {
   const result = JSON.parse(readFileSync(tmp).toString())
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     msg: 'hello'
   })
@@ -574,8 +574,8 @@ test('auto pino.destination with a string as second argument', async ({ same }) 
   const result = JSON.parse(readFileSync(tmp).toString())
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     msg: 'hello'
   })
@@ -593,8 +593,8 @@ test('does not override opts with a string as second argument', async ({ same })
   await watchFileCreated(tmp)
   const result = JSON.parse(readFileSync(tmp).toString())
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 30,
     time: 'none',
     msg: 'hello'

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -473,7 +473,7 @@ function levelTest (name) {
         err: pino.stdSerializers.err
       }
     })
-    instance[name]({ err: err })
+    instance[name]({ err })
   })
 
   test('child logger for level ' + name, ({ end, is }) => {
@@ -512,7 +512,7 @@ function consoleMethodTest (level, method) {
       is(args[0], 'test')
       end()
     })
-    const instance = require('../browser')({ level: level })
+    const instance = require('../browser')({ level })
     instance[level]('test')
   })
 }

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -22,9 +22,9 @@ test('err is serialized with additional properties set on the Error object', asy
   ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
-    level: level,
+    pid,
+    hostname,
+    level,
     type: 'Error',
     msg: err.message,
     stack: err.stack,
@@ -42,9 +42,9 @@ test('type should be retained, even if type is a property', async ({ ok, same })
   ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
-    level: level,
+    pid,
+    hostname,
+    level,
     type: 'bar',
     msg: err.message,
     stack: err.stack
@@ -62,9 +62,9 @@ test('type, message and stack should be first level properties', async ({ ok, sa
   ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
-    level: level,
+    pid,
+    hostname,
+    level,
     type: 'Error',
     msg: err.message,
     stack: err.stack,
@@ -87,9 +87,9 @@ test('err serializer', async ({ ok, same }) => {
   ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
-    level: level,
+    pid,
+    hostname,
+    level,
     err: {
       type: 'Error',
       message: err.message,
@@ -111,9 +111,9 @@ test('an error with statusCode property is not confused for a http response', as
   ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
-    level: level,
+    pid,
+    hostname,
+    level,
     type: 'Error',
     msg: err.message,
     stack: err.stack,
@@ -163,8 +163,8 @@ test('correctly ignores toString on errors', async ({ same }) => {
   const result = await once(stream, 'data')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 60,
     type: 'Error',
     msg: err.message,

--- a/test/escaping.test.js
+++ b/test/escaping.test.js
@@ -18,8 +18,8 @@ function testEscape (ch, key) {
     const result = await once(stream, 'data')
     delete result.time
     same(result, {
-      pid: pid,
-      hostname: hostname,
+      pid,
+      hostname,
       level: 60,
       name: 'hello',
       msg: 'this contains ' + key
@@ -82,8 +82,8 @@ test('correctly escape `hello \\u001F world \\n \\u0022`', async ({ same }) => {
   const result = await once(stream, 'data')
   delete result.time
   same(result, {
-    pid: pid,
-    hostname: hostname,
+    pid,
+    hostname,
     level: 60,
     name: 'hello',
     msg: 'hello \u001F world \n \u0022'

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -16,8 +16,8 @@ test('http request support', async ({ ok, same, error, teardown }) => {
     ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
     delete chunk.time
     same(chunk, {
-      pid: pid,
-      hostname: hostname,
+      pid,
+      hostname,
       level: 30,
       msg: 'my request',
       req: {
@@ -54,8 +54,8 @@ test('http request support via serializer', async ({ ok, same, error, teardown }
     ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
     delete chunk.time
     same(chunk, {
-      pid: pid,
-      hostname: hostname,
+      pid,
+      hostname,
       level: 30,
       msg: 'my request',
       req: {
@@ -70,7 +70,7 @@ test('http request support via serializer', async ({ ok, same, error, teardown }
 
   const server = http.createServer(function (req, res) {
     originalReq = req
-    instance.info({ req: req }, 'my request')
+    instance.info({ req }, 'my request')
     res.end('hello')
   })
   server.unref()
@@ -93,8 +93,8 @@ test('http request support via serializer without request connection', async ({ 
     ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
     delete chunk.time
     const expected = {
-      pid: pid,
-      hostname: hostname,
+      pid,
+      hostname,
       level: 30,
       msg: 'my request',
       req: {
@@ -113,7 +113,7 @@ test('http request support via serializer without request connection', async ({ 
   const server = http.createServer(function (req, res) {
     originalReq = req
     delete req.connection
-    instance.info({ req: req }, 'my request')
+    instance.info({ req }, 'my request')
     res.end('hello')
   })
   server.unref()
@@ -132,8 +132,8 @@ test('http response support', async ({ ok, same, error, teardown }) => {
     ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
     delete chunk.time
     same(chunk, {
-      pid: pid,
-      hostname: hostname,
+      pid,
+      hostname,
       level: 30,
       msg: 'my response',
       res: {
@@ -168,8 +168,8 @@ test('http response support via a serializer', async ({ ok, same, error, teardow
     ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
     delete chunk.time
     same(chunk, {
-      pid: pid,
-      hostname: hostname,
+      pid,
+      hostname,
       level: 30,
       msg: 'my response',
       res: {
@@ -186,7 +186,7 @@ test('http response support via a serializer', async ({ ok, same, error, teardow
     res.setHeader('x-single', 'y')
     res.setHeader('x-multi', [1, 2])
     res.end('hello')
-    instance.info({ res: res }, 'my response')
+    instance.info({ res }, 'my response')
   })
 
   server.unref()
@@ -209,8 +209,8 @@ test('http request support via serializer in a child', async ({ ok, same, error,
     ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
     delete chunk.time
     same(chunk, {
-      pid: pid,
-      hostname: hostname,
+      pid,
+      hostname,
       level: 30,
       msg: 'my request',
       req: {
@@ -225,7 +225,7 @@ test('http request support via serializer in a child', async ({ ok, same, error,
 
   const server = http.createServer(function (req, res) {
     originalReq = req
-    const child = instance.child({ req: req })
+    const child = instance.child({ req })
     child.info('my request')
     res.end('hello')
   })

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -21,8 +21,8 @@ test('metadata works', async ({ ok, same, is }) => {
       ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
       delete result.time
       same(result, {
-        pid: pid,
-        hostname: hostname,
+        pid,
+        hostname,
         level: 30,
         hello: 'world',
         msg: 'a msg'
@@ -45,8 +45,8 @@ test('child loggers works', async ({ ok, same, is }) => {
       ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
       delete result.time
       same(result, {
-        pid: pid,
-        hostname: hostname,
+        pid,
+        hostname,
         level: 30,
         hello: 'world',
         from: 'child',
@@ -71,8 +71,8 @@ test('without object', async ({ ok, same, is }) => {
       ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
       delete result.time
       same(result, {
-        pid: pid,
-        hostname: hostname,
+        pid,
+        hostname,
         level: 30,
         msg: 'a msg'
       })
@@ -94,8 +94,8 @@ test('without msg', async ({ ok, same, is }) => {
       ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
       delete result.time
       same(result, {
-        pid: pid,
-        hostname: hostname,
+        pid,
+        hostname,
         level: 30,
         hello: 'world'
       })


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

✅ The syntax is support by Node.js 4.x and up, which is well below the currently supported versions 