### PR TITLE
Bump fast-redact to v3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "winston": "^3.3.3"
   },
   "dependencies": {
-    "fast-redact": "^3.0.0",
+    "fast-redact": "^3.0.2",
     "fast-safe-stringify": "^2.0.8",
     "fastify-warning": "^0.2.0",
     "get-caller-file": "^2.0.5",


### PR DESCRIPTION
This bumps `fast-redact` to [v3.0.2](https://github.com/davidmarkclements/fast-redact/releases/tag/v3.0.2), which fixes an issue with precensored redactions.

Fixes https://github.com/pinojs/pino/issues/919
