### PR TITLE
Make sure that the main thread stays alive to process stdout.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -947,8 +947,11 @@ pino(transports)
 
 If `WeakRef`, `WeakMap` and `FinalizationRegistry` are available in the current runtime (v14.5.0+), then the thread
 will be automatically terminated in case the stream or logger goes out of scope.
-The `transport()` function adds a listener to `process.on('exit')` to ensure the worker is flushed and all data synced
-before the process exits.
+The `transport()` function adds a listener to `process.on('beforeExit')` and `process.on('exit')` to ensure the worker
+is flushed and all data synced before the process exits.
+
+Note that calling `process.exit()` on the main thread will stop the event loop on the main thread from turning. As a result,
+using `console.log` and `process.stdout` after the main thread called `process.exit()` will not produce any output.
 
 For more on transports, how they work, and how to create them see the [`Transports documentation`](/docs/transports.md).
 

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -47,7 +47,11 @@ function buildStream (filename, workerData, workerOpts) {
 }
 
 function autoEnd (stream) {
+  stream.ref()
   stream.end()
+  stream.once('close', function () {
+    stream.unref()
+  })
 }
 
 function transport (fullOptions) {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -19,9 +19,11 @@ function setupOnExit (stream) {
     })
   } else {
     const fn = autoEnd.bind(null, stream)
-    process.on('exit', fn)
+    process.once('beforeExit', fn)
+    process.once('exit', fn)
 
     stream.on('close', function () {
+      process.removeListener('beforeExit', fn)
       process.removeListener('exit', fn)
     })
   }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "fast-redact": "^3.0.0",
     "fast-safe-stringify": "^2.0.8",
     "get-caller-file": "^2.0.5",
-    "on-exit-leak-free": "^0.1.0",
+    "on-exit-leak-free": "^0.2.0",
     "pino-abstract-transport": "^0.2.0",
     "pino-std-serializers": "^4.0.0",
     "json-stringify-safe": "^5.0.1",

--- a/test/fixtures/transport-main.js
+++ b/test/fixtures/transport-main.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const { join } = require('path')
+const pino = require('../..')
+const transport = pino.transport({
+  target: join(__dirname, 'transport-worker.js')
+})
+const logger = pino(transport)
+logger.info('Hello')

--- a/test/fixtures/transport-worker.js
+++ b/test/fixtures/transport-worker.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { Writable } = require('stream')
+module.exports = (options) => {
+  const myTransportStream = new Writable({
+    write (chunk, enc, cb) {
+      console.log(chunk.toString())
+      cb()
+    }
+  })
+  return myTransportStream
+}

--- a/test/fixtures/transport-worker.js
+++ b/test/fixtures/transport-worker.js
@@ -3,6 +3,7 @@
 const { Writable } = require('stream')
 module.exports = (options) => {
   const myTransportStream = new Writable({
+    autoDestroy: true,
     write (chunk, enc, cb) {
       console.log(chunk.toString())
       cb()


### PR DESCRIPTION
This is achieved by hooking into beforeExit in on-exit-leak-free.
At that point the event loop is still running so we can catch the
most basic exit scenarios. However this would not work if we use
`process.exit(0)` to exit the main thread.

Fix #1074