### PR TITLE
pass merging object to mixins

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -99,7 +99,7 @@ logger.info('hello') // Will throw an error saying info in not found in logger o
 Default: `undefined`
 
 If provided, the `mixin` function is called each time one of the active
-logging methods is called. The function must synchronously return an
+logging methods is called. The first and only parameter is the value `mergeObject` or an empty object. The function must synchronously return an
 object. The properties of the returned object will be added to the
 logged JSON.
 
@@ -124,7 +124,7 @@ const mixin = {
 }
 
 const logger = pino({
-    mixin() {
+    mixin({ description }) {
         return mixin
     }
 })

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -147,9 +147,9 @@ function write (_obj, msg, num) {
   var obj
 
   if (_obj === undefined || _obj === null) {
-    obj = mixin ? mixin() : {}
+    obj = mixin ? mixin({}) : {}
   } else {
-    obj = Object.assign(mixin ? mixin() : {}, _obj)
+    obj = Object.assign(mixin ? mixin(_obj) : {}, _obj)
     if (!msg && objError) {
       msg = _obj.message
     }

--- a/test/mixin.test.js
+++ b/test/mixin.test.js
@@ -106,7 +106,7 @@ test('mixin can use context', async ({ ok }) => {
   const stream = sink()
   const instance = pino({
     mixin (context) {
-      ok(context !== null, 'context should be defined')
+      ok(context !== null && context !== undefined, 'context should be defined')
       return Object.assign({
         error: context.message,
         stack: context.stack
@@ -124,7 +124,7 @@ test('mixin works without context', async ({ ok }) => {
   const stream = sink()
   const instance = pino({
     mixin (context) {
-      ok(context !== null, 'context is still defined w/o passing mergeObject')
+      ok(context !== null && context !== undefined, 'context is still defined w/o passing mergeObject')
 
       return {
         something: true

--- a/test/mixin.test.js
+++ b/test/mixin.test.js
@@ -101,3 +101,36 @@ test('mixin not a function', async ({ throws }) => {
     pino({ mixin: 'not a function' }, stream)
   })
 })
+
+test('mixin can use context', async ({ ok }) => {
+  const stream = sink()
+  const instance = pino({
+    mixin (context) {
+      ok(context !== null, 'context should be defined')
+      return Object.assign({
+        error: context.message,
+        stack: context.stack
+      })
+    }
+  }, stream)
+  instance.level = name
+  instance[name]({
+    message: '123',
+    stack: 'stack'
+  }, 'test')
+})
+
+test('mixin works without context', async ({ ok }) => {
+  const stream = sink()
+  const instance = pino({
+    mixin (context) {
+      ok(context !== null, 'context is still defined w/o passing mergeObject')
+
+      return {
+        something: true
+      }
+    }
+  }, stream)
+  instance.level = name
+  instance[name]('test')
+})


### PR DESCRIPTION
Allows for mixins to take in an object and add information contextually. 

For instance, if your `mergingObject` has an `error` key (a [JS Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)), I want to add `{ message: error.message, stack: error.stack }`. This will make mixins more useful or having to pull from higher in the scope. 