### PR TITLE
doc/api: update consequtive parameters hook to take all arguments

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -544,13 +544,18 @@ const pinoOptions = {
 }
 
 function logMethod (args, method) {
-  if (args.length === 2) {
-    args[0] = `${args[0]} %j`
+  if (args.length >= 2) {
+    args[0] = args[0] + " %j".repeat(args.length - 1);
   }
   method.apply(this, args)
 }
 
 const logger = pino(pinoOptions)
+```
+
+```js
+logger.info('hello', 'world', 'and', 'hola mundo')
+// {"level":30,"time":1614876433202,"pid":92820,"hostname":"x","msg":"hello 'world' 'and' 'hola mundo'"}
 ```
 
 * See [`message` log method parameter](#message)

--- a/docs/api.md
+++ b/docs/api.md
@@ -555,7 +555,7 @@ const logger = pino(pinoOptions)
 
 ```js
 logger.info('hello', 'world', 'and', 'hola mundo')
-// {"level":30,"time":1614876433202,"pid":92820,"hostname":"x","msg":"hello 'world' 'and' 'hola mundo'"}
+// {"level":30,"time":1614876645498,"pid":92846,"hostname":"x","msg":"hello, 'world', 'and', 'hola mundo', {\"f\":1.3}"}
 ```
 
 * See [`message` log method parameter](#message)

--- a/docs/api.md
+++ b/docs/api.md
@@ -544,8 +544,8 @@ const pinoOptions = {
 }
 
 function logMethod (args, method) {
-  if (args.length >= 2) {
-    args[0] = args[0] + " %j".repeat(args.length - 1);
+  if (typeof args[0] === "string" && args.length >= 2) {
+    args[0] += ", %j".repeat(args.length - 1);
   }
   method.apply(this, args)
 }


### PR DESCRIPTION
the existing example accounted for only two arguments.

this makes the method work more like `console.log(a,b,c,...);`

refs:
- https://github.com/pinojs/pino/issues/978