### PR TITLE
Make the nestedKey only take effect in the serialized object and fix …

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -20,7 +20,8 @@ const {
   serializersSym,
   formattersSym,
   useOnlyCustomLevelsSym,
-  needsMetadataGsym
+  needsMetadataGsym,
+  messageKeySym
 } = require('./symbols')
 const {
   getLevel,
@@ -148,11 +149,15 @@ function write (_obj, msg, num) {
     obj = mixin ? mixin() : {}
   } else {
     obj = Object.assign(mixin ? mixin() : {}, _obj)
-    if (!msg && objError) {
-      msg = _obj.message
-    }
 
     if (objError) {
+      if (!msg) {
+        // replace the main msg with the message of the error
+        msg = _obj.message
+      } else {
+        // if we do have a msg, we should keep the message found on the error
+        obj.message = _obj.message
+      }
       obj.stack = _obj.stack
       if (!obj.type) {
         obj.type = 'Error'
@@ -165,6 +170,9 @@ function write (_obj, msg, num) {
   const stream = this[streamSym]
   if (stream[needsMetadataGsym] === true) {
     stream.lastLevel = num
+    if (msg) {
+      obj[this[messageKeySym]] = msg
+    }
     stream.lastObj = obj
     stream.lastMsg = msg
     stream.lastTime = t.slice(this[timeSliceIndexSym])

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -24,6 +24,7 @@ const endSym = Symbol('pino.end')
 const formatOptsSym = Symbol('pino.formatOpts')
 const messageKeySym = Symbol('pino.messageKey')
 const nestedKeySym = Symbol('pino.nestedKey')
+const nestedKeyStrSym = Symbol('pino.nestedKeyStr')
 
 const wildcardFirstSym = Symbol('pino.wildcardFirst')
 
@@ -60,5 +61,6 @@ module.exports = {
   needsMetadataGsym,
   useOnlyCustomLevelsSym,
   formattersSym,
-  hooksSym
+  hooksSym,
+  nestedKeyStrSym
 }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -22,7 +22,8 @@ const {
   streamSym,
   nestedKeySym,
   formattersSym,
-  messageKeySym
+  messageKeySym,
+  nestedKeyStrSym
 } = require('./symbols')
 
 function noop () {}
@@ -44,7 +45,6 @@ function genLog (level, hook) {
           o = mapHttpResponse(o)
         }
       }
-      if (this[nestedKeySym]) o = { [this[nestedKeySym]]: o }
       var formatParams
       if (msg === null && n.length === 0) {
         formatParams = [null]
@@ -108,10 +108,8 @@ function asJson (obj, msg, num, time) {
   if (formatters.log) {
     obj = formatters.log(obj)
   }
-  if (msg !== undefined) {
-    obj[messageKey] = msg
-  }
   const wildcardStringifier = stringifiers[wildcardFirstSym]
+  let propStr = ''
   for (var key in obj) {
     value = obj[key]
     if ((notHasOwnProperty || obj.hasOwnProperty(key)) && value !== undefined) {
@@ -139,11 +137,46 @@ function asJson (obj, msg, num, time) {
           value = (stringifier || stringify)(value)
       }
       if (value === undefined) continue
-      data += ',"' + key + '":' + value
+      propStr += ',"' + key + '":' + value
     }
   }
 
-  return data + end
+  let msgStr = ''
+  if (msg !== undefined) {
+    value = serializers[messageKey] ? serializers[messageKey](msg) : msg
+    const stringifier = stringifiers[messageKey] || wildcardStringifier
+
+    switch (typeof value) {
+      case 'undefined':
+      case 'function':
+        break
+      case 'number':
+        /* eslint no-fallthrough: "off" */
+        if (Number.isFinite(value) === false) {
+          value = null
+        }
+      // this case explicitly falls through to the next one
+      case 'boolean':
+        if (stringifier) value = stringifier(value)
+        msgStr = ',"' + messageKey + '":' + value
+        break
+      case 'string':
+        value = (stringifier || asString)(value)
+        msgStr = ',"' + messageKey + '":' + value
+        break
+      default:
+        value = (stringifier || stringify)(value)
+        msgStr = ',"' + messageKey + '":' + value
+    }
+  }
+
+  if (this[nestedKeySym]) {
+    // place all the obj properties under the specified key
+    // the nested key is already formatted from the constructor
+    return data + this[nestedKeyStrSym] + propStr.slice(1) + '}' + msgStr + end
+  } else {
+    return data + propStr + msgStr + end
+  }
 }
 
 function asChindings (instance, bindings) {

--- a/pino.js
+++ b/pino.js
@@ -34,7 +34,8 @@ const {
   mixinSym,
   useOnlyCustomLevelsSym,
   formattersSym,
-  hooksSym
+  hooksSym,
+  nestedKeyStrSym
 } = symbols
 const { epochTime, nullTime } = time
 const { pid } = process
@@ -162,6 +163,8 @@ function pino (...args) {
     [formatOptsSym]: formatOpts,
     [messageKeySym]: messageKey,
     [nestedKeySym]: nestedKey,
+    // protect against injection
+    [nestedKeyStrSym]: nestedKey ? `,${JSON.stringify(nestedKey)}:{` : '',
     [serializersSym]: serializers,
     [mixinSym]: mixin,
     [chindingsSym]: chindings,

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -171,3 +171,50 @@ test('correctly ignores toString on errors', async ({ same }) => {
     stack: err.stack
   })
 })
+
+test('correctly adds error information when nestedKey is used', async ({ same }) => {
+  const err = new Error('myerror')
+  err.toString = () => undefined
+  const stream = sink()
+  const instance = pino({
+    test: 'this',
+    nestedKey: 'obj'
+  }, stream)
+  instance.fatal(err)
+  const result = await once(stream, 'data')
+  delete result.time
+  same(result, {
+    pid,
+    hostname,
+    level: 60,
+    obj: {
+      type: 'Error',
+      stack: err.stack
+    },
+    msg: err.message
+  })
+})
+
+test('correctly adds msg on error when nestedKey is used', async ({ same }) => {
+  const err = new Error('myerror')
+  err.toString = () => undefined
+  const stream = sink()
+  const instance = pino({
+    test: 'this',
+    nestedKey: 'obj'
+  }, stream)
+  instance.fatal(err, 'msg message')
+  const result = await once(stream, 'data')
+  delete result.time
+  same(result, {
+    pid,
+    hostname,
+    level: 60,
+    obj: {
+      type: 'Error',
+      stack: err.stack,
+      message: err.message
+    },
+    msg: 'msg message'
+  })
+})

--- a/test/serializers.test.js
+++ b/test/serializers.test.js
@@ -43,6 +43,29 @@ test('custom serializer overrides default err namespace error serializer', async
   is(typeof o.err.s, 'string')
 })
 
+test('custom serializer overrides default err namespace error serializer when nestedKey is on', async ({ is }) => {
+  const stream = sink()
+  const parent = pino({
+    nestedKey: 'obj',
+    serializers: {
+      err: (e) => {
+        return {
+          t: e.constructor.name,
+          m: e.message,
+          s: e.stack
+        }
+      }
+    }
+  }, stream)
+
+  parent.info({ err: ReferenceError('test') })
+  const o = await once(stream, 'data')
+  is(typeof o.obj.err, 'object')
+  is(o.obj.err.t, 'ReferenceError')
+  is(o.obj.err.m, 'test')
+  is(typeof o.obj.err.s, 'string')
+})
+
 test('null overrides default err namespace error serializer', async ({ is }) => {
   const stream = sink()
   const parent = pino({ serializers: { err: null } }, stream)


### PR DESCRIPTION
…error detection and serialization (closes #883)

proto.js
* Copy the message property in case the obj is an error and there is a msg specified
* Load the msg as a property of obj if metadata is needed

symbols.js
* Add nestedKeyStrSym to quickly cache the string

tools.js
* Manually build the stringify for performance reasons (not too pretty...)

error.test.js + serializers.test.js
* Add a test for the new nestedKey interaction