### PR TITLE
Fix typos

### DIFF
--- a/docs/lts.md
+++ b/docs/lts.md
@@ -5,7 +5,7 @@ Pino's Long Term Support (LTS) is tied to the
 [Node.js LTS policy](https://github.com/nodejs/Release). Major versions of
 Pino, "X" releases in X.Y.Z of [semantic versioning][semver] nomenclature, will
 be issued as close as possible to the release of a new major LTS release of
-Node.js (subject to the Pino maintainers's capcity). Pino makes no guarantees
+Node.js (subject to the Pino maintainers's capacity). Pino makes no guarantees
 as to the operability of the library on unsupported releases of Node.js.
 
 Pino will not remove support for a deprecated Node.js release via a minor,

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -42,7 +42,7 @@ external processes so that the threading capabilities of the OS can be
 used (or other CPUs).
 
 One consequence of this methodology is that "error" logs do not get written to
-`stderr`. However, since Pino logs are in a parseable format, it is possible to
+`stderr`. However, since Pino logs are in a parsable format, it is possible to
 use tools like [pino-tee][pino-tee] or [jq][jq] to work with the logs. For
 example, to view only logs marked as "error" logs:
 

--- a/test/browser-serializers.test.js
+++ b/test/browser-serializers.test.js
@@ -290,7 +290,7 @@ test('children serializers get called when inherited from parent', ({ end, is })
   end()
 })
 
-test('non overriden serializers are available in the children', ({ end, is }) => {
+test('non overridden serializers are available in the children', ({ end, is }) => {
   const pSerializers = {
     onlyParent: () => 'parent',
     shared: () => 'parent'

--- a/test/browser-transmit.test.js
+++ b/test/browser-transmit.test.js
@@ -127,7 +127,7 @@ test('supplies a timestamp (ts) in logEvent object which is exactly the same as 
   var expected
   const logger = pino({
     browser: {
-      asObject: true, // implict because `write`, but just to be explicit
+      asObject: true, // implicit because `write`, but just to be explicit
       write (o) {
         expected = o.time
       },

--- a/test/custom-levels.test.js
+++ b/test/custom-levels.test.js
@@ -296,7 +296,7 @@ test('When useOnlyCustomLevels is set to true, the level formatter should only g
   is(level, 42)
 })
 
-test('custom levels accesible in prettifier function', async ({ plan, same }) => {
+test('custom levels accessible in prettifier function', async ({ plan, same }) => {
   plan(1)
   const logger = pino({
     prettyPrint: true,


### PR DESCRIPTION
Fixed several typos in `documentation` and `tests`