### PR TITLE
forward all unknown options passed to pino/file transport to destination

### DIFF
--- a/file.js
+++ b/file.js
@@ -4,9 +4,8 @@ const pino = require('./pino')
 const { once } = require('events')
 
 module.exports = async function (opts = {}) {
-  const destOpts = { dest: opts.destination || 1, sync: false }
-  if (opts.append === false) destOpts.append = false
-  if (opts.mkdir) destOpts.mkdir = true
+  const destOpts = Object.assign({}, opts, { dest: opts.destination || 1, sync: false })
+  delete destOpts.destination
   const destination = pino.destination(destOpts)
   await once(destination, 'ready')
   return destination


### PR DESCRIPTION
As discussed in #1229.

We delete the `destination` property just to avoid any confusion since that's not a properly that pino.destination / SonicBoom recognizes.