### PR TITLE
build(dependabot): ignore minor and patch github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,10 @@ version: 2
 updates:
 - package-ecosystem: github-actions
   directory: '/'
+  ignore:
+      - dependency-name: 'actions/*'
+        update-types:
+            ['version-update:semver-minor', 'version-update:semver-patch']
   schedule:
     interval: daily
   open-pull-requests-limit: 10

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v2
         with:
           ref: ${{ github.base_ref }}
       - name: Setup Node
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
       - name: Install Modules
@@ -29,7 +29,7 @@ jobs:
       - name: Run Benchmark
         run: npm run bench | tee current.txt
       - name: Upload Current Results
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v2
         with:
           name: current
           path: current.txt
@@ -39,9 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v2
       - name: Setup Node
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v2
         with:
           node-version: 12
       - name: Install Modules
@@ -49,7 +49,7 @@ jobs:
       - name: Run Benchmark
         run: npm run bench | tee branch.txt
       - name: Upload Branch Results
-        uses: actions/upload-artifact@v2.2.4
+        uses: actions/upload-artifact@v2
         with:
           name: branch
           path: branch.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
         os: [macOS-latest, windows-latest, ubuntu-latest]
         node-version: [12, 14, 16]
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install

--- a/.github/workflows/package-manager-ci.yml
+++ b/.github/workflows/package-manager-ci.yml
@@ -14,9 +14,9 @@ jobs:
         os: [windows-latest, ubuntu-latest]
         node-version: [14]
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Use pnpm
@@ -37,9 +37,9 @@ jobs:
         os: [windows-latest, ubuntu-latest]
         node-version: [14]
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Use yarn
@@ -64,9 +64,9 @@ jobs:
         os: [windows-latest, ubuntu-latest]
         node-version: [14]
     steps:
-      - uses: actions/checkout@v2.3.5
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - name: Use yarn


### PR DESCRIPTION
GitHub introduced the [ability to ignore specific updates](https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/) back in May.
This PR should stop Dependabot flooding PRs with every minor and patch update of GitHub's own actions every day.

Happy to make change for rest of Pino repos if wanted.