### PR TITLE
[ WIP ] pinole integration, next gen transports

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -3,7 +3,7 @@
 /* eslint no-prototype-builtins: 0 */
 
 const { EventEmitter } = require('events')
-const SonicBoom = require('sonic-boom')
+const pinole = require('pinole')
 const flatstr = require('flatstr')
 const {
   lsCacheSym,
@@ -169,7 +169,7 @@ function write (_obj, msg, num) {
     stream.lastTime = t.slice(this[timeSliceIndexSym])
     stream.lastLogger = this // for child loggers
   }
-  if (stream instanceof SonicBoom) stream.write(s)
+  if (stream[pinole.symbols.kPinole]) stream.write(s)
   else stream.write(flatstr(s))
 }
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -4,7 +4,7 @@
 
 const format = require('quick-format-unescaped')
 const { mapHttpRequest, mapHttpResponse } = require('pino-std-serializers')
-const SonicBoom = require('sonic-boom')
+const pinole = require('pinole')
 const stringifySafe = require('fast-safe-stringify')
 const {
   lsCacheSym,
@@ -291,8 +291,8 @@ function hasBeenTampered (stream) {
   return stream.write !== stream.constructor.prototype.write
 }
 
-function buildSafeSonicBoom (opts) {
-  const stream = new SonicBoom(opts)
+function buildSafePinole (opts) {
+  const stream = pinole(opts)
   stream.on('error', filterBrokenPipe)
   return stream
 
@@ -301,7 +301,7 @@ function buildSafeSonicBoom (opts) {
     if (err.code === 'EPIPE') {
       // If we get EPIPE, we should stop logging here
       // however we have no control to the consumer of
-      // SonicBoom, so we just overwrite the write method
+      // pinole, so we just overwrite the write method
       stream.write = noop
       stream.end = noop
       stream.flushSync = noop
@@ -317,11 +317,11 @@ function createArgsNormalizer (defaultOptions) {
   return function normalizeArgs (instance, opts = {}, stream) {
     // support stream as a string
     if (typeof opts === 'string') {
-      stream = buildSafeSonicBoom({ dest: opts, sync: true })
+      stream = buildSafePinole({ dest: opts, sync: true })
       opts = {}
     } else if (typeof stream === 'string') {
-      stream = buildSafeSonicBoom({ dest: stream, sync: true })
-    } else if (opts instanceof SonicBoom || opts.writable || opts._writableState) {
+      stream = buildSafePinole({ dest: stream, sync: true })
+    } else if (opts[pinole.symbols.kPinole] || opts.writable || opts._writableState) {
       stream = opts
       opts = null
     }
@@ -345,7 +345,7 @@ function createArgsNormalizer (defaultOptions) {
     if (enabled === false) opts.level = 'silent'
     stream = stream || process.stdout
     if (stream === process.stdout && stream.fd >= 0 && !hasBeenTampered(stream)) {
-      stream = buildSafeSonicBoom({ fd: stream.fd, sync: true })
+      stream = buildSafePinole({ fd: stream.fd, sync: true })
     }
     if (prettyPrint) {
       const prettyOpts = Object.assign({ messageKey }, prettyPrint)
@@ -425,7 +425,7 @@ function setMetadataProps (dest, that) {
 
 module.exports = {
   noop,
-  buildSafeSonicBoom,
+  buildSafePinole,
   getPrettyStream,
   asChindings,
   asJson,

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "pump": "^3.0.0",
     "semver": "^7.0.0",
     "snazzy": "^8.0.0",
+    "sonic-boom": "^1.3.0",
     "split2": "^3.1.1",
     "standard": "^14.3.3",
     "steed": "^1.1.3",
@@ -89,7 +90,7 @@
     "fast-safe-stringify": "^2.0.7",
     "flatstr": "^1.0.12",
     "pino-std-serializers": "^2.4.2",
-    "quick-format-unescaped": "^4.0.1",
-    "sonic-boom": "^1.0.2"
+    "pinole": "0.0.0",
+    "quick-format-unescaped": "^4.0.1"
   }
 }

--- a/pino.js
+++ b/pino.js
@@ -12,7 +12,7 @@ const {
   asChindings,
   final,
   stringify,
-  buildSafeSonicBoom,
+  buildSafePinole,
   buildFormatters,
   noop
 } = require('./lib/tools')
@@ -202,15 +202,30 @@ module.exports.extreme = (dest = process.stdout.fd) => {
     'The pino.extreme() option is deprecated and will be removed in v7. Use pino.destination({ sync: false }) instead.',
     { code: 'extreme_deprecation' }
   )
-  return buildSafeSonicBoom({ dest, minLength: 4096, sync: false })
+  return buildSafePinole({ dest, minLength: 4096, sync: false })
 }
 
 module.exports.destination = (dest = process.stdout.fd) => {
   if (typeof dest === 'object') {
     dest.dest = dest.dest || process.stdout.fd
-    return buildSafeSonicBoom(dest)
+    return buildSafePinole(dest)
   } else {
-    return buildSafeSonicBoom({ dest, minLength: 0, sync: true })
+    return buildSafePinole({ dest, minLength: 0, sync: true })
+  }
+}
+
+module.exports.transport = (transport, opts = {}) => {
+  if (typeof transport === 'object') {
+    opts = transport
+    if (typeof opts.transport !== 'string') {
+      throw Error('transport must be a string and must be specified')
+    }
+    return buildSafePinole(opts)
+  } else {
+    if (typeof transport !== 'string') {
+      throw Error('transport must be a string and must be specified')
+    }
+    return buildSafePinole({ ...opts, transport })
   }
 }
 

--- a/test/fixtures/basic-transport.mjs
+++ b/test/fixtures/basic-transport.mjs
@@ -1,0 +1,9 @@
+import SonicBoom from 'sonic-boom'
+
+export default (opts = { fd: 1 }) => {
+  if (!opts.dest && !opts.fd) opts.fd = 1
+  const sonic = new SonicBoom(opts)
+  return (data) => {
+    sonic.write(data, 0, true)
+  }
+}

--- a/test/fixtures/legacy-transport-consumers/natural-flush.js
+++ b/test/fixtures/legacy-transport-consumers/natural-flush.js
@@ -1,0 +1,4 @@
+const pino = require('./../../..')
+const instance = pino(pino.transport('legacy-transport'))
+instance.info('hello')
+setTimeout(() => {}, 100) // breathing time

--- a/test/fixtures/legacy-transport-consumers/sync-flush.js
+++ b/test/fixtures/legacy-transport-consumers/sync-flush.js
@@ -1,0 +1,7 @@
+const pino = require('./../../..')
+const tp = pino.transport('legacy-transport')
+const instance = pino(tp)
+instance.info('hello')
+process.on('exit', () => {
+  tp.flushSync()
+})

--- a/test/fixtures/legacy-transport/cmd.js
+++ b/test/fixtures/legacy-transport/cmd.js
@@ -1,0 +1,10 @@
+'use strict'
+const { Transform } = require('stream')
+const transform = new Transform({
+  transform (chunk, enc, cb) {
+    const { level, msg } = JSON.parse(chunk)
+    cb(null, `${level}:${msg}`)
+  }
+})
+process.stdin.pipe(transform)
+transform.pipe(process.stdout)

--- a/test/fixtures/legacy-transport/package.json
+++ b/test/fixtures/legacy-transport/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "legacy-transport",
+  "version": "1.0.0",
+  "bin": "cmd.js"
+}

--- a/test/transports.test.js
+++ b/test/transports.test.js
@@ -1,0 +1,77 @@
+'use strict'
+const os = require('os')
+const { join } = require('path')
+const { readFileSync } = require('fs')
+const { spawnSync } = require('child_process')
+const { test, teardown, comment } = require('tap')
+const { watchFileCreated } = require('./helper')
+const pino = require('../')
+
+const { pid } = process
+const hostname = os.hostname()
+
+const basicTransport = require.resolve('./fixtures/basic-transport.mjs')
+
+spawnSync('npm', ['link', join(__dirname, 'fixtures', 'legacy-transport')])
+teardown(() => {
+  comment('teardown commencing, might take a little while')
+  spawnSync('npm', ['unlink', 'legacy-transport'])
+})
+
+test('pino.transport - transport name must be supplied and be a string', async ({ throws }) => {
+  throws(() => pino.transport())
+  throws(() => pino.transport(22))
+  throws(() => pino.transport({}))
+  throws(() => pino.transport({ transport: {} }))
+})
+
+test('pino.transport basic (transport, opts)', async ({ same }) => {
+  const tmp = join(
+    os.tmpdir(),
+    '_' + Math.random().toString(36).substr(2, 9)
+  )
+  const instance = pino(pino.transport(basicTransport, {
+    dest: tmp
+  }))
+  instance.info('hello')
+  await watchFileCreated(tmp)
+  const result = JSON.parse(readFileSync(tmp).toString())
+  delete result.time
+  same(result, {
+    pid,
+    hostname,
+    level: 30,
+    msg: 'hello'
+  })
+})
+
+test('pino.transport basic ({transport, ...opts})', async ({ same }) => {
+  const tmp = join(
+    os.tmpdir(),
+    '_' + Math.random().toString(36).substr(2, 9)
+  )
+  const instance = pino(pino.transport({
+    transport: basicTransport,
+    dest: tmp
+  }))
+  instance.info('hello')
+  await watchFileCreated(tmp)
+  const result = JSON.parse(readFileSync(tmp).toString())
+  delete result.time
+  same(result, {
+    pid,
+    hostname,
+    level: 30,
+    msg: 'hello'
+  })
+})
+
+test('pino.transport legacy natural flush', async ({ is }) => {
+  const result = spawnSync(process.execPath, [join(__dirname, 'fixtures', 'legacy-transport-consumers/natural-flush.js')])
+  is(result.stdout.toString(), '30:hello')
+})
+
+test('pino.transport legacy sync flush', async ({ is }) => {
+  const result = spawnSync(process.execPath, [join(__dirname, 'fixtures', 'legacy-transport-consumers/sync-flush.js')])
+  is(result.stdout.toString(), '30:hello')
+})


### PR DESCRIPTION
For background see #614 and https://github.com/pinojs/pinole

* transports that run in worker threads
* supports ESM and CJS next gen transports
* supports "legacy" transports
* supports `flushSync`

## Roll out plan

* Part of Pino v7
* Supports Node 12 and Node 14
* I suggest we release v7 before 10 is at end-of-life, - Node 10 users can stay on Pino 6. 

## Pino transport API

Package support:

```js
  const logger = pino(pino.transport('my-transport', {some: 'options'})
```


File path support:

```js
  const logger = pino(pino.transport('./path/to/my/local/transport.js', {some: 'options'})
```

The options object must be clonable because it's passed to the worker thread - e.g. no functions etc. 


## Next Gen Transports

Transports may be ESM or CJS. I'm encouraging ESM for transports.

A canonical next gen transport runs in a worker thread and looks as follows:

```js
export default (opts) => {
  return (data, sync) => {
     // do something with data
     // useful sync boolean tells us if the main thread is trying to sync flush
  }
}
```

For asynchronous initialisation, using ESM you have Top level await but
for any async work based on opts you can make the exported function async:

```js
export default async (opts) => {
  // do something awaiting with values from opts
  return (data, sync) => {
     // do something with data
     // useful sync boolean tells us if the main thread is trying to sync flush
  }
}
```

For asynchronous writes, make the returned writing function async:

```js
export default async (opts) => {
  return async (data, sync) => {
     // do something with data and await
  }
}
```

Making the write function async is tolerable to performance constraints because this is
happening off the main thread - the ergonomics of async/await can win here. 

## Legacy Support

Support for existing transports works like so:

* IF the transport is a module
* AND IF the` package.json` has a `"bin"` field
* AND IF NOT the `package.json` has a `"pino"` field that *doesn't* have the value "legacy"

Then it's determined to be legacy. This means the transports that don't work should work automatically. But they can disambiguate by adding `"pino": "legacy"` to the` package.json`.

`Pinole` wraps legacy transports in a next gen transport wrapper and and feeds data into `process.stdin` while working around the stdout/stderr disconnect race scenario you get with worker threads during the final tick of process exit: see https://github.com/pinojs/pinole/blob/master/lib/legacy.js

This means `flushSync` works with legacy as well. 

Anything that isn't a module *must* be a next gen transport.

Modules that have a `package.json` without a `"bin"` field are interpreted as next gen transports
Modules that have a `package.json` with a `"bin"` field but with "pino": "v7" (or really anything that doesn't say legacy) are interpreted as next gen transports

Here's `pino-coloda` getting the legacy treatment from `Pinole` - this is `pino-colada` running inside a worker thread, with no modifications to `pino-colada` itself:

![image](https://user-images.githubusercontent.com/1190716/102018007-d25bee80-3d6a-11eb-8d74-20ace3502630.png)

## Approach: Performance & Safety

This approach supports flushSync by blocking the main thread using [`Atomics`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics) which unblocks conditionally when the worker thread updates a element in a `SharedArrayBuffer`. This means in the final tick (eg `process.on('exit', ...)`) **we can still do asynchronous work in the worker thread while keeping the main thread alive.**

During normal operations no `Atomics` are used, and we purposefully avoid blocking the main thread at all costs. We use the worker thread to poll the `SharedArrayBuffer`, the only work the main thread does is write into the `SharedArrayBuffer` (in the same way that `sonic-boom` writes to a buffer, using `TextEncoder`) and then update a meta-data section of the `SharedArrayBuffer` so that the worker thread knows to pass the log line(s) to the transport.

## Todo

Lot's more to do but I wanted to get eyes on this sooner rather than later

* docs
* benchmarking (thinking req/s of an http server) 
* there's some no-op methods in pinole (flush, end, etc.) that could probably benefit from some implementation details, @mcollina advice appreciated
* 100% testing for pinole (not part of this PR but blocking on it)
* probably a lot of edge cases and bug fixing in pinole @mcollina it could really use your eyes as well
* wondering if we should default to using a worker thread for normal stdout writes (depending on benchmarks) *UNLESS* os.cpus().length < 1 (or <2?)
* Node 12 support (tests seems to not work on CI at least)
* Windows support (tests seems to not work on CI at least)
