### PR TITLE
Update LTS document

### DIFF
--- a/docs/lts.md
+++ b/docs/lts.md
@@ -43,7 +43,8 @@ A "month" is defined as 30 consecutive days.
 
 | Version | Release Date | End Of LTS Date | Node.js              |
 | :------ | :----------- | :-------------- | :------------------- |
-| 6.x     | 2020-03-07   | TBD             | 10, 12, 14, 16       |
+| 7.x     | 2021-10-14   | TBD             | 12, 14, 16           |
+| 6.x     | 2020-03-07   | 2022-04-14      | 10, 12, 14, 16       |
 
 <a name="supported-os"></a>
 


### PR DESCRIPTION
According to the doc itself, we only support actively supported Node.js LTS releases. Thus, v17 is a bonus covered by our CI but not a guarantee in our policy.