### PR TITLE
docs: fix relative link in api & help

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -496,7 +496,7 @@ The `message` parameter takes precedence over the `mergedObject`.
 That is, if a `mergedObject` contains a `msg` property, and a `message` parameter
 is supplied in addition, the `msg` property in the output log will be the value of
 the `message` parameter not the value of the `msg` property on the `mergedObject`.
-See [Avoid Message Conflict](./help.md#avoid-message-conflict) for information
+See [Avoid Message Conflict](/docs/help.md#avoid-message-conflict) for information
 on how to overcome this limitation.
 
 The `messageKey` option can be used at instantiation time to change the namespace

--- a/docs/help.md
+++ b/docs/help.md
@@ -287,10 +287,10 @@ module.exports = function createLogger(options) {
 <a id="avoid-message-conflict"></a>
 ## Avoid Message Conflict
 
-As described in the [`message` documentation](./api.md#message), when a log
+As described in the [`message` documentation](/docs/api.md#message), when a log
 is written like `log.info({ msg: 'a message' }, 'another message')` then the
 final output JSON will have `"msg":"another message"` and the `'a message'`
-string will be lost. To overcome this, the [`logMethod` hook](./api.md#logmethod)
+string will be lost. To overcome this, the [`logMethod` hook](/docs/api.md#logmethod)
 can be used:
 
 ```js


### PR DESCRIPTION
Hi there.

This is a tiny fix in docs. These links are specified by relative paths, and don't work in the web page.

- [link to `Avoid Message Conflict` in `api/Logging Method Parameters` section](https://getpino.io/#/docs/api?id=logging-method-parameters)
- [link to `message documentation` in `help/Avoid Message Conflict` section](https://getpino.io/#/docs/help?id=avoid-message-conflict)
- [link to `logMethod hook` in `help/Avoid Message Conflict` section](https://getpino.io/#/docs/help?id=avoid-message-conflict)
