### PR TITLE
add transports constructor option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -367,6 +367,23 @@ documented in the [Browser API ⇗](/docs/browser.md) documentation.
 
 * See [Browser API ⇗](/docs/browser.md)
 
+#### `transport` (Object)
+
+The `transport` option is a shortcut to the [pino.transport()](#pino-transport) function.
+It support the same input options.
+```js
+require('pino')({
+  transport: {
+    target: '/absolute/path/to/my-transport.mjs'
+  }
+})
+```
+
+It is not possible to provide an additional [`destination`](#destination) argument
+when using the `transport` option. In this case an `Error` will be thrown.
+
+* See [pino.transport()](#pino-transport)
+
 <a id="destination"></a>
 ### `destination` (SonicBoom | WritableStream | String | Object)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -369,7 +369,7 @@ documented in the [Browser API ⇗](/docs/browser.md) documentation.
 
 #### `transport` (Object)
 
-The `transport` option is a shortcut to the [pino.transport()](#pino-transport) function.
+The `transport` option is a shorthand for the [pino.transport()](#pino-transport) function.
 It supports the same input options:
 ```js
 require('pino')({
@@ -389,7 +389,11 @@ require('pino')({
 })
 ```
 
-It is not possible to provide an additional [`destination`](#destination) argument
+If the transport option is supplied to `pino`, a [`destination`](#destination) parameter may not also be passed as a separate argument to `pino`:
+
+```js
+pino({ transport: {}}, '/path/to/somewhere') // THIS WILL NOT WORK, DO NOT DO THIS
+pino({ transport: {}}, process.stderr) // THIS WILL NOT WORK, DO NOT DO THIS
 when using the `transport` option. In this case an `Error` will be thrown.
 
 * See [pino.transport()](#pino-transport)

--- a/docs/api.md
+++ b/docs/api.md
@@ -370,11 +370,21 @@ documented in the [Browser API ⇗](/docs/browser.md) documentation.
 #### `transport` (Object)
 
 The `transport` option is a shortcut to the [pino.transport()](#pino-transport) function.
-It support the same input options.
+It support the same input options:
 ```js
 require('pino')({
   transport: {
     target: '/absolute/path/to/my-transport.mjs'
+  }
+})
+
+// or multiple transports
+require('pino')({
+  transport: {
+    targets: [
+      { target: '/absolute/path/to/my-transport.mjs', level: 'error' },
+      { target: 'some-file-transport', options: { destination: '/dev/null' }
+    ]
   }
 })
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -370,7 +370,7 @@ documented in the [Browser API ⇗](/docs/browser.md) documentation.
 #### `transport` (Object)
 
 The `transport` option is a shortcut to the [pino.transport()](#pino-transport) function.
-It support the same input options:
+It supports the same input options:
 ```js
 require('pino')({
   transport: {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -395,12 +395,15 @@ function createArgsNormalizer (defaultOptions) {
       stream = buildSafeSonicBoom({ dest: opts, sync: true })
       opts = {}
     } else if (typeof stream === 'string') {
+      if (opts.transport) {
+        throw Error('Only one of option.transport or stream can be specified')
+      }
       stream = buildSafeSonicBoom({ dest: stream, sync: true })
     } else if (opts instanceof SonicBoom || opts.writable || opts._writableState) {
       stream = opts
       opts = null
-    } else if (opts.transports) {
-      stream = transport(opts.transports)
+    } else if (opts.transport) {
+      stream = transport(opts.transport)
       opts = null
     }
     opts = Object.assign({}, defaultOptions, opts)

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -396,7 +396,7 @@ function createArgsNormalizer (defaultOptions) {
       opts = {}
     } else if (typeof stream === 'string') {
       if (opts && opts.transport) {
-        throw Error('Only one of option.transport or stream can be specified')
+        throw Error('only one of option.transport or stream can be specified')
       }
       stream = buildSafeSonicBoom({ dest: stream, sync: true })
     } else if (opts instanceof SonicBoom || opts.writable || opts._writableState) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -26,6 +26,7 @@ const {
   nestedKeyStrSym
 } = require('./symbols')
 const { isMainThread } = require('worker_threads')
+const transport = require('./transport')
 
 function noop () {}
 
@@ -397,6 +398,9 @@ function createArgsNormalizer (defaultOptions) {
       stream = buildSafeSonicBoom({ dest: stream, sync: true })
     } else if (opts instanceof SonicBoom || opts.writable || opts._writableState) {
       stream = opts
+      opts = null
+    } else if (opts.transports) {
+      stream = transport(opts.transports)
       opts = null
     }
     opts = Object.assign({}, defaultOptions, opts)

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -395,7 +395,7 @@ function createArgsNormalizer (defaultOptions) {
       stream = buildSafeSonicBoom({ dest: opts, sync: true })
       opts = {}
     } else if (typeof stream === 'string') {
-      if (opts.transport) {
+      if (opts && opts.transport) {
         throw Error('Only one of option.transport or stream can be specified')
       }
       stream = buildSafeSonicBoom({ dest: stream, sync: true })

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -64,7 +64,7 @@ function transport (fullOptions) {
   let target = fullOptions.target
 
   if (target && targets) {
-    throw new Error('Only one of target or targets can be specified')
+    throw new Error('only one of target or targets can be specified')
   }
 
   if (targets) {

--- a/test/transport.test.js
+++ b/test/transport.test.js
@@ -456,7 +456,7 @@ test('transport options with target and targets', async ({ fail, equal }) => {
     })
     fail('must throw')
   } catch (err) {
-    equal(err.message, 'Only one of target or targets can be specified')
+    equal(err.message, 'only one of target or targets can be specified')
   }
 })
 
@@ -469,6 +469,6 @@ test('transport options with target and stream', async ({ fail, equal }) => {
     }, '/log/null')
     fail('must throw')
   } catch (err) {
-    equal(err.message, 'Only one of option.transport or stream can be specified')
+    equal(err.message, 'only one of option.transport or stream can be specified')
   }
 })

--- a/test/transport.test.js
+++ b/test/transport.test.js
@@ -286,7 +286,7 @@ test('pino.transport with target and targets', async ({ fail, equal }) => {
     })
     fail('must throw')
   } catch (err) {
-    equal(err.message, 'Only one of target or targets can be specified')
+    equal(err.message, 'only one of target or targets can be specified')
   }
 })
 

--- a/test/transport.test.js
+++ b/test/transport.test.js
@@ -387,7 +387,7 @@ test('pino transports options with target', async ({ teardown, same }) => {
     '_' + Math.random().toString(36).substr(2, 9)
   )
   const instance = pino({
-    transports: {
+    transport: {
       target: '#pino/file',
       options: { destination }
     }
@@ -416,7 +416,7 @@ test('pino transports options with targets', async ({ teardown, same }) => {
     '_' + Math.random().toString(36).substr(2, 9)
   )
   const instance = pino({
-    transports: {
+    transport: {
       targets: [
         { target: '#pino/file', options: { destination: dest1 } },
         { target: '#pino/file', options: { destination: dest2 } }
@@ -446,17 +446,29 @@ test('pino transports options with targets', async ({ teardown, same }) => {
   })
 })
 
-test('transports options with target and targets', async ({ fail, equal }) => {
+test('transport options with target and targets', async ({ fail, equal }) => {
   try {
-    const instance = pino({
-      transports: {
+    pino({
+      transport: {
         target: {},
         targets: {}
       }
     })
-    instance.info('hello')
     fail('must throw')
   } catch (err) {
     equal(err.message, 'Only one of target or targets can be specified')
+  }
+})
+
+test('transport options with target and stream', async ({ fail, equal }) => {
+  try {
+    pino({
+      transport: {
+        target: {}
+      }
+    }, '/log/null')
+    fail('must throw')
+  } catch (err) {
+    equal(err.message, 'Only one of option.transport or stream can be specified')
   }
 })

--- a/test/transport.test.js
+++ b/test/transport.test.js
@@ -381,7 +381,7 @@ test('stdout in worker', async ({ not }) => {
   not(strip(actual).match(/Hello/), null)
 })
 
-test('pino transports options with target', async ({ teardown, same }) => {
+test('pino transport options with target', async ({ teardown, same }) => {
   const destination = join(
     os.tmpdir(),
     '_' + Math.random().toString(36).substr(2, 9)
@@ -406,7 +406,7 @@ test('pino transports options with target', async ({ teardown, same }) => {
   })
 })
 
-test('pino transports options with targets', async ({ teardown, same }) => {
+test('pino transport options with targets', async ({ teardown, same }) => {
   const dest1 = join(
     os.tmpdir(),
     '_' + Math.random().toString(36).substr(2, 9)


### PR DESCRIPTION
Implements #1105 

Opening as a draft to ask what do you prefer if:

- users add unnecessary options like a destination: should pino throw an error?

```js
  const instance = pino({
    name: 'logger',
    transport: {
      target: '#pino/file',
      options: { destination }
    }
  }, '/log/path')
``` 

- are you ok with the new `transports` field name to manage both `pino.transport()` input? ( `{target}` or `{targets:[]}` )


Then I'm going to add more tests and doc as well