### PR TITLE
Avoid data loss with conflictig 'msg' values.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -488,6 +488,8 @@ The `message` parameter takes precedence over the `mergedObject`.
 That is, if a `mergedObject` contains a `msg` property, and a `message` parameter
 is supplied in addition, the `msg` property in the output log will be the value of
 the `message` parameter not the value of the `msg` property on the `mergedObject`.
+In case this conflict occurs, the `msg` property from the object will be preserved
+in the key `originalMsg`.
 
 The `messageKey` option can be used at instantiation time to change the namespace
 from `msg` to another string as preferred.

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -109,6 +109,10 @@ function asJson (obj, msg, num, time) {
     obj = formatters.log(obj)
   }
   if (msg !== undefined) {
+    // If msg appears as a string and in the object, preserve it as "originalMsg"
+    if (obj[messageKey] !== undefined) {
+      obj.originalMsg = obj[messageKey]
+    }
     obj[messageKey] = msg
   }
   const wildcardStringifier = stringifiers[wildcardFirstSym]

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -141,6 +141,7 @@ function levelTest (name, level) {
       hostname,
       level,
       msg: 'string',
+      originalMsg: 'object',
       hello: 'world'
     })
   })


### PR DESCRIPTION
If msg appears as a string and in the object, preserve it as "originalMsg"

Before, the `msg` copy in the the object was lost.

Fixes #874

`npm run bench-basic` reports results within about a millisecond before and after this change, which is within the margin of arability on my laptop. 