### PR TITLE
doc: fix wrong link to logger.level

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -15,7 +15,7 @@
   * [logger.child()](#child)
   * [logger.bindings()](#bindings)
   * [logger.flush()](#flush)
-  * [logger.level](#level)
+  * [logger.level](#logger-level)
   * [logger.isLevelEnabled()](#islevelenabled)
   * [logger.levels](#levels)
   * [logger\[Symbol.for('pino.serializers')\]](#serializers)
@@ -705,7 +705,7 @@ and safer logging at low demand periods.
 * See [`destination` parameter](#destination)
 * See [Asynchronous Logging ⇗](/docs/asynchronous.md)
 
-<a id="level"></a>
+<a id="logger-level"></a>
 ### `logger.level` (String) [Getter/Setter]
 
 Set this property to the desired logging level.


### PR DESCRIPTION
Link was pointing to the `level` hook instead of the `level` instance property.