### PR TITLE
fix: missing types

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -562,6 +562,16 @@ declare namespace pino {
              */
             logMethod?: (args: any[], method: LogFn, level: number) => void;
         };
+
+        /**
+         * Stringification limit at a specific nesting depth when logging circular object. Default: `5`.
+         */
+         depthLimit?: number
+
+         /**
+          * Stringification limit of properties/elements when logging a specific object/array with circular references. Default: `100`.
+          */
+          edgeLimit?: number
     }
 
     interface ChildLoggerOptions {

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -55,6 +55,14 @@ pino({
 });
 
 pino({
+    depthLimit: 1
+});
+
+pino({
+    edgeLimit: 1
+});
+
+pino({
     browser: {
         write(o) {},
     },


### PR DESCRIPTION
Add missing types ([docs](https://getpino.io/#/docs/api?id=depthlimit-number)): `depthLimit` and `edgeLimit`