### PR TITLE
test: make test timeouts configurable

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -54,7 +54,7 @@ function sleep (ms) {
 
 function watchFileCreated (filename) {
   return new Promise((resolve, reject) => {
-    const TIMEOUT = 2000
+    const TIMEOUT = process.env.PINO_TEST_WAIT_WATCHFILE_TIMEOUT || 2000
     const INTERVAL = 100
     const threshold = TIMEOUT / INTERVAL
     let counter = 0
@@ -79,7 +79,7 @@ function watchFileCreated (filename) {
 
 function watchForWrite (filename, testString) {
   return new Promise((resolve, reject) => {
-    const TIMEOUT = 2000
+    const TIMEOUT = process.env.PINO_TEST_WAIT_WRITE_TIMEOUT || 2000
     const INTERVAL = 100
     const threshold = TIMEOUT / INTERVAL
     let counter = 0

--- a/test/helper.js
+++ b/test/helper.js
@@ -79,7 +79,7 @@ function watchFileCreated (filename) {
 
 function watchForWrite (filename, testString) {
   return new Promise((resolve, reject) => {
-    const TIMEOUT = process.env.PINO_TEST_WAIT_WRITE_TIMEOUT || 2000
+    const TIMEOUT = process.env.PINO_TEST_WAIT_WRITE_TIMEOUT || 10000
     const INTERVAL = 100
     const threshold = TIMEOUT / INTERVAL
     let counter = 0

--- a/test/helper.js
+++ b/test/helper.js
@@ -54,7 +54,7 @@ function sleep (ms) {
 
 function watchFileCreated (filename) {
   return new Promise((resolve, reject) => {
-    const TIMEOUT = process.env.PINO_TEST_WAIT_WATCHFILE_TIMEOUT || 2000
+    const TIMEOUT = process.env.PINO_TEST_WAIT_WATCHFILE_TIMEOUT || 10000
     const INTERVAL = 100
     const threshold = TIMEOUT / INTERVAL
     let counter = 0


### PR DESCRIPTION
We saw some timeouts in the tests when we were running to validate in Red Hat containers (for example: https://catalog.redhat.com/software/containers/ubi8/nodejs-12/5d3fff015a13461f5fb8635a).

Our investigation so far points to it being loading/resource issue on the machines we are running versus anything in the tests.

We'd like to be able to extended timeouts in the tests, this PR adds a simple way to do that through the environment. 