### PR TITLE
Drop flatstr

### DIFF
--- a/lib/levels.js
+++ b/lib/levels.js
@@ -1,6 +1,5 @@
 'use strict'
 /* eslint no-prototype-builtins: 0 */
-const flatstr = require('flatstr')
 const {
   lsCacheSym,
   levelValSym,
@@ -47,7 +46,7 @@ const nums = Object.keys(levels).reduce((o, k) => {
 }, {})
 
 const initialLsCache = Object.keys(nums).reduce((o, k) => {
-  o[k] = flatstr('{"level":' + Number(k))
+  o[k] = '{"level":' + Number(k)
   return o
 }, {})
 

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -3,8 +3,6 @@
 /* eslint no-prototype-builtins: 0 */
 
 const { EventEmitter } = require('events')
-const SonicBoom = require('sonic-boom')
-const flatstr = require('flatstr')
 const {
   lsCacheSym,
   levelValSym,
@@ -170,8 +168,7 @@ function write (_obj, msg, num) {
     stream.lastTime = t.slice(this[timeSliceIndexSym])
     stream.lastLogger = this // for child loggers
   }
-  if (stream instanceof SonicBoom) stream.write(s)
-  else stream.write(flatstr(s))
+  stream.write(s)
 }
 
 function flush () {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
   "dependencies": {
     "fast-redact": "^3.0.0",
     "fast-safe-stringify": "^2.0.7",
-    "flatstr": "^1.0.12",
     "pino-std-serializers": "^3.1.0",
     "quick-format-unescaped": "^4.0.3",
     "sonic-boom": "^1.0.2"


### PR DESCRIPTION
Since Node v12, this is not needed anymore.

So long, and thanks for all the fish `flatstr`!