### PR TITLE
fix formatters when used along transport

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -402,10 +402,9 @@ function createArgsNormalizer (defaultOptions) {
       stream = buildSafeSonicBoom({ dest: stream, sync: true })
     } else if (opts instanceof SonicBoom || opts.writable || opts._writableState) {
       stream = opts
-      opts = null
+      opts = {}
     } else if (opts.transport) {
       stream = transport({ caller, ...opts.transport })
-      opts = null
     }
     opts = Object.assign({}, defaultOptions, opts)
     opts.serializers = Object.assign({}, defaultOptions.serializers, opts.serializers)


### PR DESCRIPTION
PR fixing #1139.

Formatters are actually executed regardless of the transports in tools#asJson, the issue was while normalizing arguments during the instantiation.