### PR TITLE
Document pino.transport() async startup

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -104,11 +104,33 @@ pino(transport)
 
 For more details on `pino.transport` see the [API docs for `pino.transport`][pino-transport].
 
-
 [pino-transport]: /docs/api.md#pino-transport
 [sca]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 
 
+### Asynchronous startup
+
+The new transports boot asynchronously and calling `process.exit()` before the transport
+started will cause logs to not be delivered.
+
+```js
+const pino = require('pino')
+const transport = pino.transport({
+  targets: [
+    { target: '/absolute/path/to/my-transport.mjs', level: 'error' },
+    { target: 'some-file-transport', options: { destination: '/dev/null' }
+  ]
+})
+const logger = pino(transport)
+
+logger.info('hello')
+
+// If logs are printed before the transport is ready when process.exit(0) is called,
+// they will be lost.
+transport.on('ready', function () {
+  process.exit(0)
+})
+```
 
 ## Legacy Transports
 


### PR DESCRIPTION
Fixes #1095 

Unfortunately the asynchronous startup is a limitation of the current implementation. It might be possible to overcome this in the future but we should document it for now.

This is due to ThreadStream waiting for a `'READY'` message on the MessagePort - we would buffer all data in the meanwhile: https://github.com/pinojs/thread-stream/blob/e88be6efaccb9722b4b3ff9be6aa2cc8c1fedabd/index.js#L222-L225.