### PR TITLE
integrate fast-redact v3

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -153,7 +153,7 @@ Each path must be a string using a syntax which corresponds to JavaScript dot an
 If an object is supplied, three options can be specified:
   * `paths` (array): Required. An array of paths. See [redaction - Path Syntax ⇗](/docs/redaction.md#paths) for specifics.
   * `censor` (String|Function|Undefined): Optional. When supplied as a String the `censor` option will overwrite keys which are to be redacted. When set to `undefined` the the key will be removed entirely from the object.
-    The `censor` option may also be a mapping function. The (synchronous) mapping function is called with the unredacted value. The value returned from the mapping function becomes the applied censor value. Default: `'[Redacted]'`
+    The `censor` option may also be a mapping function. The (synchronous) mapping function has the signature `(value, path) => redactedValue` and is called with the unredacted `value` and `path` to the key being redacted, as an array. For example given a redaction path of `a.b.c` the `path` argument would be `['a', 'b', 'c']`. The value returned from the mapping function becomes the applied censor value. Default: `'[Redacted]'`
     value synchronously.
     Default: `'[Redacted]'`
   * `remove` (Boolean): Optional. Instead of censoring the value, remove both the key and the value. Default: `false`

--- a/lib/redaction.js
+++ b/lib/redaction.js
@@ -81,8 +81,19 @@ function redaction (opts, serialize) {
 
   return [...Object.keys(shape), ...Object.getOwnPropertySymbols(shape)].reduce((o, k) => {
     // top level key:
-    if (shape[k] === null) o[k] = topCensor
-    else o[k] = fastRedact({ paths: shape[k], censor, serialize, strict })
+    if (shape[k] === null) {
+      o[k] = topCensor
+    } else {
+      const wrappedCensor = typeof censor === 'function' ? (value, path) => {
+        return censor(value, [k, ...path])
+      } : censor
+      o[k] = fastRedact({
+        paths: shape[k],
+        censor: wrappedCensor,
+        serialize,
+        strict
+      })
+    }
     return o
   }, result)
 }

--- a/lib/redaction.js
+++ b/lib/redaction.js
@@ -76,13 +76,14 @@ function redaction (opts, serialize) {
     [redactFmtSym]: fastRedact({ paths, censor, serialize, strict })
   }
 
-  const topCensor = (...args) =>
-    typeof censor === 'function' ? serialize(censor(...args)) : serialize(censor)
+  const topCensor = (...args) => {
+    return typeof censor === 'function' ? serialize(censor(...args)) : serialize(censor)
+  }
 
   return [...Object.keys(shape), ...Object.getOwnPropertySymbols(shape)].reduce((o, k) => {
     // top level key:
     if (shape[k] === null) {
-      o[k] = topCensor
+      o[k] = (value) => topCensor(value, [k])
     } else {
       const wrappedCensor = typeof censor === 'function' ? (value, path) => {
         return censor(value, [k, ...path])

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "winston": "^3.3.3"
   },
   "dependencies": {
-    "fast-redact": "^2.0.0",
+    "fast-redact": "^3.0.0",
     "fast-safe-stringify": "^2.0.7",
     "flatstr": "^1.0.12",
     "pino-std-serializers": "^2.4.2",

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -219,6 +219,27 @@ test('redact.censor option – sets the redact value', async ({ is }) => {
   is(req.headers.cookie, 'test')
 })
 
+test('redact.censor option – can be a function that accepts value and path arguments', async ({ is }) => {
+  const stream = sink()
+  const instance = pino({ redact: { paths: ['req.headers.cookie'], censor: (value, path) => value + ' ' + path.join('.') } }, stream)
+  instance.info({
+    req: {
+      id: 7915,
+      method: 'GET',
+      url: '/',
+      headers: {
+        host: 'localhost:3000',
+        connection: 'keep-alive',
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      },
+      remoteAddress: '::ffff:127.0.0.1',
+      remotePort: 58022
+    }
+  })
+  const { req } = await once(stream, 'data')
+  is(req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1; req.headers.cookie')
+})
+
 test('redact.remove option – removes both key and value', async ({ is }) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'], remove: true } }, stream)

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -221,6 +221,16 @@ test('redact.censor option – sets the redact value', async ({ is }) => {
 
 test('redact.censor option – can be a function that accepts value and path arguments', async ({ is }) => {
   const stream = sink()
+  const instance = pino({ redact: { paths: ['topLevel'], censor: (value, path) => value + ' ' + path.join('.') } }, stream)
+  instance.info({
+    topLevel: 'test'
+  })
+  const { topLevel } = await once(stream, 'data')
+  is(topLevel, 'test topLevel')
+})
+
+test('redact.censor option – can be a function that accepts value and path arguments (nested path)', async ({ is }) => {
+  const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'], censor: (value, path) => value + ' ' + path.join('.') } }, stream)
   instance.info({
     req: {


### PR DESCRIPTION
* fast redact bumped up to v3.0.0
* test added for new `path` argument in `censor` function
* updated documentation
* modified `lib/redaction.js` so that the `path` argument contains top level key e.g. given a path `req.headers.cookie` `req` would not be part of `path` without these changes e.g. `['headers', 'cookie']` instead of `['req', 'headers', 'cookie']`

## Benchmark for master
```

> pino@6.6.1 bench /Users/alexmalin/beepboop/pino
> node benchmarks/utils/runbench all

Running BASIC benchmark

benchBunyan*10000: 844.948ms
benchWinston*10000: 822.856ms
benchBole*10000: 380.772ms
benchDebug*10000: 477.877ms
benchLogLevel*10000: 465.569ms
benchPino*10000: 358.172ms
benchPinoAsync*10000: 151.204ms
benchPinoNodeStream*10000: 492.985ms
benchBunyan*10000: 609.326ms
benchWinston*10000: 576.504ms
benchBole*10000: 300.278ms
benchDebug*10000: 448.624ms
benchLogLevel*10000: 485.005ms
benchPino*10000: 332.619ms
benchPinoAsync*10000: 143.967ms
benchPinoNodeStream*10000: 310.750ms

Running OBJECT benchmark

benchBunyanObj*10000: 803.785ms
benchWinstonObj*10000: 768.723ms
benchBoleObj*10000: 413.841ms
benchLogLevelObject*10000: 718.605ms
benchPinoObj*10000: 357.740ms
benchPinoAsyncObj*10000: 163.390ms
benchPinoNodeStreamObj*10000: 399.159ms
benchBunyanObj*10000: 672.353ms
benchWinstonObj*10000: 584.082ms
benchBoleObj*10000: 437.275ms
benchLogLevelObject*10000: 783.554ms
benchPinoObj*10000: 337.523ms
benchPinoAsyncObj*10000: 152.027ms
benchPinoNodeStreamObj*10000: 356.815ms

Running DEEP-OBJECT benchmark

benchBunyanDeepObj*10000: 2206.153ms
benchWinstonDeepObj*10000: 3634.311ms
benchBoleDeepObj*10000: 3086.550ms
benchLogLevelDeepObj*10000: 8491.611ms
benchPinoDeepObj*10000: 3438.069ms
benchPinoAsyncDeepObj*10000: 3246.342ms
benchPinoNodeStreamDeepObj*10000: 3534.601ms
benchBunyanDeepObj*10000: 2123.977ms
benchWinstonDeepObj*10000: 3372.812ms
benchBoleDeepObj*10000: 3044.212ms
benchLogLevelDeepObj*10000: 8254.458ms
benchPinoDeepObj*10000: 3385.819ms
benchPinoAsyncDeepObj*10000: 3276.301ms
benchPinoNodeStreamDeepObj*10000: 3543.163ms

Running MULTI-ARG benchmark

benchBunyanInterpolate*10000: 700.545ms
benchWinstonInterpolate*10000: 808.580ms
benchBoleInterpolate*10000: 299.351ms
benchPinoInterpolate*10000: 390.379ms
benchPinoAsyncInterpolate*10000: 222.390ms
benchPinoNodeStreamInterpolate*10000: 433.064ms
benchBunyanInterpolateAll*10000: 781.685ms
benchWinstonInterpolateAll*10000: 588.903ms
benchBoleInterpolateAll*10000: 475.171ms
benchPinoInterpolateAll*10000: 507.815ms
benchPinoAsyncInterpolateAll*10000: 281.674ms
benchPinoNodeStreamInterpolateAll*10000: 475.312ms
benchBunyanInterpolateExtra*10000: 1110.482ms
benchWinstonInterpolateExtra*10000: 617.635ms
benchBoleInterpolateExtra*10000: 685.264ms
benchPinoInterpolateExtra*10000: 462.420ms
benchPinoAsyncInterpolateExtra*10000: 247.581ms
benchPinoNodeStreamInterpolateExtra*10000: 416.628ms
benchBunyanInterpolateDeep*10000: 15971.974ms
benchWinstonInterpolateDeep*10000: 632.734ms
benchBoleInterpolateDeep*10000: 15531.228ms
benchPinoInterpolateDeep*10000: 14663.226ms
benchPinoAsyncInterpolateDeep*10000: 15982.998ms
benchPinoNodeStreamInterpolateDeep*10000: 15673.247ms
benchBunyanInterpolate*10000: 768.152ms
benchWinstonInterpolate*10000: 581.080ms
benchBoleInterpolate*10000: 370.911ms
benchPinoInterpolate*10000: 333.854ms
benchPinoAsyncInterpolate*10000: 157.033ms
benchPinoNodeStreamInterpolate*10000: 369.549ms
benchBunyanInterpolateAll*10000: 842.878ms
benchWinstonInterpolateAll*10000: 715.919ms
benchBoleInterpolateAll*10000: 433.404ms
benchPinoInterpolateAll*10000: 461.988ms
benchPinoAsyncInterpolateAll*10000: 273.706ms
benchPinoNodeStreamInterpolateAll*10000: 468.229ms
benchBunyanInterpolateExtra*10000: 941.428ms
benchWinstonInterpolateExtra*10000: 534.768ms
benchBoleInterpolateExtra*10000: 643.587ms
benchPinoInterpolateExtra*10000: 468.973ms
benchPinoAsyncInterpolateExtra*10000: 297.243ms
benchPinoNodeStreamInterpolateExtra*10000: 452.582ms
benchBunyanInterpolateDeep*10000: 16158.433ms
benchWinstonInterpolateDeep*10000: 621.860ms
benchBoleInterpolateDeep*10000: 15479.769ms
benchPinoInterpolateDeep*10000: 14497.161ms
benchPinoAsyncInterpolateDeep*10000: 15950.447ms
benchPinoNodeStreamInterpolateDeep*10000: 15579.050ms

Running LONG-STRING benchmark

benchBunyan*1000: 407.063ms
benchWinston*1000: 506.124ms
benchBole*1000: 318.469ms
benchPino*1000: 272.611ms
benchPinoAsync*1000: 266.449ms
benchPinoNodeStream*1000: 300.591ms
benchBunyan*1000: 346.199ms
benchWinston*1000: 334.544ms
benchBole*1000: 286.142ms
benchPino*1000: 242.867ms
benchPinoAsync*1000: 249.373ms
benchPinoNodeStream*1000: 287.103ms

Running CHILD benchmark

benchBunyanChild*10000: 840.019ms
benchBoleChild*10000: 409.322ms
benchPinoChild*10000: 340.360ms
benchPinoAssyncChild*10000: 185.373ms
benchPinoNodeStreamChild*10000: 311.129ms
benchBunyanChild*10000: 702.736ms
benchBoleChild*10000: 372.883ms
benchPinoChild*10000: 317.843ms
benchPinoAssyncChild*10000: 157.442ms
benchPinoNodeStreamChild*10000: 350.028ms

Running CHILD-CHILD benchmark

benchBunyanChildChild*10000: 642.138ms
benchPinoChildChild*10000: 285.330ms
benchPinoAsyncChildChild*10000: 101.095ms
benchPinoNodeStreamChildChild*10000: 335.937ms
benchBunyanChildChild*10000: 526.424ms
benchPinoChildChild*10000: 251.370ms
benchPinoAsyncChildChild*10000: 115.912ms
benchPinoNodeStreamChildChild*10000: 259.831ms

Running CHILD-CREATION benchmark

benchBunyanCreation*10000: 608.303ms
benchBoleCreation*10000: 349.223ms
benchPinoCreation*10000: 301.260ms
benchPinoAsyncCreation*10000: 144.804ms
benchPinoNodeStreamCreation*10000: 381.837ms
benchBunyanCreation*10000: 792.511ms
benchBoleCreation*10000: 333.019ms
benchPinoCreation*10000: 347.596ms
benchPinoAsyncCreation*10000: 146.168ms
benchPinoNodeStreamCreation*10000: 375.369ms

Running FORMATTERS benchmark

benchPinoNoFormatters*10000: 375.098ms
benchPinoFormatters*10000: 409.970ms
benchPinoNoFormatters*10000: 367.792ms
benchPinoFormatters*10000: 404.872ms

==========
BASIC benchmark averages
Bunyan average: 727.137ms
Winston average: 699.680ms
Bole average: 340.525ms
Debug average: 463.250ms
LogLevel average: 475.287ms
Pino average: 345.396ms
PinoAsync average: 147.586ms
PinoNodeStream average: 401.868ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
OBJECT benchmark averages
BunyanObj average: 738.069ms
WinstonObj average: 676.402ms
BoleObj average: 425.558ms
LogLevelObject average: 751.080ms
PinoObj average: 347.632ms
PinoAsyncObj average: 157.708ms
PinoNodeStreamObj average: 377.987ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
DEEP-OBJECT benchmark averages
BunyanDeepObj average: 2165.065ms
WinstonDeepObj average: 3503.561ms
BoleDeepObj average: 3065.381ms
LogLevelDeepObj average: 8373.035ms
PinoDeepObj average: 3411.944ms
PinoAsyncDeepObj average: 3261.322ms
PinoNodeStreamDeepObj average: 3538.882ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
MULTI-ARG benchmark averages
BunyanInterpolate average: 734.349ms
WinstonInterpolate average: 694.830ms
BoleInterpolate average: 335.131ms
PinoInterpolate average: 362.116ms
PinoAsyncInterpolate average: 189.712ms
PinoNodeStreamInterpolate average: 401.307ms
BunyanInterpolateAll average: 812.282ms
WinstonInterpolateAll average: 652.411ms
BoleInterpolateAll average: 454.288ms
PinoInterpolateAll average: 484.901ms
PinoAsyncInterpolateAll average: 277.690ms
PinoNodeStreamInterpolateAll average: 471.770ms
BunyanInterpolateExtra average: 1025.955ms
WinstonInterpolateExtra average: 576.202ms
BoleInterpolateExtra average: 664.426ms
PinoInterpolateExtra average: 465.697ms
PinoAsyncInterpolateExtra average: 272.412ms
PinoNodeStreamInterpolateExtra average: 434.605ms
BunyanInterpolateDeep average: 16065.203ms
WinstonInterpolateDeep average: 627.297ms
BoleInterpolateDeep average: 15505.498ms
PinoInterpolateDeep average: 14580.194ms
PinoAsyncInterpolateDeep average: 15966.722ms
PinoNodeStreamInterpolateDeep average: 15626.148ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
LONG-STRING benchmark averages
Bunyan average: 376.631ms
Winston average: 420.334ms
Bole average: 302.305ms
Pino average: 257.739ms
PinoAsync average: 257.911ms
PinoNodeStream average: 293.847ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
CHILD benchmark averages
BunyanChild average: 771.378ms
BoleChild average: 391.102ms
PinoChild average: 329.101ms
PinoAssyncChild average: 171.407ms
PinoNodeStreamChild average: 330.579ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
CHILD-CHILD benchmark averages
BunyanChildChild average: 584.281ms
PinoChildChild average: 268.350ms
PinoAsyncChildChild average: 108.504ms
PinoNodeStreamChildChild average: 297.884ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
CHILD-CREATION benchmark averages
BunyanCreation average: 700.407ms
BoleCreation average: 341.121ms
PinoCreation average: 324.428ms
PinoAsyncCreation average: 145.486ms
PinoNodeStreamCreation average: 378.603ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
FORMATTERS benchmark averages
PinoNoFormatters average: 371.445ms
PinoFormatters average: 407.421ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)

```
## Benchmark for this branch
```

> pino@6.6.1 bench /Users/alexmalin/beepboop/pino
> node benchmarks/utils/runbench all

Running BASIC benchmark

benchBunyan*10000: 666.838ms
benchWinston*10000: 899.984ms
benchBole*10000: 357.332ms
benchDebug*10000: 468.993ms
benchLogLevel*10000: 414.724ms
benchPino*10000: 351.060ms
benchPinoAsync*10000: 165.568ms
benchPinoNodeStream*10000: 365.240ms
benchBunyan*10000: 616.949ms
benchWinston*10000: 605.973ms
benchBole*10000: 223.002ms
benchDebug*10000: 328.783ms
benchLogLevel*10000: 360.066ms
benchPino*10000: 313.188ms
benchPinoAsync*10000: 135.091ms
benchPinoNodeStream*10000: 335.693ms

Running OBJECT benchmark

benchBunyanObj*10000: 768.215ms
benchWinstonObj*10000: 675.630ms
benchBoleObj*10000: 355.997ms
benchLogLevelObject*10000: 688.747ms
benchPinoObj*10000: 344.569ms
benchPinoAsyncObj*10000: 127.892ms
benchPinoNodeStreamObj*10000: 288.542ms
benchBunyanObj*10000: 681.758ms
benchWinstonObj*10000: 627.758ms
benchBoleObj*10000: 359.814ms
benchLogLevelObject*10000: 727.941ms
benchPinoObj*10000: 331.361ms
benchPinoAsyncObj*10000: 150.302ms
benchPinoNodeStreamObj*10000: 263.929ms

Running DEEP-OBJECT benchmark

benchBunyanDeepObj*10000: 2210.586ms
benchWinstonDeepObj*10000: 3660.742ms
benchBoleDeepObj*10000: 3079.373ms
benchLogLevelDeepObj*10000: 8452.019ms
benchPinoDeepObj*10000: 3456.505ms
benchPinoAsyncDeepObj*10000: 3347.338ms
benchPinoNodeStreamDeepObj*10000: 3621.611ms
benchBunyanDeepObj*10000: 2160.379ms
benchWinstonDeepObj*10000: 3441.786ms
benchBoleDeepObj*10000: 2960.748ms
benchLogLevelDeepObj*10000: 8404.014ms
benchPinoDeepObj*10000: 3442.866ms
benchPinoAsyncDeepObj*10000: 3268.291ms
benchPinoNodeStreamDeepObj*10000: 3764.560ms

Running MULTI-ARG benchmark

benchBunyanInterpolate*10000: 808.243ms
benchWinstonInterpolate*10000: 729.551ms
benchBoleInterpolate*10000: 367.836ms
benchPinoInterpolate*10000: 385.607ms
benchPinoAsyncInterpolate*10000: 196.141ms
benchPinoNodeStreamInterpolate*10000: 266.772ms
benchBunyanInterpolateAll*10000: 795.133ms
benchWinstonInterpolateAll*10000: 524.998ms
benchBoleInterpolateAll*10000: 426.067ms
benchPinoInterpolateAll*10000: 472.470ms
benchPinoAsyncInterpolateAll*10000: 273.381ms
benchPinoNodeStreamInterpolateAll*10000: 509.138ms
benchBunyanInterpolateExtra*10000: 968.728ms
benchWinstonInterpolateExtra*10000: 565.918ms
benchBoleInterpolateExtra*10000: 698.152ms
benchPinoInterpolateExtra*10000: 475.882ms
benchPinoAsyncInterpolateExtra*10000: 265.088ms
benchPinoNodeStreamInterpolateExtra*10000: 516.444ms
benchBunyanInterpolateDeep*10000: 15861.773ms
benchWinstonInterpolateDeep*10000: 652.305ms
benchBoleInterpolateDeep*10000: 15584.875ms
benchPinoInterpolateDeep*10000: 14496.247ms
benchPinoAsyncInterpolateDeep*10000: 16030.237ms
benchPinoNodeStreamInterpolateDeep*10000: 15520.141ms
benchBunyanInterpolate*10000: 688.174ms
benchWinstonInterpolate*10000: 652.224ms
benchBoleInterpolate*10000: 243.882ms
benchPinoInterpolate*10000: 337.570ms
benchPinoAsyncInterpolate*10000: 151.719ms
benchPinoNodeStreamInterpolate*10000: 469.280ms
benchBunyanInterpolateAll*10000: 697.146ms
benchWinstonInterpolateAll*10000: 607.054ms
benchBoleInterpolateAll*10000: 368.549ms
benchPinoInterpolateAll*10000: 586.771ms
benchPinoAsyncInterpolateAll*10000: 389.092ms
benchPinoNodeStreamInterpolateAll*10000: 667.880ms
benchBunyanInterpolateExtra*10000: 1031.530ms
benchWinstonInterpolateExtra*10000: 612.001ms
benchBoleInterpolateExtra*10000: 573.832ms
benchPinoInterpolateExtra*10000: 459.795ms
benchPinoAsyncInterpolateExtra*10000: 254.851ms
benchPinoNodeStreamInterpolateExtra*10000: 549.937ms
benchBunyanInterpolateDeep*10000: 15950.191ms
benchWinstonInterpolateDeep*10000: 613.779ms
benchBoleInterpolateDeep*10000: 15514.672ms
benchPinoInterpolateDeep*10000: 14301.253ms
benchPinoAsyncInterpolateDeep*10000: 16253.126ms
benchPinoNodeStreamInterpolateDeep*10000: 15459.443ms

Running LONG-STRING benchmark

benchBunyan*1000: 477.267ms
benchWinston*1000: 533.691ms
benchBole*1000: 376.286ms
benchPino*1000: 308.042ms
benchPinoAsync*1000: 295.645ms
benchPinoNodeStream*1000: 319.019ms
benchBunyan*1000: 343.026ms
benchWinston*1000: 329.938ms
benchBole*1000: 353.410ms
benchPino*1000: 258.765ms
benchPinoAsync*1000: 250.023ms
benchPinoNodeStream*1000: 330.469ms

Running CHILD benchmark

benchBunyanChild*10000: 739.381ms
benchBoleChild*10000: 402.233ms
benchPinoChild*10000: 340.185ms
benchPinoAssyncChild*10000: 200.274ms
benchPinoNodeStreamChild*10000: 437.021ms
benchBunyanChild*10000: 691.251ms
benchBoleChild*10000: 349.443ms
benchPinoChild*10000: 324.989ms
benchPinoAssyncChild*10000: 186.757ms
benchPinoNodeStreamChild*10000: 336.107ms

Running CHILD-CHILD benchmark

benchBunyanChildChild*10000: 872.446ms
benchPinoChildChild*10000: 394.926ms
benchPinoAsyncChildChild*10000: 169.525ms
benchPinoNodeStreamChildChild*10000: 435.490ms
benchBunyanChildChild*10000: 730.524ms
benchPinoChildChild*10000: 348.002ms
benchPinoAsyncChildChild*10000: 175.538ms
benchPinoNodeStreamChildChild*10000: 344.925ms

Running CHILD-CREATION benchmark

benchBunyanCreation*10000: 852.313ms
benchBoleCreation*10000: 341.199ms
benchPinoCreation*10000: 384.252ms
benchPinoAsyncCreation*10000: 204.223ms
benchPinoNodeStreamCreation*10000: 472.175ms
benchBunyanCreation*10000: 780.142ms
benchBoleCreation*10000: 394.109ms
benchPinoCreation*10000: 370.345ms
benchPinoAsyncCreation*10000: 149.815ms
benchPinoNodeStreamCreation*10000: 394.269ms

Running FORMATTERS benchmark

benchPinoNoFormatters*10000: 390.732ms
benchPinoFormatters*10000: 439.773ms
benchPinoNoFormatters*10000: 348.173ms
benchPinoFormatters*10000: 404.922ms

==========
BASIC benchmark averages
Bunyan average: 641.893ms
Winston average: 752.978ms
Bole average: 290.167ms
Debug average: 398.888ms
LogLevel average: 387.395ms
Pino average: 332.124ms
PinoAsync average: 150.329ms
PinoNodeStream average: 350.466ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
OBJECT benchmark averages
BunyanObj average: 724.986ms
WinstonObj average: 651.694ms
BoleObj average: 357.906ms
LogLevelObject average: 708.344ms
PinoObj average: 337.965ms
PinoAsyncObj average: 139.097ms
PinoNodeStreamObj average: 276.236ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
DEEP-OBJECT benchmark averages
BunyanDeepObj average: 2185.483ms
WinstonDeepObj average: 3551.264ms
BoleDeepObj average: 3020.061ms
LogLevelDeepObj average: 8428.016ms
PinoDeepObj average: 3449.686ms
PinoAsyncDeepObj average: 3307.815ms
PinoNodeStreamDeepObj average: 3693.086ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
MULTI-ARG benchmark averages
BunyanInterpolate average: 748.208ms
WinstonInterpolate average: 690.888ms
BoleInterpolate average: 305.859ms
PinoInterpolate average: 361.589ms
PinoAsyncInterpolate average: 173.930ms
PinoNodeStreamInterpolate average: 368.026ms
BunyanInterpolateAll average: 746.139ms
WinstonInterpolateAll average: 566.026ms
BoleInterpolateAll average: 397.308ms
PinoInterpolateAll average: 529.620ms
PinoAsyncInterpolateAll average: 331.236ms
PinoNodeStreamInterpolateAll average: 588.509ms
BunyanInterpolateExtra average: 1000.129ms
WinstonInterpolateExtra average: 588.959ms
BoleInterpolateExtra average: 635.992ms
PinoInterpolateExtra average: 467.839ms
PinoAsyncInterpolateExtra average: 259.970ms
PinoNodeStreamInterpolateExtra average: 533.190ms
BunyanInterpolateDeep average: 15905.982ms
WinstonInterpolateDeep average: 633.042ms
BoleInterpolateDeep average: 15549.773ms
PinoInterpolateDeep average: 14398.750ms
PinoAsyncInterpolateDeep average: 16141.681ms
PinoNodeStreamInterpolateDeep average: 15489.792ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
LONG-STRING benchmark averages
Bunyan average: 410.147ms
Winston average: 431.815ms
Bole average: 364.848ms
Pino average: 283.404ms
PinoAsync average: 272.834ms
PinoNodeStream average: 324.744ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
CHILD benchmark averages
BunyanChild average: 715.316ms
BoleChild average: 375.838ms
PinoChild average: 332.587ms
PinoAssyncChild average: 193.516ms
PinoNodeStreamChild average: 386.564ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
CHILD-CHILD benchmark averages
BunyanChildChild average: 801.485ms
PinoChildChild average: 371.464ms
PinoAsyncChildChild average: 172.531ms
PinoNodeStreamChildChild average: 390.207ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
CHILD-CREATION benchmark averages
BunyanCreation average: 816.227ms
BoleCreation average: 367.654ms
PinoCreation average: 377.298ms
PinoAsyncCreation average: 177.019ms
PinoNodeStreamCreation average: 433.222ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)
==========
FORMATTERS benchmark averages
PinoNoFormatters average: 369.452ms
PinoFormatters average: 422.348ms
==========
System: Darwin/darwin x64 18.7.0 ~ Intel(R) Core(TM) i7-6567U CPU @ 3.30GHz (cores/threads: 4)

```