### PR TITLE
Revert "Avoid data loss with conflicting 'msg' values."

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -488,8 +488,6 @@ The `message` parameter takes precedence over the `mergedObject`.
 That is, if a `mergedObject` contains a `msg` property, and a `message` parameter
 is supplied in addition, the `msg` property in the output log will be the value of
 the `message` parameter not the value of the `msg` property on the `mergedObject`.
-In case this conflict occurs, the `msg` property from the object will be preserved
-in the key `originalMsg`.
 
 The `messageKey` option can be used at instantiation time to change the namespace
 from `msg` to another string as preferred.

--- a/docs/api.md
+++ b/docs/api.md
@@ -470,7 +470,7 @@ logger.info({MIX: {IN: true}})
 // {"level":30,"time":1531254555820,"pid":55956,"hostname":"x","MIX":{"IN":true}}
 ```
 
-<a id=message></a>
+<a id="message"></a>
 #### `message` (String)
 
 A `message` string can optionally be supplied as the first parameter, or
@@ -488,6 +488,8 @@ The `message` parameter takes precedence over the `mergedObject`.
 That is, if a `mergedObject` contains a `msg` property, and a `message` parameter
 is supplied in addition, the `msg` property in the output log will be the value of
 the `message` parameter not the value of the `msg` property on the `mergedObject`.
+See [Avoid Message Conflict](./help.md#avoid-message-conflict) for information
+on how to overcome this limitation.
 
 The `messageKey` option can be used at instantiation time to change the namespace
 from `msg` to another string as preferred.
@@ -505,7 +507,7 @@ then be interpolated accordingly.
 * See [`messageKey` pino option](#opt-messagekey)
 * See [`...interpolationValues` log method parameter](#interpolationvalues)
 
-<a id=interpolationvalues></a>
+<a id="interpolationvalues"></a>
 #### `...interpolationValues` (Any)
 
 All arguments supplied after `message` are serialized and interpolated according

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -109,10 +109,6 @@ function asJson (obj, msg, num, time) {
     obj = formatters.log(obj)
   }
   if (msg !== undefined) {
-    // If msg appears as a string and in the object, preserve it as "originalMsg"
-    if (obj[messageKey] !== undefined) {
-      obj.originalMsg = obj[messageKey]
-    }
     obj[messageKey] = msg
   }
   const wildcardStringifier = stringifiers[wildcardFirstSym]

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -141,7 +141,6 @@ function levelTest (name, level) {
       hostname,
       level,
       msg: 'string',
-      originalMsg: 'object',
       hello: 'world'
     })
   })


### PR DESCRIPTION
Reverts pinojs/pino#876

This causes issues in dependent applications. See https://github.com/fastify/fastify/issues/2453

To get the same effect, use the log method hook:

```js
'use strict'

const log = require('pino')({
  level: 'debug',
  hooks: {
    logMethod (inputArgs, method) {
      if (inputArgs.length === 2 && inputArgs[0].msg) {
       inputArgs[0].originalMessage = inputArgs[0].msg
      }
      return method.apply(this, inputArgs)
    }
  }
})

log.info('no original message')
log.info({ msg: 'mapped to originalMsg' }, 'a message')

// {"level":30,"time":1596195825857,"pid":48580,"hostname":"mini2018","msg":"no original message"}
// {"level":30,"time":1596195825858,"pid":48580,"hostname":"mini2018","msg":"a message","originalMessage":"mapped to originalMsg","originalMsg":"mapped to originalMsg"}
```

cc: @markstos 