### PR TITLE
fix: flush thread-stream missing callback

### DIFF
--- a/file.js
+++ b/file.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { Transform, pipeline } = require('stream')
-const pino = require('../pino')
+const pino = require('./pino')
 const { once } = require('events')
 
 module.exports = async function (opts = {}) {

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -190,7 +190,9 @@ function write (_obj, msg, num) {
   stream.write(s)
 }
 
+function noop () {}
+
 function flush () {
   const stream = this[streamSym]
-  if ('flush' in stream) stream.flush()
+  if ('flush' in stream) stream.flush(noop)
 }

--- a/test/fixtures/console-transport.js
+++ b/test/fixtures/console-transport.js
@@ -1,12 +1,10 @@
 const { Writable } = require('stream')
-const { pass } = require('tap')
 
 module.exports = (options) => {
   const myTransportStream = new Writable({
     write (chunk, enc, cb) {
       // apply a transform and send to stdout
       console.log(chunk.toString().toUpperCase())
-      pass()
       cb()
     }
   })

--- a/test/fixtures/console-transport.js
+++ b/test/fixtures/console-transport.js
@@ -1,0 +1,14 @@
+const { Writable } = require('stream')
+const { pass } = require('tap')
+
+module.exports = (options) => {
+  const myTransportStream = new Writable({
+    write (chunk, enc, cb) {
+      // apply a transform and send to stdout
+      console.log(chunk.toString().toUpperCase())
+      pass()
+      cb()
+    }
+  })
+  return myTransportStream
+}

--- a/test/syncfalse.test.js
+++ b/test/syncfalse.test.js
@@ -116,3 +116,13 @@ test('flush does nothing with sync true (default)', async () => {
   const instance = require('..')()
   instance.flush()
 })
+
+test('thread-stream async flush', async () => {
+  const pino = require('..')
+  const transport = pino.transport({
+    target: join(__dirname, 'fixtures', 'console-transport.js')
+  })
+  const instance = pino(transport)
+  instance.info('hello')
+  instance.flush()
+})

--- a/test/targets.test.js
+++ b/test/targets.test.js
@@ -8,7 +8,7 @@ test('file-target mocked', async function ({ equal, same, plan, pass }) {
   plan(1)
   let ret
   const fileTarget = proxyquire('../file', {
-    '../pino': {
+    './pino': {
       destination (opts) {
         same(opts, { dest: 1, sync: false })
 


### PR DESCRIPTION
Fixes #1136 

Currently, `.flush` will be either `sonic-beam` stream or `thread-stream` stream.
`sonic-beam` stream do not require `callback` for `.flush`. But, `thread-stream` does.

I just put a `noop` callback inside the function to prevent throwing for `thread-stream`.