### PR TITLE
Set sync: true when passing in no defaults

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -314,10 +314,10 @@ function createArgsNormalizer (defaultOptions) {
   return function normalizeArgs (instance, opts = {}, stream) {
     // support stream as a string
     if (typeof opts === 'string') {
-      stream = buildSafeSonicBoom({ dest: opts })
+      stream = buildSafeSonicBoom({ dest: opts, sync: true })
       opts = {}
     } else if (typeof stream === 'string') {
-      stream = buildSafeSonicBoom({ dest: stream })
+      stream = buildSafeSonicBoom({ dest: stream, sync: true })
     } else if (opts instanceof SonicBoom || opts.writable || opts._writableState) {
       stream = opts
       opts = null
@@ -341,7 +341,7 @@ function createArgsNormalizer (defaultOptions) {
     if (enabled === false) opts.level = 'silent'
     stream = stream || process.stdout
     if (stream === process.stdout && stream.fd >= 0 && !hasBeenTampered(stream)) {
-      stream = buildSafeSonicBoom({ fd: stream.fd })
+      stream = buildSafeSonicBoom({ fd: stream.fd, sync: true })
     }
     if (prettyPrint) {
       const prettyOpts = Object.assign({ messageKey }, prettyPrint)

--- a/test/exit.test.js
+++ b/test/exit.test.js
@@ -22,6 +22,21 @@ test('pino.destination log everything when calling process.exit(0)', async ({ is
   isNot(actual.match(/world/), null)
 })
 
+test('pino with no args log everything when calling process.exit(0)', async ({ isNot }) => {
+  var actual = ''
+  const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'default-exit.js')])
+
+  child.stdout.pipe(writer((s, enc, cb) => {
+    actual += s
+    cb()
+  }))
+
+  await once(child, 'close')
+
+  isNot(actual.match(/hello/), null)
+  isNot(actual.match(/world/), null)
+})
+
 test('sync false does not log everything when calling process.exit(0)', async ({ is }) => {
   var actual = ''
   const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'syncfalse-exit.js')])

--- a/test/fixtures/default-exit.js
+++ b/test/fixtures/default-exit.js
@@ -1,0 +1,8 @@
+global.process = { __proto__: process, pid: 123456 }
+Date.now = function () { return 1459875739796 }
+require('os').hostname = function () { return 'abcdefghijklmnopqr' }
+var pino = require(require.resolve('./../../'))
+var logger = pino()
+logger.info('hello')
+logger.info('world')
+process.exit(0)


### PR DESCRIPTION
In the migration to the sync flag, we have changed the default of pino
making it async by default. This resolves the problem.

Fixes #849.