### PR TITLE
Wrap prototype in factory and guard against loss of scope. 

### DIFF
--- a/lib/levels.js
+++ b/lib/levels.js
@@ -112,7 +112,8 @@ function setLevel (level) {
 
 function getLevel (level) {
   const { levels, levelVal } = this
-  return levels.labels[levelVal]
+  // protection against potential loss of Pino scope from serializers (edge case with circular refs - https://github.com/pinojs/pino/issues/833)
+  return (levels && levels.labels) ? levels.labels[levelVal] : ''
 }
 
 function isLevelEnabled (logLevel) {

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -65,7 +65,9 @@ const prototype = {
 Object.setPrototypeOf(prototype, EventEmitter.prototype)
 
 // exporting and consuming the prototype object using factory pattern fixes scoping issues with getters when serializing
-module.exports = () => prototype
+module.exports = function () {
+  return Object.create(prototype)
+}
 
 const resetChildingsFormatter = bindings => bindings
 function child (bindings) {

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -64,7 +64,8 @@ const prototype = {
 
 Object.setPrototypeOf(prototype, EventEmitter.prototype)
 
-module.exports = prototype
+// exporting and consuming the prototype object using factory pattern fixes scoping issues with getters when serializing
+module.exports = () => prototype
 
 const resetChildingsFormatter = bindings => bindings
 function child (bindings) {

--- a/pino.js
+++ b/pino.js
@@ -169,7 +169,8 @@ function pino (...args) {
     [hooksSym]: hooks,
     silent: noop
   })
-  Object.setPrototypeOf(instance, proto)
+
+  Object.setPrototypeOf(instance, proto())
 
   genLsCache(instance)
 

--- a/test/levels.test.js
+++ b/test/levels.test.js
@@ -553,6 +553,7 @@ test('changing level from info to silent and back to info in child logger', asyn
   check(is, result, expected.level, expected.msg)
 })
 
+// testing for potential loss of Pino constructor scope from serializers - an edge case with circular refs see:  https://github.com/pinojs/pino/issues/833
 test('trying to get levels when `this` is no longer a Pino instance returns an empty string', async ({ is }) => {
   const notPinoInstance = { some: 'object', getLevel: levelsLib.getLevel }
   const blankedLevelValue = notPinoInstance.getLevel()

--- a/test/levels.test.js
+++ b/test/levels.test.js
@@ -4,6 +4,8 @@ const { test } = require('tap')
 const { sink, once, check } = require('./helper')
 const pino = require('../')
 
+const levelsLib = require('../lib/levels')
+
 // Silence all warnings for this test
 process.removeAllListeners('warning')
 process.on('warning', () => {})
@@ -549,4 +551,10 @@ test('changing level from info to silent and back to info in child logger', asyn
   child.info('hello world')
   result = await once(stream, 'data')
   check(is, result, expected.level, expected.msg)
+})
+
+test('trying to get levels when `this` is no longer a Pino instance returns an empty string', async ({ is }) => {
+  const notPinoInstance = { some: 'object', getLevel: levelsLib.getLevel }
+  const blankedLevelValue = notPinoInstance.getLevel()
+  is(blankedLevelValue, '')
 })


### PR DESCRIPTION
The scope of the Pino class instance is lost when circular refs are routed through `decirc` - and `levels` is undefined in the getter. 

This PR wraps the Pino prototype in a factory - which helps with scope, and adds a protection in the `getLevels` function, with a  simple test to keep coverage up. 

Fixes #833 