### PR TITLE
fix(caller): use calling file name for libraries calling Pino

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ profile-*
 # lock files
 yarn.lock
 package-lock.json
+
+!test/fixtures/eval/node_modules

--- a/lib/caller.js
+++ b/lib/caller.js
@@ -1,7 +1,17 @@
 'use strict'
 
+const fs = require('fs')
+
 function noOpPrepareStackTrace (_, stack) {
   return stack
+}
+
+function isFileName (input) {
+  return typeof input === 'string' && fs.existsSync(input)
+}
+
+function isOutsideNodeModules (file) {
+  return isFileName(file) && file.indexOf('node_modules') === -1
 }
 
 module.exports = function getCaller () {
@@ -14,13 +24,15 @@ module.exports = function getCaller () {
     return undefined
   }
 
-  for (const entry of stack.slice(2)) {
+  const entries = stack.slice(2)
+
+  for (const entry of entries) {
     const file = entry ? entry.getFileName() : undefined
 
-    if (file && file.indexOf('node_modules') === -1) {
+    if (isOutsideNodeModules(file)) {
       return file
     }
   }
 
-  return stack[2]?.getFileName()
+  return entries[0] ? entries[0].getFileName() : undefined
 }

--- a/lib/caller.js
+++ b/lib/caller.js
@@ -21,4 +21,6 @@ module.exports = function getCaller () {
       return file
     }
   }
+
+  return stack[2]?.getFileName()
 }

--- a/lib/caller.js
+++ b/lib/caller.js
@@ -6,12 +6,8 @@ function noOpPrepareStackTrace (_, stack) {
   return stack
 }
 
