### PR TITLE
Handle complex object cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "fast-redact": "^3.0.0",
-    "fast-safe-stringify": "^2.0.7",
+    "fast-safe-stringify": "^2.0.8",
     "flatstr": "^1.0.12",
     "pino-std-serializers": "^3.1.0",
     "quick-format-unescaped": "^4.0.3",

--- a/test/complex-objects.test.js
+++ b/test/complex-objects.test.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const { test } = require('tap')
+const { sink, once } = require('./helper')
+const { PassThrough } = require('stream')
+const pino = require('../')
+
+test('Proxy and stream objects', async ({ equal }) => {
+  const s = new PassThrough()
+  s.resume()
+  s.write('', () => {})
+  const obj = { s, p: new Proxy({}, { get () { throw new Error('kaboom') } }) }
+  const stream = sink()
+  const instance = pino(stream)
+  instance.info({ obj })
+
+  const result = await once(stream, 'data')
+
+  equal(result.obj, '[unable to serialize, circular reference is too complex to analyze]')
+})
+
+test('Proxy and stream objects', async ({ equal }) => {
+  const s = new PassThrough()
+  s.resume()
+  s.write('', () => {})
+  const obj = { s, p: new Proxy({}, { get () { throw new Error('kaboom') } }) }
+  const stream = sink()
+  const instance = pino(stream)
+  instance.info(obj)
+
+  const result = await once(stream, 'data')
+
+  equal(result.p, '[unable to serialize, circular reference is too complex to analyze]')
+})


### PR DESCRIPTION
This was fixed in https://github.com/davidmarkclements/fast-safe-stringify/pull/52 but it's better to add a regression test here as well. 

I will open another issue to talk about a more long term solution for this problem.