### PR TITLE
Pin quick-format-unescaped

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "fast-safe-stringify": "^2.0.7",
     "flatstr": "^1.0.12",
     "pino-std-serializers": "^3.1.0",
-    "quick-format-unescaped": "^4.0.1",
+    "quick-format-unescaped": "~4.0.1",
     "sonic-boom": "^1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "fast-safe-stringify": "^2.0.7",
     "flatstr": "^1.0.12",
     "pino-std-serializers": "^3.1.0",
-    "quick-format-unescaped": "~4.0.1",
+    "quick-format-unescaped": "4.0.1",
     "sonic-boom": "^1.0.2"
   }
 }


### PR DESCRIPTION
This is a temporary fix for #983 until a resolution is provided in the upstream library. Right now, new installs of Pino that have not locked the dependency tree before two days ago will be broken if this PR is not shipped.