### PR TITLE
Support the newer pino-pretty as well as the older in v6.x

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -180,7 +180,7 @@ function getPrettyStream (opts, prettifier, dest, instance) {
     return prettifierMetaWrapper(prettifier(opts), dest, opts)
   }
   try {
-    const prettyFactory = require('pino-pretty')
+    const prettyFactory = require('pino-pretty').prettyFactory || require('pino-pretty')
     prettyFactory.asMetaWrapper = prettifierMetaWrapper
     return prettifierMetaWrapper(prettyFactory(opts), dest, opts)
   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "import-fresh": "^3.2.1",
     "log": "^6.0.0",
     "loglevel": "^1.6.7",
-    "pino-pretty": "^4.1.0",
+    "pino-pretty": "^5.0.0",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
     "pump": "^3.0.0",

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -54,12 +54,26 @@ test('throws when prettyPrint is true but pino-pretty module is not installed', 
   // pino pretty *is* installed, and probably also cached, so rather than
   // messing with the filesystem the simplest way to generate a not found
   // error is to simulate it:
-  const prettyFactory = require('pino-pretty')
+  const pinoPretty = require('pino-pretty')
   require.cache[require.resolve('pino-pretty')].exports = () => {
     throw Error('Cannot find module \'pino-pretty\'')
   }
   throws(() => pino({ prettyPrint: true }), 'Missing `pino-pretty` module: `pino-pretty` must be installed separately')
+  require.cache[require.resolve('pino-pretty')].exports = pinoPretty
+})
+
+test('support older pino-pretty', async ({ doesNotThrow }) => {
+  // pino pretty *is* installed, and probably also cached, so rather than
+  // messing with the filesystem the simplest way to generate a not found
+  // error is to simulate it:
+  const pinoPretty = require('pino-pretty')
+  const prettyFactory = pinoPretty.prettyFactory
+  pinoPretty.prettyFactory = undefined
   require.cache[require.resolve('pino-pretty')].exports = prettyFactory
+
+  doesNotThrow(() => pino({ prettyPrint: true }))
+
+  delete require.cache[require.resolve('pino-pretty')]
 })
 
 test('throws when prettyPrint has invalid options', async ({ throws }) => {


### PR DESCRIPTION
pino-pretty will change its export in v7. This change makes
it possible to support pino-pretty v4, v5, v6 and upcoming v7 at
the same time.

It also bumps the pino-pretty devDependency to v5.