### PR TITLE
fix(docs/transports): #pino/file has been renamed to pino/file

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -212,7 +212,7 @@ The `options.destination` property may be set to specify the desired file destin
 ```js
 const pino = require('pino')
 const transport = pino.transport({
-  target: '#pino/file',
+  target: 'pino/file',
   options: { destination: '/path/to/file' }
 })
 pino(transport)
@@ -220,7 +220,7 @@ pino(transport)
 
 The `options.destination` property may also be a number to represent a file descriptor. Typically this would be `1` to write to STDOUT or `2` to write to STDERR. If `options.destination` is not set, it defaults to `1` which means logs will be written to STDOUT.
 
-The difference between using the `#pino/file` transport builtin and using `pino.destination` is that `pino.destination` runs in the main thread, whereas `#pino/file` sets up `pino.destination` in a worker thread.
+The difference between using the `pino/file` transport builtin and using `pino.destination` is that `pino.destination` runs in the main thread, whereas `pino/file` sets up `pino.destination` in a worker thread.
 
 #### `pino-pretty`
 


### PR DESCRIPTION
This resolved #1158