### PR TITLE
dep: removes fast-safe-stringify dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
   },
   "dependencies": {
     "fast-redact": "^3.0.0",
-    "fast-safe-stringify": "^2.0.8",
     "fastify-warning": "^0.2.0",
     "get-caller-file": "^2.0.5",
     "json-stringify-safe": "^5.0.1",


### PR DESCRIPTION
This was left behind from #1066 