### PR TITLE
Use fastify-warning for deprecation notices

### DIFF
--- a/lib/deprecations.js
+++ b/lib/deprecations.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const warning = require('fastify-warning')()
+module.exports = warning
+
+const warnName = 'PinoWarning'
+
+warning.create(warnName, 'PINODEP004', 'bindings.serializers is deprecated, use options.serializers option instead')
+
+warning.create(warnName, 'PINODEP005', 'bindings.formatters is deprecated, use options.formatters option instead')
+
+warning.create(warnName, 'PINODEP006', 'bindings.customLevels is deprecated, use options.customLevels option instead')
+
+warning.create(warnName, 'PINODEP007', 'bindings.level is deprecated, use options.level option instead')

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -5,6 +5,7 @@
 const { EventEmitter } = require('events')
 const SonicBoom = require('sonic-boom')
 const flatstr = require('flatstr')
+const warning = require('./deprecations')
 const {
   lsCacheSym,
   levelValSym,
@@ -87,19 +88,19 @@ function child (bindings, options) {
   const instance = Object.create(this)
 
   if (bindings.hasOwnProperty('serializers') === true) {
-    process.emitWarning('bindings.serializers is deprecated, use options.serializers option instead', 'Warning', 'PINODEP004')
+    warning.emit('PINODEP004')
     options.serializers = bindings.serializers
   }
   if (bindings.hasOwnProperty('formatters') === true) {
-    process.emitWarning('bindings.formatters is deprecated, use options.formatters option instead', 'Warning', 'PINODEP005')
+    warning.emit('PINODEP005')
     options.formatters = bindings.formatters
   }
   if (bindings.hasOwnProperty('customLevels') === true) {
-    process.emitWarning('bindings.customLevels is deprecated, use options.customLevels option instead', 'Warning', 'PINODEP006')
+    warning.emit('PINODEP006')
     options.customLevels = bindings.customLevels
   }
   if (bindings.hasOwnProperty('level') === true) {
-    process.emitWarning('bindings.level is deprecated, use options.level option instead', 'Warning', 'PINODEP007')
+    warning.emit('PINODEP007')
     options.level = bindings.level
   }
   if (options.hasOwnProperty('serializers') === true) {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   "dependencies": {
     "fast-redact": "^3.0.0",
     "fast-safe-stringify": "^2.0.8",
+    "fastify-warning": "^0.2.0",
     "flatstr": "^1.0.12",
     "pino-std-serializers": "^3.1.0",
     "quick-format-unescaped": "^4.0.3",


### PR DESCRIPTION
This pull request uses `fastify-warning` instead of `process.emitWarning` directly in order to reduce the verbosity of warning messages. With this change, warnings will be emitted once per warning instead of every time the deprecated usage is invoked.

---
PR donated @knockaway.