### PR TITLE
Restrict the deprecation of prettyPrint to disallow require('pino-pretty’)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -358,7 +358,10 @@ and searching for logged objects can start from a consistent path.
 
 Default: `false`
 
-__DEPRECATED: use [`transport`](#transport) instead.__
+__DEPRECATED: automatically requiring of `pino-pretty` is deprecated__. 
+There are two alternatives:
+1. [`transport`](#transport) instead.__
+2. pass `prettyPrint: require('pino-pretty')`.
 
 Enables pretty printing log logs. This is intended for non-production
 configurations. This may be set to a configuration object as outlined in the

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -1,6 +1,9 @@
 'use strict'
 
-const pino = require('..')()
+const pino = require('..')({
+  // Uncomment to enable pretty printing
+  // prettyPrint: require('pino-pretty')
+})
 
 pino.info('hello world')
 pino.error('this is at error level')

--- a/lib/deprecations.js
+++ b/lib/deprecations.js
@@ -5,4 +5,4 @@ module.exports = warning
 
 const warnName = 'PinoWarning'
 
-warning.create(warnName, 'PINODEP008', 'prettyPrint is deprecated, use the pino-pretty transport instead')
+warning.create(warnName, 'PINODEP008', 'prettyPrint: true is deprecated, use `prettyPrint: require(\'pino-pretty\')` or pino.transport() instead.')

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -212,11 +212,17 @@ function asChindings (instance, bindings) {
 }
 
 function getPrettyStream (opts, prettifier, dest, instance) {
+  if (prettifier && typeof prettifier.prettyFactory === 'function') {
+    // this is pino-pretty
+    prettifier = prettifier.prettyFactory
+  }
   if (prettifier && typeof prettifier === 'function') {
     prettifier = prettifier.bind(instance)
     return prettifierMetaWrapper(prettifier(opts), dest, opts)
   }
   try {
+    // The direct require of pino-pretty is deprecated
+    warning.emit('PINODEP008')
     const prettyFactory = require('pino-pretty').prettyFactory
     prettyFactory.asMetaWrapper = prettifierMetaWrapper
     return prettifierMetaWrapper(prettyFactory(opts), dest, opts)
@@ -421,14 +427,17 @@ function createArgsNormalizer (defaultOptions) {
       opts.levelKey = opts.changeLevelName
       delete opts.changeLevelName
     }
-    const { enabled, prettyPrint, prettifier, messageKey } = opts
+    const { enabled, prettyPrint, messageKey } = opts
+    let prettifier = opts.prettifier
     if (enabled === false) opts.level = 'silent'
     stream = stream || process.stdout
     if (stream === process.stdout && stream.fd >= 0 && !hasBeenTampered(stream)) {
       stream = buildSafeSonicBoom({ fd: stream.fd, sync: true })
     }
     if (prettyPrint) {
-      warning.emit('PINODEP008')
+      if (typeof prettyPrint === 'function' || !prettifier) {
+        prettifier = prettyPrint
+      }
       const prettyOpts = Object.assign({ messageKey }, prettyPrint)
       stream = getPrettyStream(prettyOpts, prettifier, stream, instance)
     }

--- a/test/fixtures/pretty/basic.js
+++ b/test/fixtures/pretty/basic.js
@@ -2,5 +2,5 @@ global.process = { __proto__: process, pid: 123456 }
 Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
-const log = pino({ prettyPrint: true })
+const log = pino({ prettyPrint: require('pino-pretty') })
 log.info('h')

--- a/test/fixtures/pretty/child-with-serializer.js
+++ b/test/fixtures/pretty/child-with-serializer.js
@@ -3,7 +3,7 @@ Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
 const log = pino({
-  prettyPrint: true,
+  prettyPrint: require('pino-pretty'),
   serializers: {
     a (num) {
       return num * 2

--- a/test/fixtures/pretty/child-with-updated-chindings.js
+++ b/test/fixtures/pretty/child-with-updated-chindings.js
@@ -2,7 +2,7 @@ global.process = { __proto__: process, pid: 123456 }
 Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
-const log = pino({ prettyPrint: true }).child({ foo: 123 })
+const log = pino({ prettyPrint: require('pino-pretty') }).child({ foo: 123 })
 log.info('before')
 log.setBindings({ foo: 456, bar: 789 })
 log.info('after')

--- a/test/fixtures/pretty/child.js
+++ b/test/fixtures/pretty/child.js
@@ -2,7 +2,7 @@ global.process = { __proto__: process, pid: 123456 }
 Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
-const log = pino({ prettyPrint: true }).child({ a: 1 })
+const log = pino({ prettyPrint: require('pino-pretty') }).child({ a: 1 })
 log.info('h')
 log.child({ b: 2 }).info('h3')
 setTimeout(() => log.info('h2'), 200)

--- a/test/fixtures/pretty/custom-time-label.js
+++ b/test/fixtures/pretty/custom-time-label.js
@@ -4,6 +4,6 @@ require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
 const log = pino({
   timestamp: () => ',"custom-time-label":"test"',
-  prettyPrint: true
+  prettyPrint: require('pino-pretty')
 })
 log.info('h')

--- a/test/fixtures/pretty/custom-time.js
+++ b/test/fixtures/pretty/custom-time.js
@@ -4,6 +4,6 @@ require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
 const log = pino({
   timestamp: () => ',"time":"test"',
-  prettyPrint: true
+  prettyPrint: require('pino-pretty')
 })
 log.info('h')

--- a/test/fixtures/pretty/dateformat.js
+++ b/test/fixtures/pretty/dateformat.js
@@ -5,6 +5,7 @@ const pino = require(require.resolve('./../../../'))
 const log = pino({
   prettyPrint: {
     translateTime: true
-  }
+  },
+  prettifier: require('pino-pretty')
 })
 log.info('h')

--- a/test/fixtures/pretty/error-props.js
+++ b/test/fixtures/pretty/error-props.js
@@ -3,7 +3,10 @@ Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
 const log = pino({
-  prettyPrint: { errorProps: 'code,errno' }
+  prettyPrint: {
+    errorProps: 'code,errno'
+  },
+  prettifier: require('pino-pretty')
 })
 const err = Object.assign(new Error('kaboom'), { code: 'ENOENT', errno: 1 })
 log.error(err)

--- a/test/fixtures/pretty/error.js
+++ b/test/fixtures/pretty/error.js
@@ -2,6 +2,6 @@ global.process = { __proto__: process, pid: 123456 }
 Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
-const log = pino({ prettyPrint: true })
+const log = pino({ prettyPrint: require('pino-pretty') })
 log.error(new Error('kaboom'))
 log.error(new Error('kaboom'), 'with a message')

--- a/test/fixtures/pretty/final-no-log-before.js
+++ b/test/fixtures/pretty/final-no-log-before.js
@@ -2,7 +2,7 @@ global.process = { __proto__: process, pid: 123456 }
 Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
-const log = pino({ prettyPrint: true })
+const log = pino({ prettyPrint: require('pino-pretty') })
 process.once('beforeExit', pino.final(log, (_, logger) => {
   logger.info('beforeExit')
 }))

--- a/test/fixtures/pretty/final-return.js
+++ b/test/fixtures/pretty/final-return.js
@@ -2,6 +2,6 @@ global.process = { __proto__: process, pid: 123456 }
 Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
-const log = pino({ prettyPrint: true })
+const log = pino({ prettyPrint: require('pino-pretty') })
 log.info('h')
 pino.final(log).info('after')

--- a/test/fixtures/pretty/final.js
+++ b/test/fixtures/pretty/final.js
@@ -2,7 +2,7 @@ global.process = { __proto__: process, pid: 123456 }
 Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
-const log = pino({ prettyPrint: true })
+const log = pino({ prettyPrint: require('pino-pretty') })
 log.info('h')
 process.once('beforeExit', pino.final(log, (_, logger) => {
   logger.info('beforeExit')

--- a/test/fixtures/pretty/formatters.js
+++ b/test/fixtures/pretty/formatters.js
@@ -3,7 +3,7 @@ Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
 const log = pino({
-  prettyPrint: true,
+  prettyPrint: require('pino-pretty'),
   formatters: {
     log (obj) {
       return { foo: 'formatted_' + obj.foo }

--- a/test/fixtures/pretty/level-first.js
+++ b/test/fixtures/pretty/level-first.js
@@ -2,5 +2,10 @@ global.process = { __proto__: process, pid: 123456 }
 Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
-const log = pino({ prettyPrint: { levelFirst: true } })
+const log = pino({
+  prettyPrint: {
+    levelFirst: true
+  },
+  prettifier: require('pino-pretty')
+})
 log.info('h')

--- a/test/fixtures/pretty/no-time.js
+++ b/test/fixtures/pretty/no-time.js
@@ -4,6 +4,6 @@ require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
 const log = pino({
   timestamp: false,
-  prettyPrint: true
+  prettyPrint: require('pino-pretty')
 })
 log.info('h')

--- a/test/fixtures/pretty/obj-msg-prop.js
+++ b/test/fixtures/pretty/obj-msg-prop.js
@@ -2,5 +2,5 @@ global.process = { __proto__: process, pid: 123456 }
 Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
-const log = pino({ prettyPrint: true })
+const log = pino({ prettyPrint: require('pino-pretty') })
 log.info({ msg: 'hello' })

--- a/test/fixtures/pretty/redact.js
+++ b/test/fixtures/pretty/redact.js
@@ -3,7 +3,7 @@ Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
 const log = pino({
-  prettyPrint: true,
+  prettyPrint: require('pino-pretty'),
   redact: ['foo.an']
 })
 log.info({ foo: { an: 'object' } }, 'h')

--- a/test/fixtures/pretty/serializers.js
+++ b/test/fixtures/pretty/serializers.js
@@ -3,7 +3,7 @@ Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
 const log = pino({
-  prettyPrint: true,
+  prettyPrint: require('pino-pretty'),
   serializers: {
     foo (obj) {
       if (obj.an !== 'object') {

--- a/test/fixtures/pretty/skipped-output.js
+++ b/test/fixtures/pretty/skipped-output.js
@@ -3,7 +3,7 @@ Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
 const log = pino({
-  prettyPrint: true,
+  prettyPrint: {},
   prettifier: function () {
     return function () {
       return undefined

--- a/test/fixtures/pretty/suppress-flush-sync-warning.js
+++ b/test/fixtures/pretty/suppress-flush-sync-warning.js
@@ -2,6 +2,6 @@ global.process = { __proto__: process, pid: 123456 }
 Date.now = function () { return 1459875739796 }
 require('os').hostname = function () { return 'abcdefghijklmnopqr' }
 const pino = require(require.resolve('./../../../'))
-const log = pino({ prettyPrint: { suppressFlushSyncWarning: true } })
+const log = pino({ prettyPrint: { suppressFlushSyncWarning: true }, prettifier: require('pino-pretty') })
 log.info('h')
 log.fatal('h1')


### PR DESCRIPTION
The main source of problems for pino-pretty was our internal require. This keeps the same logic around but allow the user to pass through pino-pretty.

Note I can also produce an _alternative_ PR that shows how to use pino-pretty as a standard stream. I’ll prepare it after this soon.

Fixes https://github.com/pinojs/pino/issues/1201