### PR TITLE
Better describe base options in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -269,7 +269,7 @@ Default: `{pid: process.pid, hostname: os.hostname}`
 
 Key-value object added as child logger to each log line.
 
-Set to `null` to avoid adding `pid`, `hostname` and `name` properties to each log.
+Set to `undefined` to avoid adding `pid`, `hostname` properties to each log.
 
 #### `enabled` (Boolean)
 


### PR DESCRIPTION
There is possible bug in documentation how the base options works, as with recommended `null` values the log contained
.. "pid":null,"hostname":null ..

When i supplied `undefined` values, this removed those two properties entirely from the log;
also the is no `name` property so maybe the mention of it should be dropped too?