### PR TITLE
Upgrade all available http links to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # pino
 [![Build Status](https://img.shields.io/github/workflow/status/pinojs/pino/CI)](https://github.com/pinojs/pino/actions)
-&nbsp;[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
+&nbsp;[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 &nbsp;[![TypeScript definitions on DefinitelyTyped](https://img.shields.io/badge/DefinitelyTyped-.d.ts-brightgreen.svg?style=flat)](https://definitelytyped.org)
 
 [Very low overhead](#low-overhead) Node.js logger.
@@ -134,7 +134,7 @@ See the [CONTRIBUTING.md](https://github.com/pinojs/pino/blob/master/CONTRIBUTIN
 <a name="acknowledgements"></a>
 ## Acknowledgements
 
-This project was kindly sponsored by [nearForm](http://nearform.com).
+This project was kindly sponsored by [nearForm](https://nearform.com).
 
 Logo and identity designed by Cosmic Fox Design: https://www.behance.net/cosmicfox.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -163,7 +163,7 @@ If an object is supplied, three options can be specified:
 **WARNING**: Never allow user input to define redacted paths.
 
 * See the [redaction ⇗](/docs/redaction.md) documentation.
-* See [fast-redact#caveat ⇗](http://github.com/davidmarkclements/fast-redact#caveat)
+* See [fast-redact#caveat ⇗](https://github.com/davidmarkclements/fast-redact#caveat)
 
 <a id=opt-hooks></a>
 #### `hooks` (Object)

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -51,6 +51,6 @@ PinoAsyncInterpolateExtra average: 209.552ms
 PinoNodeStreamInterpolateExtra average: 413.195ms
 ```
 
-For a fair comparison, [LogLevel](http://npm.im/loglevel) was extended
-to include a timestamp and [bole](http://npm.im/bole) had
+For a fair comparison, [LogLevel](https://npm.im/loglevel) was extended
+to include a timestamp and [bole](https://npm.im/bole) had
 `fastTime` mode switched on.

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -1,6 +1,6 @@
 # Browser API
 
-Pino is compatible with [`browserify`](http://npm.im/browserify) for browser side usage:
+Pino is compatible with [`browserify`](https://npm.im/browserify) for browser side usage:
 
 This can be useful with isomorphic/universal JavaScript code.
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -14,7 +14,7 @@ Please send a PR to add new modules!
 + [`express-pino-logger`](https://github.com/pinojs/express-pino-logger): use
 Pino to log requests within [express](https://expressjs.com/).
 + [`koa-pino-logger`](https://github.com/pinojs/koa-pino-logger): use Pino to
-log requests within [Koa](http://koajs.com/).
+log requests within [Koa](https://koajs.com/).
 + [`pino-arborsculpture`](https://github.com/pinojs/pino-arborsculpture): change
 log levels at runtime.
 + [`pino-caller`](https://github.com/pinojs/pino-caller): add callsite to the log line.

--- a/docs/help.md
+++ b/docs/help.md
@@ -120,7 +120,7 @@ Given a similar scenario as in the [Log rotation](#rotate) section a basic
 
 Let's assume we want to store all error messages to a separate log file.
 
-Install [pino-tee](http://npm.im/pino-tee) with:
+Install [pino-tee](https://npm.im/pino-tee) with:
 
 ```bash
 npm i pino-tee -g
@@ -209,15 +209,15 @@ the logs human friendly.
 <a id="debug"></a>
 ## Pino with `debug`
 
-The popular [`debug`](http://npm.im/debug) is used in many modules across the ecosystem.
+The popular [`debug`](https://npm.im/debug) is used in many modules across the ecosystem.
 
-The [`pino-debug`](http://github.com/pinojs/pino-debug) module
+The [`pino-debug`](https://github.com/pinojs/pino-debug) module
 can capture calls to `debug` loggers and run them
 through `pino` instead. This results in a 10x (20x in asynchronous mode)
 performance improvement - even though `pino-debug` is logging additional
 data and wrapping it in JSON.
 
-To quickly enable this install [`pino-debug`](http://github.com/pinojs/pino-debug)
+To quickly enable this install [`pino-debug`](https://github.com/pinojs/pino-debug)
 and preload it with the `-r` flag, enabling any `debug` logs with the
 `DEBUG` environment variable:
 
@@ -226,8 +226,8 @@ $ npm i pino-debug
 $ DEBUG=* node -r pino-debug app.js
 ```
 
-[`pino-debug`](http://github.com/pinojs/pino-debug) also offers fine grain control to map specific `debug`
-namespaces to `pino` log levels. See [`pino-debug`](http://github.com/pinojs/pino-debug)
+[`pino-debug`](https://github.com/pinojs/pino-debug) also offers fine grain control to map specific `debug`
+namespaces to `pino` log levels. See [`pino-debug`](https://github.com/pinojs/pino-debug)
 for more.
 
 <a id="windows"></a>

--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -115,7 +115,7 @@ By way of example, the following are all valid paths:
 
 ## Overhead
 
-Pino's redaction functionality is built on top of [`fast-redact`](http://github.com/davidmarkclements/fast-redact)
+Pino's redaction functionality is built on top of [`fast-redact`](https://github.com/davidmarkclements/fast-redact)
 which adds about 2% overhead to `JSON.stringify` when using paths without wildcards.
 
 When used with pino logger with a single redacted path, any overhead is within noise -

--- a/docs/web.md
+++ b/docs/web.md
@@ -55,7 +55,7 @@ app.get('/', function (req, res) {
 app.listen(3000)
 ```
 
-See the [pino-http readme](http://npm.im/pino-http) for more info.
+See the [pino-http readme](https://npm.im/pino-http) for more info.
 
 <a id="hapi"></a>
 ## Pino with Hapi
@@ -117,7 +117,7 @@ start().catch((err) => {
 })
 ```
 
-See the [hapi-pino readme](http://npm.im/hapi-pino) for more info.
+See the [hapi-pino readme](https://npm.im/hapi-pino) for more info.
 
 <a id="restify"></a>
 ## Pino with Restify
@@ -140,7 +140,7 @@ server.get('/', function (req, res) {
 server.listen(3000)
 ```
 
-See the [restify-pino-logger readme](http://npm.im/restify-pino-logger) for more info.
+See the [restify-pino-logger readme](https://npm.im/restify-pino-logger) for more info.
 
 <a id="koa"></a>
 ## Pino with Koa
@@ -187,7 +187,7 @@ function handle (req, res) {
 server.listen(3000)
 ```
 
-See the [pino-http readme](http://npm.im/pino-http) for more info.
+See the [pino-http readme](https://npm.im/pino-http) for more info.
 
 
 <a id="nest"></a>
@@ -226,4 +226,4 @@ async function bootstrap() {
 bootstrap()
 ```
 
-See the [nestjs-pino readme](http://npm.im/nestjs-pino) for more info.
+See the [nestjs-pino readme](https://npm.im/nestjs-pino) for more info.


### PR DESCRIPTION
Upgraded all `http` links to `https` that support the `https` protocol.

<details>
  <summary>All upgraded links</summary>

  Links
  ---

https://standardjs.com
https://nearform.com
https://github.com/davidmarkclements/fast-redact#caveat
https://npm.im/loglevel
https://npm.im/bole
https://npm.im/browserify
https://koajs.com
https://npm.im/pino-tee
https://npm.im/debug
https://github.com/pinojs/pino-debug
https://github.com/davidmarkclements/fast-redact
https://npm.im/pino-http
https://npm.im/hapi-pino
https://npm.im/restify-pino-logger
https://npm.im/nestjs-pino
</details>
