### PR TITLE
docs(readme): fix link to vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # pino
 [![npm version](https://img.shields.io/npm/v/pino)](https://www.npmjs.com/package/pino)
 [![Build Status](https://img.shields.io/github/workflow/status/pinojs/pino/CI)](https://github.com/pinojs/pino/actions)
-[![Known Vulnerabilities](https://snyk.io/test/github/pinojs/pino/badge.svg)](https://snyk.io/test/github/fastify/pino)
+[![Known Vulnerabilities](https://snyk.io/test/github/pinojs/pino/badge.svg)](https://snyk.io/test/github/pinojs/pino)
 [![Coverage Status](https://coveralls.io/repos/github/pinojs/pino/badge.svg?branch=master)](https://coveralls.io/github/pinojs/pino?branch=master)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 [![TypeScript definitions on DefinitelyTyped](https://img.shields.io/badge/DefinitelyTyped-.d.ts-brightgreen.svg?style=flat)](https://definitelytyped.org)


### PR DESCRIPTION
The current link refers to the fastifyjs org and doesn't work.

Refs: https://github.com/pinojs/pino/pull/961