### PR TITLE
docs: clarify options.timestamp usage

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -289,12 +289,20 @@ Set to `true` to logs newline delimited JSON with `\r\n` instead of `\n`.
 Default: `true`
 
 Enables or disables the inclusion of a timestamp in the
-log message. If a function is supplied, it must synchronously return a JSON string
+log message. If a function is supplied, it must synchronously return a partial JSON string
 representation of the time, e.g. `,"time":1493426328206` (which is the default).
 
 If set to `false`, no timestamp will be included in the output.
+
 See [stdTimeFunctions](#pino-stdtimefunctions) for a set of available functions
 for passing in as a value for this option.
+
+Example:
+```js
+timestamp: () => `,"time":"${new Date(Date.now()).toISOString()}"`
+// which is equivilent to:
+// timestamp: stdTimeFunctions.isoTime
+```
 
 **Caution**: attempting to format time in-process will significantly impact logging performance.
 


### PR DESCRIPTION
I mistook the meaning of `,"timestamp"...` and description and was wondering why my log entries looked like this: `{"level":302021-01-16T22:08:04.469Z,"pid":11224, ...`.

the way this works was a little surprising but i'm sure makes sense for perf reasons.