### PR TITLE
address destructuring mergeObject in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -124,8 +124,10 @@ const mixin = {
 }
 
 const logger = pino({
-    mixin({ description }) {
-        return mixin
+    mixin(obj) {
+        return {
+          description: obj.description
+        }
     }
 })
 


### PR DESCRIPTION
Follow-on to https://github.com/pinojs/pino/pull/926 to address [this comment](https://github.com/pinojs/pino/pull/926#discussion_r523279100) by @mcollina: 

> let's name the paramenter obj, without destructuring

