### PR TITLE
Apply err serializer everywhere.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -257,6 +257,10 @@ These functions should return an JSONifiable object and they
 should never throw. When logging an object, each top-level property
 matching the exact key of a serializer will be serialized using the defined serializer.
 
+The serializers are applied when a property in the logged object matches a property
+in the serialiers. The only exception is the `err` serializer as it is also applied in case
+the object is an instance of `Error`, e.g. `logger.info(new Error('kaboom'))`.
+
 * See [pino.stdSerializers](#pino-stdserializers)
 
 ##### `serializers[Symbol.for('pino.*')]` (Function) - DEPRECATED

--- a/docs/api.md
+++ b/docs/api.md
@@ -258,7 +258,7 @@ should never throw. When logging an object, each top-level property
 matching the exact key of a serializer will be serialized using the defined serializer.
 
 The serializers are applied when a property in the logged object matches a property
-in the serialiers. The only exception is the `err` serializer as it is also applied in case
+in the serializers. The only exception is the `err` serializer as it is also applied in case
 the object is an instance of `Error`, e.g. `logger.info(new Error('kaboom'))`.
 
 * See [pino.stdSerializers](#pino-stdserializers)

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -151,9 +151,9 @@ function write (_obj, msg, num) {
     const serializers = this[serializersSym]
     obj = Object.assign(mixin ? mixin() : {}, serializers.err(_obj))
     // backward compat, set message
-    if (obj.message && !msg) {
-      msg = obj.message
-      obj.message = undefined
+    obj.message = undefined
+    if (!msg) {
+      msg = _obj.message
     }
   } else {
     obj = Object.assign(mixin ? mixin() : {}, _obj)

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -143,23 +143,20 @@ function setBindings (newBindings) {
 function write (_obj, msg, num) {
   const t = this[timeSym]()
   const mixin = this[mixinSym]
-  const objError = _obj instanceof Error
   var obj
 
   if (_obj === undefined || _obj === null) {
     obj = mixin ? mixin() : {}
+  } else if (_obj instanceof Error) {
+    const serializers = this[serializersSym]
+    obj = Object.assign(mixin ? mixin() : {}, serializers.err(_obj))
+    // backward compat, set message
+    if (obj.message && !msg) {
+      msg = obj.message
+      obj.message = undefined
+    }
   } else {
     obj = Object.assign(mixin ? mixin() : {}, _obj)
-    if (!msg && objError) {
-      msg = _obj.message
-    }
-
-    if (objError) {
-      obj.stack = _obj.stack
-      if (!obj.type) {
-        obj.type = 'Error'
-      }
-    }
   }
 
   const s = this[asJsonSym](obj, msg, num, t)

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -324,6 +324,7 @@ function createArgsNormalizer (defaultOptions) {
       opts = null
     }
     opts = Object.assign({}, defaultOptions, opts)
+    opts.serializers = Object.assign({}, defaultOptions.serializers, opts.serializers)
     if ('extreme' in opts) {
       throw Error('The extreme option has been removed, use pino.destination({ sync: false }) instead')
     }

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -32,25 +32,6 @@ test('err is serialized with additional properties set on the Error object', asy
   })
 })
 
-test('type should be retained, even if type is a property', async ({ ok, same }) => {
-  const stream = sink()
-  const err = Object.assign(new Error('myerror'), { type: 'bar' })
-  const instance = pino(stream)
-  instance.level = name
-  instance[name](err)
-  const result = await once(stream, 'data')
-  ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
-  delete result.time
-  same(result, {
-    pid,
-    hostname,
-    level,
-    type: 'bar',
-    msg: err.message,
-    stack: err.stack
-  })
-})
-
 test('type, message and stack should be first level properties', async ({ ok, same }) => {
   const stream = sink()
   const err = Object.assign(new Error('foo'), { foo: 'bar' })
@@ -169,5 +150,27 @@ test('correctly ignores toString on errors', async ({ same }) => {
     type: 'Error',
     msg: err.message,
     stack: err.stack
+  })
+})
+
+test('assign mixin()', async ({ same }) => {
+  const err = new Error('myerror')
+  const stream = sink()
+  const instance = pino({
+    mixin () {
+      return { hello: 'world' }
+    }
+  }, stream)
+  instance.fatal(err)
+  const result = await once(stream, 'data')
+  delete result.time
+  same(result, {
+    pid,
+    hostname,
+    level: 60,
+    type: 'Error',
+    msg: err.message,
+    stack: err.stack,
+    hello: 'world'
   })
 })

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -174,3 +174,41 @@ test('assign mixin()', async ({ same }) => {
     hello: 'world'
   })
 })
+
+test('no err serializer', async ({ same }) => {
+  const err = new Error('myerror')
+  const stream = sink()
+  const instance = pino({
+    serializers: {}
+  }, stream)
+  instance.fatal(err)
+  const result = await once(stream, 'data')
+  delete result.time
+  same(result, {
+    pid,
+    hostname,
+    level: 60,
+    type: 'Error',
+    msg: err.message,
+    stack: err.stack
+  })
+})
+
+test('empty serializer', async ({ same }) => {
+  const err = new Error('myerror')
+  const stream = sink()
+  const instance = pino({
+    serializers: {
+      err () {}
+    }
+  }, stream)
+  instance.fatal(err)
+  const result = await once(stream, 'data')
+  delete result.time
+  same(result, {
+    pid,
+    hostname,
+    level: 60,
+    msg: err.message
+  })
+})


### PR DESCRIPTION
Apply the error serializer if the error object is top-level. It does not seem to cause any performance regressions from my checks.

Fixes #895 