### PR TITLE
upgrade fast-redact to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,11 +102,11 @@
     "winston": "^3.3.3"
   },
   "dependencies": {
-    "fast-redact": "^3.0.0",
-    "process-warning": "^1.0.0",
+    "fast-redact": "^3.1.0",
     "on-exit-leak-free": "^0.2.0",
     "pino-abstract-transport": "v0.5.0",
     "pino-std-serializers": "^4.0.0",
+    "process-warning": "^1.0.0",
     "quick-format-unescaped": "^4.0.3",
     "real-require": "^0.1.0",
     "safe-stable-stringify": "^2.1.0",


### PR DESCRIPTION
* Upgraded fast-redact to 3.1.0, multi-wildcard support for log redaction
* fix package.json deps order