### PR TITLE
fix(deps): upgrade to sonic-boom 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
     "flatstr": "^1.0.12",
     "pino-std-serializers": "^3.1.0",
     "quick-format-unescaped": "^4.0.3",
-    "sonic-boom": "^1.0.2"
+    "sonic-boom": "^2.0.1"
   }
 }


### PR DESCRIPTION
This has been a fun journey.  This all started with me trying to upgrade `sonic-boom` in one of our own repositories, but found typescript type conflicts between the v1 types in `@types/sonic-boom` and the built-in types in v2.  This was surfaced because we're also using pino, which brings in v1 types.  The PR that started this path is here:
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/53559

It's unclear exactly what caused the semver major bump between v1 and v2 of sonic-boom, but all of the tests here seem to just pass with no other changes.  A closer look would be appreciated :)  Thank you folks!