### PR TITLE
docs: use brackets for hyphenated properties

### DIFF
--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -3,11 +3,12 @@
 > Redaction is not supported in the browser [#670](https://github.com/pinojs/pino/issues/670)
 
 To redact sensitive information, supply paths to keys that hold sensitive data
-using the `redact` option:
+using the `redact` option. Note that paths which contain hypens need to use
+brackets in order to access the hyphenated property:
 
 ```js
 const logger = require('.')({
-  redact: ['key', 'path.to.key', 'stuff.thats[*].secret']
+  redact: ['key', 'path.to.key', 'stuff.thats[*].secret', 'path["with-hyphen"]']
 })
 
 logger.info({


### PR DESCRIPTION
Related to #480, which is the sole source of relevant documentation for users that run into `redact paths array contains an invalid path`.