### PR TITLE
Allow to suppress prettyPrint flush sync warning

### DIFF
--- a/docs/pretty.md
+++ b/docs/pretty.md
@@ -85,10 +85,10 @@ will be written to the destination stream.
   See the [`pino-pretty` documentation][pp] for more information on the options
   that can be passed via `prettyPrint`.
    
-  Pretty stream doesn't guarantee final log writes and corresponding warning is written to logs on 
-  first synchronous flushing.
-  To disable this warning, e.g. if you use pretty stream consciously and know that some logs can be lost,
-  you can pass `suppressFlushSyncWarning : true` to prettyPrint:
+The default prettifier write stream does not guarantee final log writes.
+Correspondingly, a warning is written to logs on first synchronous flushing.
+This warning may be suppressed by passing `suppressFlushSyncWarning : true` to
+`prettyPrint`:
   ```js
   const pino = require('pino')
   const log = pino({

--- a/docs/pretty.md
+++ b/docs/pretty.md
@@ -84,5 +84,18 @@ will be written to the destination stream.
   ```
   See the [`pino-pretty` documentation][pp] for more information on the options
   that can be passed via `prettyPrint`.
+   
+  Pretty stream doesn't guarantee final log writes and corresponding warning is written to logs on 
+  first synchronous flushing.
+  To disable this warning, e.g. if you use pretty stream consciously and know that some logs can be lost,
+  you can pass `suppressFlushSyncWarning : true` to prettyPrint:
+  ```js
+  const pino = require('pino')
+  const log = pino({
+    prettyPrint: {
+      suppressFlushSyncWarning: true
+    }
+  })
+  ```
 
   [pp]: https://github.com/pinojs/pino-pretty

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -128,7 +128,7 @@ function asJson (obj, msg, num, time) {
           if (Number.isFinite(value) === false) {
             value = null
           }
-        // this case explicity falls through to the next one
+        // this case explicitly falls through to the next one
         case 'boolean':
           if (stringifier) value = stringifier(value)
           break
@@ -177,18 +177,19 @@ function asChindings (instance, bindings) {
 function getPrettyStream (opts, prettifier, dest, instance) {
   if (prettifier && typeof prettifier === 'function') {
     prettifier = prettifier.bind(instance)
-    return prettifierMetaWrapper(prettifier(opts), dest)
+    return prettifierMetaWrapper(prettifier(opts), dest, opts)
   }
   try {
     var prettyFactory = require('pino-pretty')
     prettyFactory.asMetaWrapper = prettifierMetaWrapper
-    return prettifierMetaWrapper(prettyFactory(opts), dest)
+    return prettifierMetaWrapper(prettyFactory(opts), dest, opts)
   } catch (e) {
     throw Error('Missing `pino-pretty` module: `pino-pretty` must be installed separately')
   }
 }
 
-function prettifierMetaWrapper (pretty, dest) {
+function prettifierMetaWrapper (pretty, dest, opts) {
+  opts = Object.assign({ suppressFlushSyncWarning: false }, opts)
   var warned = false
   return {
     [needsMetadataGsym]: true,
@@ -197,7 +198,7 @@ function prettifierMetaWrapper (pretty, dest) {
     lastObj: null,
     lastLogger: null,
     flushSync () {
-      if (warned) {
+      if (opts.suppressFlushSyncWarning || warned) {
         return
       }
       warned = true

--- a/test/fixtures/pretty/suppress-flush-sync-warning.js
+++ b/test/fixtures/pretty/suppress-flush-sync-warning.js
@@ -1,0 +1,7 @@
+global.process = { __proto__: process, pid: 123456 }
+Date.now = function () { return 1459875739796 }
+require('os').hostname = function () { return 'abcdefghijklmnopqr' }
+var pino = require(require.resolve('./../../../'))
+var log = pino({ prettyPrint: { suppressFlushSyncWarning: true } })
+log.info('h')
+log.fatal('h1')

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -287,6 +287,18 @@ test('final works without prior logging', async ({ isNot }) => {
   isNot(strip(actual).match(/INFO\s+\(123456 on abcdefghijklmnopqr\): beforeExit/), null)
 })
 
+test('suppress flush sync warning when corresponding option is specified', async ({ isNot, is }) => {
+  var actual = ''
+  const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'pretty', 'suppress-flush-sync-warning.js')])
+
+  child.stdout.pipe(writer((s, enc, cb) => {
+    actual += s
+    cb()
+  }))
+  await once(child, 'close')
+  is(strip(actual).match(/WARN\s+\(123456 on abcdefghijklmnopqr\): pino.final with prettyPrint does not support flushing/), null)
+})
+
 test('works as expected with an object with the msg prop', async ({ isNot }) => {
   var actual = ''
   const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'pretty', 'obj-msg-prop.js')])


### PR DESCRIPTION
Described in https://github.com/pinojs/pino-pretty/issues/108 issue.
I understood that this issue belongs more to the pino, should I close in pino/pretty and move to pino repo?