### PR TITLE
feat: Improve caller detection.

### DIFF
--- a/lib/caller.js
+++ b/lib/caller.js
@@ -1,3 +1,5 @@
+'use strict'
+
 function noOpPrepareStackTrace (_, stack) {
   return stack
 }

--- a/lib/caller.js
+++ b/lib/caller.js
@@ -1,0 +1,22 @@
+function noOpPrepareStackTrace (_, stack) {
+  return stack
+}
+
+module.exports = function getCaller () {
+  const originalPrepare = Error.prepareStackTrace
+  Error.prepareStackTrace = noOpPrepareStackTrace
+  const stack = new Error().stack
+  Error.prepareStackTrace = originalPrepare
+
+  if (!Array.isArray(stack)) {
+    return undefined
+  }
+
+  for (const entry of stack.slice(2)) {
+    const file = entry ? entry.getFileName() : undefined
+
+    if (file && file.indexOf('node_modules') === -1) {
+      return file
+    }
+  }
+}

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { createRequire } = require('module')
-const getCaller = require('get-caller-file')
+const getCaller = require('./caller')
 const { join, isAbsolute } = require('path')
 
 let onExit

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
   "dependencies": {
     "fast-redact": "^3.0.0",
     "fastify-warning": "^0.2.0",
-    "get-caller-file": "^2.0.5",
     "on-exit-leak-free": "^0.2.0",
     "pino-abstract-transport": "v0.4.0",
     "pino-std-serializers": "^4.0.0",

--- a/pino.js
+++ b/pino.js
@@ -2,7 +2,7 @@
 /* eslint no-prototype-builtins: 0 */
 const os = require('os')
 const stdSerializers = require('pino-std-serializers')
-const caller = require('get-caller-file')
+const caller = require('./lib/caller')
 const redaction = require('./lib/redaction')
 const time = require('./lib/time')
 const proto = require('./lib/proto')


### PR DESCRIPTION
This PR improves the caller fallbacking slightly modifying the logic used by `get-caller-file`.
Rather than stopping on the third element of the stack, the code iterates the list until a file entry which does not contain `node_modules` is found. This should cover the case in which pino is installed as a dependency of another module (even recursively).

Once the approach is cleared, I'll take care of tests and docs.