### PR TITLE
order levels, trace maps to DEBUG severity

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -254,20 +254,20 @@ similar to the one below to retain log levels in Google Clould Logging
 const pino = require('pino')
 
 // https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity
-const PinoLevelToSeverityLookup = {  
-  'trace': 'DEFAULT',
-  'fatal': 'CRITICAL',
-  'debug': 'DEBUG',
-  'info': 'INFO',
-  'warn': 'WARNING',
-  'error': 'ERROR',
-}
+const PinoLevelToSeverityLookup = {
+  trace: 'DEBUG',
+  debug: 'DEBUG',
+  info: 'INFO',
+  warn: 'WARNING',
+  error: 'ERROR',
+  fatal: 'CRITICAL',
+};
 
 const defaultPinoConf = {
   messageKey: 'message',
   formatters: {
     level(label, number) {
-      return { 
+      return {
         severity: PinoLevelToSeverityLookup[label] || PinoLevelToSeverityLookup['info'],
         level: number,
       }
@@ -279,4 +279,3 @@ module.exports = function createLogger(options) {
   return pino(Object.assign({}, options, defaultPinoConf))
 }
 ```
-


### PR DESCRIPTION
cc @rahulballal

As per gcp docs severity DEBUG(100) is for debug or trace information.

Signed-off-by: Naseem <naseem@transit.app>