### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -32,7 +32,7 @@ fastify.get('/', async (request, reply) => {
 The `logger` option can also be set to an object, which will be passed through directly
 as the [`pino` options object](/docs/api.md#options-object).
 
-See the [fastify documentation](https://www.fastify.io/docs/latest/Logging/) for more information.
+See the [fastify documentation](https://www.fastify.io/docs/latest/Reference/Logging/) for more information.
 
 <a id="express"></a>
 ## Pino with Express


### PR DESCRIPTION
origin url was Not Found