### PR TITLE
Add timestamp option to browser env, closes #903

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -311,7 +311,7 @@ function getTimeFunction (opts) {
   if (opts.timestamp === false) {
     return nullTime
   }
-  return Date.now
+  return epochTime
 }
 
 function mock () { return {} }

--- a/test/browser-timestamp.test.js
+++ b/test/browser-timestamp.test.js
@@ -4,7 +4,7 @@ const pino = require('../browser')
 
 Date.now = () => 1599400603614
 
-test('prints null timestamp', ({ end, is }) => {
+test('null timestamp', ({ end, is }) => {
   const instance = pino({
     timestamp: pino.stdTimeFunctions.nullTime,
     browser: {
@@ -18,7 +18,7 @@ test('prints null timestamp', ({ end, is }) => {
   end()
 })
 
-test('prints iso timestamp', ({ end, is }) => {
+test('iso timestamp', ({ end, is }) => {
   const instance = pino({
     timestamp: pino.stdTimeFunctions.isoTime,
     browser: {
@@ -32,7 +32,7 @@ test('prints iso timestamp', ({ end, is }) => {
   end()
 })
 
-test('prints epoch timestamp', ({ end, is }) => {
+test('epoch timestamp', ({ end, is }) => {
   const instance = pino({
     timestamp: pino.stdTimeFunctions.epochTime,
     browser: {
@@ -46,7 +46,7 @@ test('prints epoch timestamp', ({ end, is }) => {
   end()
 })
 
-test('prints unix timestamp', ({ end, is }) => {
+test('unix timestamp', ({ end, is }) => {
   const instance = pino({
     timestamp: pino.stdTimeFunctions.unixTime,
     browser: {
@@ -60,7 +60,7 @@ test('prints unix timestamp', ({ end, is }) => {
   end()
 })
 
-test('prints epoch timestamp by default', ({ end, is }) => {
+test('epoch timestamp by default', ({ end, is }) => {
   const instance = pino({
     browser: {
       asObject: true,
@@ -73,7 +73,7 @@ test('prints epoch timestamp by default', ({ end, is }) => {
   end()
 })
 
-test('prints epoch timestamp by default', ({ end, is }) => {
+test('not print timestamp if the option is false', ({ end, is }) => {
   const instance = pino({
     timestamp: false,
     browser: {

--- a/test/browser-timestamp.test.js
+++ b/test/browser-timestamp.test.js
@@ -1,0 +1,88 @@
+'use strict'
+const test = require('tape')
+const pino = require('../browser')
+
+Date.now = () => 1599400603614
+
+test('prints null timestamp', ({ end, is }) => {
+  const instance = pino({
+    timestamp: pino.stdTimeFunctions.nullTime,
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.time, undefined)
+      }
+    }
+  })
+  instance.info('hello world')
+  end()
+})
+
+test('prints iso timestamp', ({ end, is }) => {
+  const instance = pino({
+    timestamp: pino.stdTimeFunctions.isoTime,
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.time, '2020-09-06T13:56:43.614Z')
+      }
+    }
+  })
+  instance.info('hello world')
+  end()
+})
+
+test('prints epoch timestamp', ({ end, is }) => {
+  const instance = pino({
+    timestamp: pino.stdTimeFunctions.epochTime,
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.time, 1599400603614)
+      }
+    }
+  })
+  instance.info('hello world')
+  end()
+})
+
+test('prints unix timestamp', ({ end, is }) => {
+  const instance = pino({
+    timestamp: pino.stdTimeFunctions.unixTime,
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.time, Math.round(1599400603614 / 1000.0))
+      }
+    }
+  })
+  instance.info('hello world')
+  end()
+})
+
+test('prints epoch timestamp by default', ({ end, is }) => {
+  const instance = pino({
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.time, 1599400603614)
+      }
+    }
+  })
+  instance.info('hello world')
+  end()
+})
+
+test('prints epoch timestamp by default', ({ end, is }) => {
+  const instance = pino({
+    timestamp: false,
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.time, undefined)
+      }
+    }
+  })
+  instance.info('hello world')
+  end()
+})


### PR DESCRIPTION
This PR makes `timestamp` option work in the same way as the node.js environment.

https://github.com/pinojs/pino/issues/903