### PR TITLE
Make ThreadStream sync: false (the default)

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -29,12 +29,11 @@ function setupOnExit (stream) {
   }
 }
 
-function buildStream (filename, workerData, workerOpts) {
+function buildStream (filename, workerData, workerOpts, streamOpts = {}) {
   const stream = new ThreadStream({
     filename,
     workerData,
-    workerOpts,
-    sync: true // TODO should this be configurable?
+    workerOpts
   })
 
   stream.on('ready', function () {

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -29,7 +29,7 @@ function setupOnExit (stream) {
   }
 }
 
-function buildStream (filename, workerData, workerOpts, streamOpts = {}) {
+function buildStream (filename, workerData, workerOpts) {
   const stream = new ThreadStream({
     filename,
     workerData,


### PR DESCRIPTION
There is no reason to be `sync: true` on this and it slows everything dow.