### PR TITLE
fix: passing stream to transport

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -406,7 +406,7 @@ function createArgsNormalizer (defaultOptions) {
       stream = opts
       opts = {}
     } else if (opts.transport) {
-      if (opts instanceof SonicBoom || opts.transport.writable || opts.transport._writableState) {
+      if (opts.transport instanceof SonicBoom || opts.transport.writable || opts.transport._writableState) {
         throw Error('option.transport do not allow stream, please pass to option directly. e.g. pino(transport)')
       }
       stream = transport({ caller, ...opts.transport })

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -406,6 +406,9 @@ function createArgsNormalizer (defaultOptions) {
       stream = opts
       opts = {}
     } else if (opts.transport) {
+      if (opts instanceof SonicBoom || opts.transport.writable || opts.transport._writableState) {
+        throw Error('option.transport do not allow stream, please pass to option directly. e.g. pino(transport)')
+      }
       stream = transport({ caller, ...opts.transport })
     }
     opts = Object.assign({}, defaultOptions, opts)

--- a/test/transport/core.test.js
+++ b/test/transport/core.test.js
@@ -480,3 +480,20 @@ test('transport options with target and stream', async ({ fail, equal }) => {
     equal(err.message, 'only one of option.transport or stream can be specified')
   }
 })
+
+test('transport options with stream', async ({ fail, equal, teardown }) => {
+  try {
+    const dest1 = join(
+      os.tmpdir(),
+      '_' + Math.random().toString(36).substr(2, 9)
+    )
+    const transportStream = pino.transport({ target: 'pino/file', options: { destination: dest1 } })
+    teardown(transportStream.end.bind(transportStream))
+    pino({
+      transport: transportStream
+    })
+    fail('must throw')
+  } catch (err) {
+    equal(err.message, 'option.transport do not allow stream, please pass to option directly. e.g. pino(transport)')
+  }
+})


### PR DESCRIPTION
throw if people pass a stream to `option.transport`.

Closes #1285 