### PR TITLE
Restore automerge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,18 +44,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
 
-## Disabled because the exclude parameter causes a syntax error
-## and I don't know how to fix it. ~ James Sumners 2021-06-20
-#   automerge:
-#     needs: test
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: fastify/github-action-merge-dependabot@v2.1.1
-#         with:
-#           github-token: ${{ secrets.GITHUB_TOKEN }}
-#           exclude: [
-#             'sonic-boom',
-#             'pino-std-serializers',
-#             'quick-format-unescaped',
-#             'fast-redact'
-#           ]
+   automerge:
+     needs: test
+     runs-on: ubuntu-latest
+     steps:
+       - uses: fastify/github-action-merge-dependabot@v2.4.0
+         with:
+           github-token: ${{ secrets.GITHUB_TOKEN }}
+           exclude: [
+             'sonic-boom',
+             'pino-std-serializers',
+             'quick-format-unescaped',
+             'fast-redact'
+           ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,16 +44,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel-finished: true
 
-   automerge:
-     needs: test
-     runs-on: ubuntu-latest
-     steps:
-       - uses: fastify/github-action-merge-dependabot@v2.4.0
-         with:
-           github-token: ${{ secrets.GITHUB_TOKEN }}
-           exclude: [
-             'sonic-boom',
-             'pino-std-serializers',
-             'quick-format-unescaped',
-             'fast-redact'
-           ]
+  automerge:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fastify/github-action-merge-dependabot@v2.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          exclude: [
+            'sonic-boom',
+            'pino-std-serializers',
+            'quick-format-unescaped',
+            'fast-redact'
+          ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: fastify/github-action-merge-dependabot@v2.4.0
+      - uses: fastify/github-action-merge-dependabot@v2.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          exclude: [
-            'sonic-boom',
-            'pino-std-serializers',
-            'quick-format-unescaped',
-            'fast-redact'
-          ]
+          exclude: 'sonic-boom,pino-std-serializers,quick-format-unescaped,fast-redact'

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "homepage": "http://getpino.io",
   "devDependencies": {
-    "@types/node": "^16.7.10",
+    "@types/node": "^16.9.4",
     "airtap": "4.0.3",
     "benchmark": "^2.1.4",
     "bole": "^4.0.0",


### PR DESCRIPTION
refs https://github.com/fastify/github-action-merge-dependabot/issues/53

It previously didn't work because github-action-merge expected syntax that is not supported by GitHub Actions.