### PR TITLE
Disable code coverage on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install
         run: npm i
-      - name: Tests
-        run: npm test
+      - name: Test
+        run: |
+              if [ "$RUNNER_OS" == "Windows ]; then
+                npm run without-cov
+              elseif
+                npm test
+              fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install
         run: npm i
-      - name: Test
-        run: |
-              if [ "$RUNNER_OS" == "Windows ]; then
-                npm run without-cov
-              elseif
-                npm test
-              fi
+      - name: Test with coverage
+        if: matrix.os != 'windows-latest'
+        run: npm test
+      - name: Test without coverage
+        if: matrix.os == 'windows-latest'
+        run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
         run: npm test
       - name: Test without coverage
         if: matrix.os == 'windows-latest'
-        run: npm test
+        run: npm run without-cov

--- a/.taprc
+++ b/.taprc
@@ -1,5 +1,4 @@
 esm: false
 ts: false
 jsx: false
-coverage: false
 timeout: 480

--- a/.taprc
+++ b/.taprc
@@ -1,5 +1,5 @@
 esm: false
 ts: false
 jsx: false
-coverage: true
+coverage: false
 timeout: 480

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "docs": "docsify serve",
     "browser-test": "airtap --local 8080 test/browser*test.js",
     "test": "standard | snazzy && tap --100 test/*test.js",
+    "without-cov": "standard | snazzy && tap --no-cov test/*test.js",
     "cov-ui": "tap --coverage-report=html test/*test.js",
     "bench": "node benchmarks/utils/runbench all",
     "bench-basic": "node benchmarks/utils/runbench basic",


### PR DESCRIPTION
Currently we fail on Windows and node v14 for some problem (https://github.com/nodejs/node/issues/33166).
Therefore, I'm disabling coverage on Windows.