### PR TITLE
feat: child redact option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -141,6 +141,7 @@ logger.info('Message 2')
 If the `mixin` feature is being used merely to add static metadata to each log message,
 then a [child logger ⇗](/docs/child-loggers.md) should be used instead.
 
+<a id=opt-redact></a>
 #### `redact` (Array | Object):
 
 Default: `undefined`
@@ -715,6 +716,8 @@ const child = logger.child({ foo: 'bar' }, { redact: ['foo'] })
 logger.info({ hello: 'world' })
 // {"level":30,"time":1625794553558,"pid":67930,"hostname":"x","hello":"world", "foo": "[Redacted]" }
 ```
+
+* See [`redact` option](#opt-redact)
 
 <a id="bindings"></a>
 ### `logger.bindings()`

--- a/docs/api.md
+++ b/docs/api.md
@@ -141,7 +141,7 @@ logger.info('Message 2')
 If the `mixin` feature is being used merely to add static metadata to each log message,
 then a [child logger ⇗](/docs/child-loggers.md) should be used instead.
 
-<a id=opt-redact></a>
+<a id="opt-redact"></a>
 #### `redact` (Array | Object):
 
 Default: `undefined`
@@ -701,12 +701,11 @@ child.info({test: 'will be overwritten'})
 
 #### `options` (Object)
 
-Custom options for child logger, it will override the parent options if applied.
+Options for child logger. These options will override the parent logger options.
 
 ##### `options.redact` (Array | Object)
 
-Setting `options.redact` to array or object will override the parent `redact` options. If
-you want to remove `redact` inherited from parent logger, you should pass `[]`.
+Setting `options.redact` to an array or object will override the parent `redact` options. To remove `redact` options inherited from the parent logger set this value as an empty array (`[]`).
 
 ```js
 const logger = require('pino')({ redact: ['hello'] })

--- a/docs/api.md
+++ b/docs/api.md
@@ -639,7 +639,7 @@ the process crashes or exits.
 Noop function.
 
 <a id="child"></a>
-### `logger.child(bindings) => logger`
+### `logger.child(bindings, [options]) => logger`
 
 The `logger.child` method allows for the creation of stateful loggers,
 where key-value pairs can be pinned to a logger causing them to be output
