### PR TITLE
[Docs] document that `.child()` call triggers `level-change` event.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -841,8 +841,7 @@ logger.level = 'trace' // trigger event
 ```
 
 Please note that due to a [known bug](https://github.com/pinojs/pino/issues/1006), every `logger.child()` call will
-fire a `level-change` event, with `levelLabel` equal to `previousLevelLabel` and `levelValue` equal to `previousLevelValue`.
-You might want to ignore these events, using something like:
+fire a `level-change` event. You might want to ignore these events, using something like:
 
 ```js
 const logger = require('pino')()

--- a/docs/api.md
+++ b/docs/api.md
@@ -841,7 +841,7 @@ logger.level = 'trace' // trigger event
 ```
 
 Please note that due to a [known bug](https://github.com/pinojs/pino/issues/1006), every `logger.child()` call will
-fire a `level-change` event. You might want to ignore these events, using something like:
+fire a `level-change` event. These events can be ignored by writing an event handler like:
 
 ```js
 const logger = require('pino')()

--- a/docs/api.md
+++ b/docs/api.md
@@ -846,9 +846,10 @@ fire a `level-change` event. These events can be ignored by writing an event han
 ```js
 const logger = require('pino')()
 logger.on('level-change', function (lvl, val, prevLvl, prevVal) {
-  if (logger === this) {
-    console.log('%s (%d) was changed to %s (%d)', prevLvl, prevVal, lvl, val)
+  if (logger !== this) {
+    return
   }
+  console.log('%s (%d) was changed to %s (%d)', prevLvl, prevVal, lvl, val)
 })
 logger.child({}); // trigger an event by creating a child instance, notice no console.log
 logger.level = 'trace' // trigger event using actual value change, notice console.log

--- a/docs/api.md
+++ b/docs/api.md
@@ -840,6 +840,20 @@ logger.on('level-change', (lvl, val, prevLvl, prevVal) => {
 logger.level = 'trace' // trigger event
 ```
 
+Please note that due to a [known bug](https://github.com/pinojs/pino/issues/1006), every `logger.child()` call will
+fire a `level-change` event, with `levelLabel` equal to `previousLevelLabel` and `levelValue` equal to `previousLevelValue`.
+You might want to ignore these events, using something like:
+
+```js
+const logger = require('pino')()
+logger.on('level-change', (lvl, val, prevLvl, prevVal) => {
+  if (lvl !== prevLvl) {
+    console.log('%s (%d) was changed to %s (%d)', prevLvl, prevVal, lvl, val)
+  }
+})
+logger.child({}); // trigger an event by creating a child instance.
+```
+
 <a id="version"></a>
 ### `logger.version` (String)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -846,12 +846,13 @@ You might want to ignore these events, using something like:
 
 ```js
 const logger = require('pino')()
-logger.on('level-change', (lvl, val, prevLvl, prevVal) => {
-  if (lvl !== prevLvl) {
+logger.on('level-change', function (lvl, val, prevLvl, prevVal) {
+  if (logger === this) {
     console.log('%s (%d) was changed to %s (%d)', prevLvl, prevVal, lvl, val)
   }
 })
-logger.child({}); // trigger an event by creating a child instance.
+logger.child({}); // trigger an event by creating a child instance, notice no console.log
+logger.level = 'trace' // trigger event using actual value change, notice console.log
 ```
 
 <a id="version"></a>


### PR DESCRIPTION
As discussed [in the issue 1006](https://github.com/pinojs/pino/issues/1006#issuecomment-817205040) I've created an update to docs. Unfortunately, I have no bandwidth to fix this bug right now, but I guess letting people know about it is also good.