-function isFileName (input) {
-  return typeof input === 'string' && fs.existsSync(input)
-}
-
-function isOutsideNodeModules (file) {
-  return isFileName(file) && file.indexOf('node_modules') === -1
+function isOutsideNodeModules (input) {
+  return typeof input === 'string' && fs.existsSync(input) && input.indexOf('node_modules') === -1
 }
 
 module.exports = function getCaller () {

--- a/test/fixtures/eval/index.js
+++ b/test/fixtures/eval/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-eval */
 
 eval(`
-const pino = require('../../')
+const pino = require('../../../')
 
 const logger = pino(
   pino.transport({

--- a/test/fixtures/eval/node_modules/14-files.js
+++ b/test/fixtures/eval/node_modules/14-files.js
@@ -1,0 +1,3 @@
+const file1 = require("./file1.js")
+
+file1()

--- a/test/fixtures/eval/node_modules/2-files.js
+++ b/test/fixtures/eval/node_modules/2-files.js
@@ -1,0 +1,3 @@
+const file12 = require("./file12.js")
+
+file12()

--- a/test/fixtures/eval/node_modules/file1.js
+++ b/test/fixtures/eval/node_modules/file1.js
@@ -1,0 +1,5 @@
+const file2 = require("./file2.js")
+
+module.exports = function () {
+    file2()
+}

--- a/test/fixtures/eval/node_modules/file10.js
+++ b/test/fixtures/eval/node_modules/file10.js
@@ -1,0 +1,5 @@
+const file11 = require("./file11.js")
+
+module.exports = function () {
+    file11()
+}

--- a/test/fixtures/eval/node_modules/file11.js
+++ b/test/fixtures/eval/node_modules/file11.js
@@ -1,0 +1,5 @@
+const file12 = require("./file12.js")
+
+module.exports = function () {
+    file12()
+}

--- a/test/fixtures/eval/node_modules/file12.js
+++ b/test/fixtures/eval/node_modules/file12.js
@@ -1,0 +1,5 @@
+const file13 = require("./file13.js")
+
+module.exports = function () {
+    file13()
+}

--- a/test/fixtures/eval/node_modules/file13.js
+++ b/test/fixtures/eval/node_modules/file13.js
@@ -1,0 +1,5 @@
+const file14 = require("./file14.js")
+
+module.exports = function () {
+    file14()
+}

--- a/test/fixtures/eval/node_modules/file14.js
+++ b/test/fixtures/eval/node_modules/file14.js
@@ -1,0 +1,11 @@
+const pino = require("../../../../");
+
+module.exports = function() {
+    const logger = pino(
+        pino.transport({
+            target: 'pino-pretty'
+        })
+    )
+
+    logger.info('done!')
+}

--- a/test/fixtures/eval/node_modules/file2.js
+++ b/test/fixtures/eval/node_modules/file2.js
@@ -1,0 +1,5 @@
+const file3 = require("./file3.js")
+
+module.exports = function () {
+    file3()
+}

--- a/test/fixtures/eval/node_modules/file3.js
+++ b/test/fixtures/eval/node_modules/file3.js
@@ -1,0 +1,5 @@
+const file4 = require("./file4.js")
+
+module.exports = function () {
+    file4()
+}

--- a/test/fixtures/eval/node_modules/file4.js
+++ b/test/fixtures/eval/node_modules/file4.js
@@ -1,0 +1,5 @@
+const file5 = require("./file5.js")
+
+module.exports = function () {
+    file5()
+}

--- a/test/fixtures/eval/node_modules/file5.js
+++ b/test/fixtures/eval/node_modules/file5.js
@@ -1,0 +1,5 @@
+const file6 = require("./file6.js")
+
+module.exports = function () {
+    file6()
+}

--- a/test/fixtures/eval/node_modules/file6.js
+++ b/test/fixtures/eval/node_modules/file6.js
@@ -1,0 +1,5 @@
+const file7 = require("./file7.js")
+
+module.exports = function () {
+    file7()
+}

--- a/test/fixtures/eval/node_modules/file7.js
+++ b/test/fixtures/eval/node_modules/file7.js
@@ -1,0 +1,5 @@
+const file8 = require("./file8.js")
+
+module.exports = function () {
+    file8()
+}

--- a/test/fixtures/eval/node_modules/file8.js
+++ b/test/fixtures/eval/node_modules/file8.js
@@ -1,0 +1,5 @@
+const file9 = require("./file9.js")
+
+module.exports = function () {
+    file9()
+}

--- a/test/fixtures/eval/node_modules/file9.js
+++ b/test/fixtures/eval/node_modules/file9.js
@@ -1,0 +1,5 @@
+const file10 = require("./file10.js")
+
+module.exports = function () {
+    file10()
+}

--- a/test/transport/caller.test.js
+++ b/test/transport/caller.test.js
@@ -7,8 +7,38 @@ const execa = require('execa')
 
 const { once } = require('../helper')
 
-test('app using a custom transport', async function (t) {
-  const evalApp = join(__dirname, '../', '/fixtures/eval')
+test('when using a custom transport outside node_modules, the first file outside node_modules should be used', async function (t) {
+  const evalApp = join(__dirname, '../', '/fixtures/eval/index.js')
+  const child = execa(process.argv[0], [evalApp])
+
+  let actual = ''
+  child.stdout.pipe(writer((s, enc, cb) => {
+    actual += s
+    cb()
+  }))
+
+  await once(child, 'close')
+
+  t.match(actual, /done!/)
+})
+
+test('when using a custom transport where some files in stacktrace are in the node_modules, the first file outside node_modules should be used', async function (t) {
+  const evalApp = join(__dirname, '../', '/fixtures/eval/node_modules/2-files.js')
+  const child = execa(process.argv[0], [evalApp])
+
+  let actual = ''
+  child.stdout.pipe(writer((s, enc, cb) => {
+    actual += s
+    cb()
+  }))
+
+  await once(child, 'close')
+
+  t.match(actual, /done!/)
+})
+
+test('when using a custom transport where all files in stacktrace are in the node_modules, the first file inside node_modules should be used', async function (t) {
+  const evalApp = join(__dirname, '../', '/fixtures/eval/node_modules/14-files.js')
   const child = execa(process.argv[0], [evalApp])
 
   let actual = ''


### PR DESCRIPTION
Excluding all the files in `node_modules` didn't work with `nestjs-pino`

I guess because there are too many files before reaching the user's files

This will return the file in second position in the stacktrace as `get-caller-file` did if we can't find a file outside `node_modules`

Stacktrace:
````
/Users/my-repo/node_modules/one-dependency/packages/file1.js
/Users/my-repo/node_modules/one-dependency/packages/file2.hs
/Users/my-repo/node_modules/pino-http/logger.js
/Users/my-repo/node_modules/pino-http/logger.js
/Users/my-repo/node_modules/nestjs-pino/LoggerModule.js
/Users/my-repo/node_modules/nestjs-pino/LoggerModule.js
/Users/my-repo/node_modules/@nestjs/core/middleware/middleware-module.js
/Users/my-repo/node_modules/@nestjs/core/middleware/middleware-module.js
````

Other example:
````
/Users/my-repo/node_modules/nestjs-pino/PinoLogger.js
/Users/my-repo/node_modules/@nestjs/core/injector/injector.js
/Users/my-repo/node_modules/@nestjs/core/injector/injector.js
/Users/my-repo/node_modules/@nestjs/core/injector/injector.js
/Users/my-repo/node_modules/@nestjs/core/injector/injector.js
/Users/my-repo/node_modules/@nestjs/core/injector/injector.js
/Users/my-repo/node_modules/@nestjs/core/injector/injector.js
/Users/my-repo/node_modules/@nestjs/core/injector/injector.js
````

I wasn't able to create a test for this case

This fixes https://github.com/pinojs/pino/issues/1277