### PR TITLE
Avoid duplicate action runs for eg. Dependabot

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,8 @@
 name: Benchmarks
 on:
   push:
+    branches:
+      - main
     paths-ignore:
         - 'docs/**'
         - '*.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 on:
   push:
+    branches:
+      - main
     paths-ignore:
         - 'docs/**'
         - '*.md'


### PR DESCRIPTION
Dependabot, and some of you who are maintainers here, pushes to branches in the pino repo itself and unless one tell GitHub Action that it should jobs to only trigger the `push` events on the `main` branch, then it will trigger both the `push` and the `pull_request` events when PR:s gets opened for those, making a Dependabot PR look like:

<img width="942" alt="Skärmavbild 2021-11-15 kl  23 02 06" src="https://user-images.githubusercontent.com/34457/141860234-f18bbc72-f243-4e65-8922-bf398e126729.png">

I recently made this change myself to get rid of this duplicates, thought I would share 👍 