### PR TITLE
Bump up pino-std-serializers dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pino",
-  "version": "6.9.0",
+  "version": "6.9.1",
   "description": "super fast, all natural json logger",
   "main": "pino.js",
   "browser": "./browser.js",
@@ -88,7 +88,7 @@
     "fast-redact": "^3.0.0",
     "fast-safe-stringify": "^2.0.7",
     "flatstr": "^1.0.12",
-    "pino-std-serializers": "^2.4.2",
+    "pino-std-serializers": "^3.1.0",
     "quick-format-unescaped": "^4.0.1",
     "sonic-boom": "^1.0.2"
   }

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -3,7 +3,7 @@
 const http = require('http')
 const os = require('os')
 const semver = require('semver')
-const { test } = require('tap')
+const { test, skip } = require('tap')
 const { sink, once } = require('./helper')
 const pino = require('../')
 
@@ -24,8 +24,8 @@ test('http request support', async ({ ok, same, error, teardown }) => {
         method: originalReq.method,
         url: originalReq.url,
         headers: originalReq.headers,
-        remoteAddress: originalReq.connection.remoteAddress,
-        remotePort: originalReq.connection.remotePort
+        remoteAddress: originalReq.socket.remoteAddress,
+        remotePort: originalReq.socket.remotePort
       }
     })
   }))
@@ -62,8 +62,8 @@ test('http request support via serializer', async ({ ok, same, error, teardown }
         method: originalReq.method,
         url: originalReq.url,
         headers: originalReq.headers,
-        remoteAddress: originalReq.connection.remoteAddress,
-        remotePort: originalReq.connection.remotePort
+        remoteAddress: originalReq.socket.remoteAddress,
+        remotePort: originalReq.socket.remotePort
       }
     })
   }))
@@ -83,7 +83,8 @@ test('http request support via serializer', async ({ ok, same, error, teardown }
   server.close()
 })
 
-test('http request support via serializer without request connection', async ({ ok, same, error, teardown }) => {
+// skipped because request connection is deprecated since v13, and request socket is always available
+skip('http request support via serializer without request connection', async ({ ok, same, error, teardown }) => {
   var originalReq
   const instance = pino({
     serializers: {
@@ -104,8 +105,8 @@ test('http request support via serializer without request connection', async ({ 
       }
     }
     if (semver.gte(process.version, '13.0.0')) {
-      expected.req.remoteAddress = originalReq.connection.remoteAddress
-      expected.req.remotePort = originalReq.connection.remotePort
+      expected.req.remoteAddress = originalReq.socket.remoteAddress
+      expected.req.remotePort = originalReq.socket.remotePort
     }
     same(chunk, expected)
   }))
@@ -217,8 +218,8 @@ test('http request support via serializer in a child', async ({ ok, same, error,
         method: originalReq.method,
         url: originalReq.url,
         headers: originalReq.headers,
-        remoteAddress: originalReq.connection.remoteAddress,
-        remotePort: originalReq.connection.remotePort
+        remoteAddress: originalReq.socket.remoteAddress,
+        remotePort: originalReq.socket.remotePort
       }
     })
   }))


### PR DESCRIPTION
It's been several versions since `pino-std-serializers` was aligned with `pino`