@@ -697,6 +697,24 @@ child.info({test: 'will be overwritten'})
 
 * See [`serializers` option](#opt-serializers)
 * See [pino.stdSerializers](#pino-stdSerializers)
+
+#### `options` (Object)
+
+Custom options for child logger, it will override the parent options if applied.
+
+##### `options.redact` (Array | Object)
+
+Setting `options.redact` to array or object will override the parent `redact` options. If
+you want to remove `redact` inherited from parent logger, you should pass `[]`.
+
+```js
+const logger = require('pino')({ redact: ['hello'] })
+logger.info({ hello: 'world' })
+// {"level":30,"time":1625794363403,"pid":67930,"hostname":"x","hello":"[Redacted]"}
+const child = logger.child({ foo: 'bar' }, { redact: ['foo'] })
+logger.info({ hello: 'world' })
+// {"level":30,"time":1625794553558,"pid":67930,"hostname":"x","hello":"world", "foo": "[Redacted]" }
+```
 
 <a id="bindings"></a>
 ### `logger.bindings()`

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -21,7 +21,11 @@ const {
   serializersSym,
   formattersSym,
   useOnlyCustomLevelsSym,
-  needsMetadataGsym
+  needsMetadataGsym,
+  redactFmtSym,
+  stringifySym,
+  formatOptsSym,
+  stringifiersSym
 } = require('./symbols')
 const {
   getLevel,
@@ -35,11 +39,13 @@ const {
 const {
   asChindings,
   asJson,
-  buildFormatters
+  buildFormatters,
+  stringify
 } = require('./tools')
 const {
   version
 } = require('./meta')
+const redaction = require('./redaction')
 
 // note: use of class is satirical
 // https://github.com/pinojs/pino/pull/433#pullrequestreview-127703127
@@ -71,10 +77,13 @@ module.exports = function () {
 }
 
 const resetChildingsFormatter = bindings => bindings
-function child (bindings) {
+// TODO: formatters, serializers, customLevels should move to options
+// and depercation warning should emit
+function child (bindings, options) {
   if (!bindings) {
     throw Error('missing bindings for child Pino')
   }
+  options = options || {} // default options to empty object
   const serializers = this[serializersSym]
   const formatters = this[formattersSym]
   const instance = Object.create(this)
@@ -119,6 +128,17 @@ function child (bindings) {
     instance.levels = mappings(bindings.customLevels, instance[useOnlyCustomLevelsSym])
     genLsCache(instance)
   }
+
+  // redact must place before asChindings and only replace if exist
+  if ((typeof options.redact === 'object' && options.redact !== null) || Array.isArray(options.redact)) {
+    instance.redact = options.redact // replace redact directly
+    const stringifiers = redaction(instance.redact, stringify)
+    const formatOpts = { stringify: stringifiers[redactFmtSym] }
+    instance[stringifySym] = stringify
+    instance[stringifiersSym] = stringifiers
+    instance[formatOptsSym] = formatOpts
+  }
+
   instance[chindingsSym] = asChindings(instance, bindings)
   const childLevel = bindings.level || this.level
   instance[setLevelSym](childLevel)

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -795,3 +795,22 @@ test('child can customize redact', async ({ equal }) => {
   equal(req.method, 'GET')
   equal(req.url, '[Redacted]')
 })
+
+test('child can remove parent redact by array', async ({ equal }) => {
+  const stream = sink()
+  const instance = pino({ redact: ['req.method', '*.headers.cookie'] }, stream)
+  instance.child({
+    req: {
+      method: 'GET',
+      url: '/',
+      headers: {
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      }
+    }
+  }, {
+    redact: []
+  }).info('message completed')
+  const { req } = await once(stream, 'data')
+  equal(req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
+  equal(req.method, 'GET')
+})

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -775,3 +775,23 @@ test('child bindings are redacted using wildcard and plain path keys', async ({ 
   equal(req.headers.cookie, '[Redacted]')
   equal(req.method, '[Redacted]')
 })
+
+test('child can customize redact', async ({ equal }) => {
+  const stream = sink()
+  const instance = pino({ redact: ['req.method', '*.headers.cookie'] }, stream)
+  instance.child({
+    req: {
+      method: 'GET',
+      url: '/',
+      headers: {
+        cookie: 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;'
+      }
+    }
+  }, {
+    redact: ['req.url']
+  }).info('message completed')
+  const { req } = await once(stream, 'data')
+  equal(req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
+  equal(req.method, 'GET')
+  equal(req.url, '[Redacted]')
+})


### PR DESCRIPTION
Fixes: #831

I think child redact option is a important piece in my application, so I want to push forward for the child `options` discussed in the issue mention above.
I am relatively new in `pino` and I hope the method adopted do not have anything wrong.

I have run benchmark in my computer against the master bench and it should claim that no performance drop.

<details><summary>Before Benchmark</summary>
<p>

```
Running BASIC benchmark

benchBunyan*10000: 565.999ms
benchWinston*10000: 415.691ms
benchBole*10000: 228.661ms
benchDebug*10000: 365.646ms
benchLogLevel*10000: 335.88ms
benchPino*10000: 327.115ms
benchPinoAsync*10000: 164.915ms
benchPinoNodeStream*10000: 247.776ms
benchBunyan*10000: 457.424ms
benchWinston*10000: 362.67ms
benchBole*10000: 213.013ms
benchDebug*10000: 393.197ms
benchLogLevel*10000: 381.517ms
benchPino*10000: 350.057ms
benchPinoAsync*10000: 155.095ms
benchPinoNodeStream*10000: 275.198ms

Running OBJECT benchmark

benchBunyanObj*10000: 631.586ms
benchWinstonObj*10000: 591.859ms
benchBoleObj*10000: 317.796ms
benchLogLevelObject*10000: 593.543ms
benchPinoObj*10000: 335.924ms
benchPinoAsyncObj*10000: 142.843ms
benchPinoNodeStreamObj*10000: 245.006ms
benchBunyanObj*10000: 491.808ms
benchWinstonObj*10000: 386.373ms
benchBoleObj*10000: 230.106ms
benchLogLevelObject*10000: 506.045ms
benchPinoObj*10000: 352.597ms
benchPinoAsyncObj*10000: 133.298ms
benchPinoNodeStreamObj*10000: 248.173ms

Running DEEP-OBJECT benchmark

benchBunyanDeepObj*10000: 1.637s
benchWinstonDeepObj*10000: 2.896s
benchBoleDeepObj*10000: 2.190s
benchLogLevelDeepObj*10000: 6.290s
benchPinoDeepObj*10000: 2.989s
benchPinoAsyncDeepObj*10000: 2.666s
benchPinoNodeStreamDeepObj*10000: 2.528s
benchBunyanDeepObj*10000: 1.664s
benchWinstonDeepObj*10000: 2.776s
benchBoleDeepObj*10000: 2.044s
benchLogLevelDeepObj*10000: 6.460s
benchPinoDeepObj*10000: 2.739s
benchPinoAsyncDeepObj*10000: 2.567s
benchPinoNodeStreamDeepObj*10000: 2.540s

Running MULTI-ARG benchmark

benchBunyanInterpolate*10000: 611.512ms
benchWinstonInterpolate*10000: 556.427ms
benchBoleInterpolate*10000: 300.274ms
benchPinoInterpolate*10000: 397.956ms
benchPinoAsyncInterpolate*10000: 162.616ms
benchPinoNodeStreamInterpolate*10000: 301.354ms
benchBunyanInterpolateAll*10000: 620.673ms
benchWinstonInterpolateAll*10000: 395.661ms
benchBoleInterpolateAll*10000: 285.444ms
benchPinoInterpolateAll*10000: 422.98ms
benchPinoAsyncInterpolateAll*10000: 227.033ms
benchPinoNodeStreamInterpolateAll*10000: 332.409ms
benchBunyanInterpolateExtra*10000: 753.323ms
benchWinstonInterpolateExtra*10000: 372.128ms
benchBoleInterpolateExtra*10000: 462.279ms
benchPinoInterpolateExtra*10000: 440.548ms
benchPinoAsyncInterpolateExtra*10000: 267.373ms
benchPinoNodeStreamInterpolateExtra*10000: 391.017ms
benchBunyanInterpolateDeep*10000: 11.755s
benchWinstonInterpolateDeep*10000: 413.734ms
benchBoleInterpolateDeep*10000: 11.541s
benchPinoInterpolateDeep*10000: 10.958s
benchPinoAsyncInterpolateDeep*10000: 13.310s
benchPinoNodeStreamInterpolateDeep*10000: 12.091s
benchBunyanInterpolate*10000: 615.164ms
benchWinstonInterpolate*10000: 479.242ms
benchBoleInterpolate*10000: 266.791ms
benchPinoInterpolate*10000: 323.613ms
benchPinoAsyncInterpolate*10000: 133.496ms
benchPinoNodeStreamInterpolate*10000: 250.74ms
benchBunyanInterpolateAll*10000: 553.988ms
benchWinstonInterpolateAll*10000: 377.401ms
benchBoleInterpolateAll*10000: 294.79ms
benchPinoInterpolateAll*10000: 406.356ms
benchPinoAsyncInterpolateAll*10000: 223.791ms
benchPinoNodeStreamInterpolateAll*10000: 341.048ms
benchBunyanInterpolateExtra*10000: 713.979ms
benchWinstonInterpolateExtra*10000: 401.308ms
benchBoleInterpolateExtra*10000: 547.842ms
benchPinoInterpolateExtra*10000: 481.403ms
benchPinoAsyncInterpolateExtra*10000: 265.648ms
benchPinoNodeStreamInterpolateExtra*10000: 416.328ms
benchBunyanInterpolateDeep*10000: 12.017s
benchWinstonInterpolateDeep*10000: 391.527ms
benchBoleInterpolateDeep*10000: 11.431s
benchPinoInterpolateDeep*10000: 11.085s
benchPinoAsyncInterpolateDeep*10000: 13.217s
benchPinoNodeStreamInterpolateDeep*10000: 11.933s

Running LONG-STRING benchmark

benchBunyan*1000: 364.641ms
benchWinston*1000: 377.04ms
benchBole*1000: 304.269ms
benchPino*1000: 224.144ms
benchPinoAsync*1000: 162.587ms
benchPinoNodeStream*1000: 245.273ms
benchBunyan*1000: 258.519ms
benchWinston*1000: 245.635ms
benchBole*1000: 223.371ms
benchPino*1000: 175.629ms
benchPinoAsync*1000: 151.728ms
benchPinoNodeStream*1000: 228.696ms

Running CHILD benchmark

benchBunyanChild*10000: 579.33ms
benchBoleChild*10000: 263.597ms
benchPinoChild*10000: 320.129ms
benchPinoAssyncChild*10000: 165.297ms
benchPinoNodeStreamChild*10000: 255.115ms
benchBunyanChild*10000: 535.184ms
benchBoleChild*10000: 235.573ms
benchPinoChild*10000: 324.713ms
benchPinoAssyncChild*10000: 143.312ms
benchPinoNodeStreamChild*10000: 295.837ms

Running CHILD-CHILD benchmark

benchBunyanChildChild*10000: 764.655ms
benchPinoChildChild*10000: 431.244ms
benchPinoAsyncChildChild*10000: 208.845ms
benchPinoNodeStreamChildChild*10000: 332.659ms
benchBunyanChildChild*10000: 670.634ms
benchPinoChildChild*10000: 410.771ms
benchPinoAsyncChildChild*10000: 184.903ms
benchPinoNodeStreamChildChild*10000: 320.741ms

Running CHILD-CREATION benchmark

benchBunyanCreation*10000: 696.063ms
benchBoleCreation*10000: 290.168ms
benchPinoCreation*10000: 348.629ms
benchPinoAsyncCreation*10000: 163.276ms
benchPinoNodeStreamCreation*10000: 271.273ms
benchBunyanCreation*10000: 552.675ms
benchBoleCreation*10000: 278.458ms
benchPinoCreation*10000: 323.292ms
benchPinoAsyncCreation*10000: 139.271ms
benchPinoNodeStreamCreation*10000: 237.481ms

Running FORMATTERS benchmark

benchPinoNoFormatters*10000: 359.546ms
benchPinoFormatters*10000: 382.063ms
benchPinoNoFormatters*10000: 332.23ms
benchPinoFormatters*10000: 356.583ms

==========
BASIC benchmark averages
Bunyan average: 511.712ms
Winston average: 389.180ms
Bole average: 220.837ms
Debug average: 379.422ms
LogLevel average: 358.698ms
Pino average: 338.586ms
PinoAsync average: 160.005ms
PinoNodeStream average: 261.487ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
OBJECT benchmark averages
BunyanObj average: 561.697ms
WinstonObj average: 489.116ms
BoleObj average: 273.951ms
LogLevelObject average: 549.794ms
PinoObj average: 344.260ms
PinoAsyncObj average: 138.070ms
PinoNodeStreamObj average: 246.589ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
DEEP-OBJECT benchmark averages
BunyanDeepObj average: 1.651ms
WinstonDeepObj average: 2.836ms
BoleDeepObj average: 2.117ms
LogLevelDeepObj average: 6.375ms
PinoDeepObj average: 2.864ms
PinoAsyncDeepObj average: 2.617ms
PinoNodeStreamDeepObj average: 2.534ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
MULTI-ARG benchmark averages
BunyanInterpolate average: 613.338ms
WinstonInterpolate average: 517.835ms
BoleInterpolate average: 283.533ms
PinoInterpolate average: 360.784ms
PinoAsyncInterpolate average: 148.056ms
PinoNodeStreamInterpolate average: 276.047ms
BunyanInterpolateAll average: 587.331ms
WinstonInterpolateAll average: 386.531ms
BoleInterpolateAll average: 290.117ms
PinoInterpolateAll average: 414.668ms
PinoAsyncInterpolateAll average: 225.412ms
PinoNodeStreamInterpolateAll average: 336.728ms
BunyanInterpolateExtra average: 733.651ms
WinstonInterpolateExtra average: 386.718ms
BoleInterpolateExtra average: 505.060ms
PinoInterpolateExtra average: 460.976ms
PinoAsyncInterpolateExtra average: 266.510ms
PinoNodeStreamInterpolateExtra average: 403.673ms
BunyanInterpolateDeep average: 11.886ms
WinstonInterpolateDeep average: 402.630ms
BoleInterpolateDeep average: 11.486ms
PinoInterpolateDeep average: 11.021ms
PinoAsyncInterpolateDeep average: 13.264ms
PinoNodeStreamInterpolateDeep average: 12.012ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
LONG-STRING benchmark averages
Bunyan average: 311.580ms
Winston average: 311.337ms
Bole average: 263.820ms
Pino average: 199.887ms
PinoAsync average: 157.157ms
PinoNodeStream average: 236.984ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
CHILD benchmark averages
BunyanChild average: 557.257ms
BoleChild average: 249.585ms
PinoChild average: 322.421ms
PinoAssyncChild average: 154.305ms
PinoNodeStreamChild average: 275.476ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
CHILD-CHILD benchmark averages
BunyanChildChild average: 717.644ms
PinoChildChild average: 421.008ms
PinoAsyncChildChild average: 196.874ms
PinoNodeStreamChildChild average: 326.700ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
CHILD-CREATION benchmark averages
BunyanCreation average: 624.369ms
BoleCreation average: 284.313ms
PinoCreation average: 335.961ms
PinoAsyncCreation average: 151.274ms
PinoNodeStreamCreation average: 254.377ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
FORMATTERS benchmark averages
PinoNoFormatters average: 345.888ms
PinoFormatters average: 369.323ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
Done in 203.57s.
```

</p>
</details>


<details><summary>After Benchmark</summary>
<p>

```
Running BASIC benchmark

benchBunyan*10000: 512.441ms
benchWinston*10000: 443.769ms
benchBole*10000: 236.513ms
benchDebug*10000: 361.416ms
benchLogLevel*10000: 343.498ms
benchPino*10000: 325.424ms
benchPinoAsync*10000: 141.388ms
benchPinoNodeStream*10000: 269.256ms
benchBunyan*10000: 484.536ms
benchWinston*10000: 405.267ms
benchBole*10000: 224.228ms
benchDebug*10000: 349.879ms
benchLogLevel*10000: 323.245ms
benchPino*10000: 309.888ms
benchPinoAsync*10000: 127.122ms
benchPinoNodeStream*10000: 263.601ms

Running OBJECT benchmark

benchBunyanObj*10000: 650.374ms
benchWinstonObj*10000: 550.211ms
benchBoleObj*10000: 289.429ms
benchLogLevelObject*10000: 612.805ms
benchPinoObj*10000: 371.134ms
benchPinoAsyncObj*10000: 168.143ms
benchPinoNodeStreamObj*10000: 304.867ms
benchBunyanObj*10000: 560.529ms
benchWinstonObj*10000: 457.724ms
benchBoleObj*10000: 253.246ms
benchLogLevelObject*10000: 529.231ms
benchPinoObj*10000: 324.642ms
benchPinoAsyncObj*10000: 139.569ms
benchPinoNodeStreamObj*10000: 266.16ms

Running DEEP-OBJECT benchmark

benchBunyanDeepObj*10000: 1.541s
benchWinstonDeepObj*10000: 2.651s
benchBoleDeepObj*10000: 2.108s
benchLogLevelDeepObj*10000: 6.274s
benchPinoDeepObj*10000: 2.511s
benchPinoAsyncDeepObj*10000: 2.416s
benchPinoNodeStreamDeepObj*10000: 2.981s
benchBunyanDeepObj*10000: 1.693s
benchWinstonDeepObj*10000: 2.546s
benchBoleDeepObj*10000: 2.051s
benchLogLevelDeepObj*10000: 5.859s
benchPinoDeepObj*10000: 2.838s
benchPinoAsyncDeepObj*10000: 2.328s
benchPinoNodeStreamDeepObj*10000: 2.540s

Running MULTI-ARG benchmark

benchBunyanInterpolate*10000: 522.56ms
benchWinstonInterpolate*10000: 451.437ms
benchBoleInterpolate*10000: 248.749ms
benchPinoInterpolate*10000: 331.118ms
benchPinoAsyncInterpolate*10000: 145.471ms
benchPinoNodeStreamInterpolate*10000: 256.618ms
benchBunyanInterpolateAll*10000: 545.72ms
benchWinstonInterpolateAll*10000: 382.007ms
benchBoleInterpolateAll*10000: 314.385ms
benchPinoInterpolateAll*10000: 488.975ms
benchPinoAsyncInterpolateAll*10000: 298.812ms
benchPinoNodeStreamInterpolateAll*10000: 405.278ms
benchBunyanInterpolateExtra*10000: 885.602ms
benchWinstonInterpolateExtra*10000: 448.112ms
benchBoleInterpolateExtra*10000: 535.161ms
benchPinoInterpolateExtra*10000: 488.331ms
benchPinoAsyncInterpolateExtra*10000: 279.082ms
benchPinoNodeStreamInterpolateExtra*10000: 406.026ms
benchBunyanInterpolateDeep*10000: 11.763s
benchWinstonInterpolateDeep*10000: 416.369ms
benchBoleInterpolateDeep*10000: 11.536s
benchPinoInterpolateDeep*10000: 11.331s
benchPinoAsyncInterpolateDeep*10000: 12.627s
benchPinoNodeStreamInterpolateDeep*10000: 11.248s
benchBunyanInterpolate*10000: 543.955ms
benchWinstonInterpolate*10000: 381.765ms
benchBoleInterpolate*10000: 227.521ms
benchPinoInterpolate*10000: 324.623ms
benchPinoAsyncInterpolate*10000: 132.379ms
benchPinoNodeStreamInterpolate*10000: 250.198ms
benchBunyanInterpolateAll*10000: 532.365ms
benchWinstonInterpolateAll*10000: 379.309ms
benchBoleInterpolateAll*10000: 287.95ms
benchPinoInterpolateAll*10000: 423.502ms
benchPinoAsyncInterpolateAll*10000: 220.127ms
benchPinoNodeStreamInterpolateAll*10000: 356.683ms
benchBunyanInterpolateExtra*10000: 712.464ms
benchWinstonInterpolateExtra*10000: 382.906ms
benchBoleInterpolateExtra*10000: 487.143ms
benchPinoInterpolateExtra*10000: 423.432ms
benchPinoAsyncInterpolateExtra*10000: 218.865ms
benchPinoNodeStreamInterpolateExtra*10000: 332.691ms
benchBunyanInterpolateDeep*10000: 11.501s
benchWinstonInterpolateDeep*10000: 389.426ms
benchBoleInterpolateDeep*10000: 11.243s
benchPinoInterpolateDeep*10000: 11.094s
benchPinoAsyncInterpolateDeep*10000: 12.169s
benchPinoNodeStreamInterpolateDeep*10000: 11.825s

Running LONG-STRING benchmark

benchBunyan*1000: 288.371ms
benchWinston*1000: 311.013ms
benchBole*1000: 244.556ms
benchPino*1000: 205.773ms
benchPinoAsync*1000: 182.66ms
benchPinoNodeStream*1000: 319.076ms
benchBunyan*1000: 355.135ms
benchWinston*1000: 311.341ms
benchBole*1000: 266.17ms
benchPino*1000: 210.723ms
benchPinoAsync*1000: 175.913ms
benchPinoNodeStream*1000: 267.224ms

Running CHILD benchmark

benchBunyanChild*10000: 711.494ms
benchBoleChild*10000: 326.987ms
benchPinoChild*10000: 395.936ms
benchPinoAssyncChild*10000: 209.92ms
benchPinoNodeStreamChild*10000: 331.641ms
benchBunyanChild*10000: 602.613ms
benchBoleChild*10000: 241.809ms
benchPinoChild*10000: 332.743ms
benchPinoAssyncChild*10000: 154.145ms
benchPinoNodeStreamChild*10000: 255.794ms

Running CHILD-CHILD benchmark

benchBunyanChildChild*10000: 608.079ms
benchPinoChildChild*10000: 357.372ms
benchPinoAsyncChildChild*10000: 152.734ms
benchPinoNodeStreamChildChild*10000: 260.133ms
benchBunyanChildChild*10000: 566.764ms
benchPinoChildChild*10000: 333.476ms
benchPinoAsyncChildChild*10000: 158.476ms
benchPinoNodeStreamChildChild*10000: 303.375ms

Running CHILD-CREATION benchmark

benchBunyanCreation*10000: 612.907ms
benchBoleCreation*10000: 323.49ms
benchPinoCreation*10000: 367.404ms
benchPinoAsyncCreation*10000: 162.778ms
benchPinoNodeStreamCreation*10000: 296.58ms
benchBunyanCreation*10000: 589.987ms
benchBoleCreation*10000: 257.221ms
benchPinoCreation*10000: 329.088ms
benchPinoAsyncCreation*10000: 139.828ms
benchPinoNodeStreamCreation*10000: 244.437ms

Running FORMATTERS benchmark

benchPinoNoFormatters*10000: 351.658ms
benchPinoFormatters*10000: 387.997ms
benchPinoNoFormatters*10000: 374.553ms
benchPinoFormatters*10000: 428.687ms

==========
BASIC benchmark averages
Bunyan average: 498.489ms
Winston average: 424.518ms
Bole average: 230.370ms
Debug average: 355.648ms
LogLevel average: 333.371ms
Pino average: 317.656ms
PinoAsync average: 134.255ms
PinoNodeStream average: 266.428ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
OBJECT benchmark averages
BunyanObj average: 605.452ms
WinstonObj average: 503.967ms
BoleObj average: 271.337ms
LogLevelObject average: 571.018ms
PinoObj average: 347.888ms
PinoAsyncObj average: 153.856ms
PinoNodeStreamObj average: 285.514ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
DEEP-OBJECT benchmark averages
BunyanDeepObj average: 1.617ms
WinstonDeepObj average: 2.598ms
BoleDeepObj average: 2.080ms
LogLevelDeepObj average: 6.066ms
PinoDeepObj average: 2.675ms
PinoAsyncDeepObj average: 2.372ms
PinoNodeStreamDeepObj average: 2.760ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
MULTI-ARG benchmark averages
BunyanInterpolate average: 533.257ms
WinstonInterpolate average: 416.601ms
BoleInterpolate average: 238.135ms
PinoInterpolate average: 327.870ms
PinoAsyncInterpolate average: 138.925ms
PinoNodeStreamInterpolate average: 253.408ms
BunyanInterpolateAll average: 539.043ms
WinstonInterpolateAll average: 380.658ms
BoleInterpolateAll average: 301.168ms
PinoInterpolateAll average: 456.239ms
PinoAsyncInterpolateAll average: 259.470ms
PinoNodeStreamInterpolateAll average: 380.981ms
BunyanInterpolateExtra average: 799.033ms
WinstonInterpolateExtra average: 415.509ms
BoleInterpolateExtra average: 511.152ms
PinoInterpolateExtra average: 455.882ms
PinoAsyncInterpolateExtra average: 248.974ms
PinoNodeStreamInterpolateExtra average: 369.358ms
BunyanInterpolateDeep average: 11.632ms
WinstonInterpolateDeep average: 402.898ms
BoleInterpolateDeep average: 11.389ms
PinoInterpolateDeep average: 11.212ms
PinoAsyncInterpolateDeep average: 12.398ms
PinoNodeStreamInterpolateDeep average: 11.537ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
LONG-STRING benchmark averages
Bunyan average: 321.753ms
Winston average: 311.177ms
Bole average: 255.363ms
Pino average: 208.248ms
PinoAsync average: 179.286ms
PinoNodeStream average: 293.150ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
CHILD benchmark averages
BunyanChild average: 657.053ms
BoleChild average: 284.398ms
PinoChild average: 364.339ms
PinoAssyncChild average: 182.032ms
PinoNodeStreamChild average: 293.718ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
CHILD-CHILD benchmark averages
BunyanChildChild average: 587.421ms
PinoChildChild average: 345.424ms
PinoAsyncChildChild average: 155.605ms
PinoNodeStreamChildChild average: 281.754ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
CHILD-CREATION benchmark averages
BunyanCreation average: 601.447ms
BoleCreation average: 290.356ms
PinoCreation average: 348.246ms
PinoAsyncCreation average: 151.303ms
PinoNodeStreamCreation average: 270.509ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
==========
FORMATTERS benchmark averages
PinoNoFormatters average: 363.106ms
PinoFormatters average: 408.342ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
Done in 198.82s.
```

</p>
</details>

You can see the last test which is newly added for benchmark child creation with option.

<details><summary>Child Creation Benchmark with new test</summary>
<p>

```
Running CHILD-CREATION benchmark

benchBunyanCreation*10000: 646.246ms
benchBoleCreation*10000: 304.24ms
benchPinoCreation*10000: 368.686ms
benchPinoAsyncCreation*10000: 167.826ms
benchPinoNodeStreamCreation*10000: 265.586ms
benchPinoCreationWithOption*10000: 388.445ms
benchBunyanCreation*10000: 579.643ms
benchBoleCreation*10000: 255.497ms
benchPinoCreation*10000: 327.33ms
benchPinoAsyncCreation*10000: 146.89ms
benchPinoNodeStreamCreation*10000: 264.245ms
benchPinoCreationWithOption*10000: 328.114ms

==========
CHILD-CREATION benchmark averages
BunyanCreation average: 612.945ms
BoleCreation average: 279.869ms
PinoCreation average: 348.008ms
PinoAsyncCreation average: 157.358ms
PinoNodeStreamCreation average: 264.916ms
PinoCreationWithOption average: 358.279ms
==========
System: Linux/linux x64 4.4.0-19041-Microsoft ~ AMD Ryzen 5 3600 6-Core Processor               (cores/threads: 12)
Done in 4.46s.
```

</p>
</details>
