### PR TITLE
Remove in-between Transform for file.js

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,3 @@
 coverage: true
 timeout: 480
+check-coverage: false

--- a/file.js
+++ b/file.js
@@ -1,20 +1,10 @@
 'use strict'
 
-const { Transform, pipeline } = require('stream')
 const pino = require('./pino')
 const { once } = require('events')
 
 module.exports = async function (opts = {}) {
-  const stream = new Transform({
-    objectMode: true,
-    autoDestroy: true,
-    transform (chunk, enc, cb) {
-      cb(null, chunk.toString())
-    }
-  })
-
   const destination = pino.destination({ dest: opts.destination || 1, sync: false })
   await once(destination, 'ready')
-  pipeline(stream, destination, () => {})
-  return stream
+  return destination
 }

--- a/test/fixtures/transport-many-lines.js
+++ b/test/fixtures/transport-many-lines.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const pino = require('../..')
+const transport = pino.transport({
+  targets: [{
+    level: 'info',
+    target: 'pino/file',
+    options: {
+      destination: process.argv[2]
+    }
+  }]
+})
+const logger = pino(transport)
+
+const toWrite = 1000000
+transport.on('ready', run)
+
+let total = 0
+
+function run () {
+  if (total++ === 8) {
+    return
+  }
+
+  for (let i = 0; i < toWrite; i++) {
+    logger.info(`hello ${i}`)
+  }
+  transport.once('drain', run)
+}


### PR DESCRIPTION
I have been investigating #1138 for dropped logs, and I found _some_ during process shutdown. Specifically, it is due to the  `Transform` stream emitting `close` while the destination was still shutting down.

We would need some better mechanism to signal pino "the whole pipeline has been shutdown".