### PR TITLE
Fix types for `pino.multistream`

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -246,7 +246,8 @@ declare namespace P {
     }
 
     function multistream(
-        streamsArray: StreamEntry[], opts?: P.MultiStreamOptions
+        streamsArray: (DestinationStream | StreamEntry)[] | DestinationStream | StreamEntry,
+        opts?: P.MultiStreamOptions
     ): MultiStreamRes
 
     /**

--- a/test/types/pino-multistream.test-d.ts
+++ b/test/types/pino-multistream.test-d.ts
@@ -11,6 +11,11 @@ const streams = [
   { level: 'fatal' as const, stream: createWriteStream('') }
 ]
 
+expectType<pino.MultiStreamRes>(pino.multistream(process.stdout))
+expectType<pino.MultiStreamRes>(pino.multistream([createWriteStream('')]))
+expectType<pino.MultiStreamRes>(pino.multistream({ level: 'error' as const, stream: process.stderr }))
+expectType<pino.MultiStreamRes>(pino.multistream([{ level: 'fatal' as const, stream: createWriteStream('') }]))
+
 expectType<pino.MultiStreamRes>(pino.multistream(streams))
 expectType<pino.MultiStreamRes>(pino.multistream(streams, {}))
 expectType<pino.MultiStreamRes>(pino.multistream(streams, { levels: { 'info': 30 } }))


### PR DESCRIPTION
Fixes TypeScript types for `pino.multistream`.

Also, the implementation of `pino.multistream` is actually pretty loose with the first argument. It can handle:

- An object with `stream` and optionally `level` properties (i.e. a `StreamEntry`)
- An object with a `write` method (i.e. a `DestinationStream`)
- An array of the above

However, only array of `StreamEntry` is documented, and the current types reflect that. I don't know if that is intentional, so I have not changed that for now. If not, then the correct type should be `(DestinationStream | StreamEntry)[] | DestinationStream | StreamEntry`