### PR TITLE
[v6.x] set max depth and edge limit

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -25,6 +25,11 @@ const {
   messageKeySym
 } = require('./symbols')
 
+const defaultStringifyOptions = {
+  depthLimit: 100,
+  edgelimit: 200
+}
+
 function noop () {}
 
 function genLog (level, hook) {
@@ -401,7 +406,7 @@ function stringify (obj) {
   try {
     return JSON.stringify(obj)
   } catch (_) {
-    return stringifySafe(obj)
+    return stringifySafe(obj, undefined, undefined, defaultStringifyOptions)
   }
 }
 


### PR DESCRIPTION
Fixes #990

We might want to expose this as config values.

(Note that we cannot forward-port this change to v7.x, as we switched the serialization engine)