### PR TITLE
Add option `mixinMergeStrategy`

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -16,6 +16,7 @@ const {
   mixinSym,
   asJsonSym,
   writeSym,
+  mixinMergeStrategySym,
   timeSym,
   timeSliceIndexSym,
   streamSym,
@@ -177,16 +178,29 @@ function setBindings (newBindings) {
   delete this[parsedChindingsSym]
 }
 
+/**
+ * Default strategy for creating `mergeObject` from arguments and the result from `mixin()`.
+ * Fields from `mergeObject` have higher priority in this strategy.
+ *
+ * @param {Object} mergeObject The object a user has supplied to the logging function.
+ * @param {Object} mixinObject The result of the `mixin` method.
+ * @return {Object}
+ */
+function defaultMixinMergeStrategy (mergeObject, mixinObject) {
+  return Object.assign(mixinObject, mergeObject)
+}
+
 function write (_obj, msg, num) {
   const t = this[timeSym]()
   const mixin = this[mixinSym]
+  const mixinMergeStrategy = this[mixinMergeStrategySym] || defaultMixinMergeStrategy
   const objError = _obj instanceof Error
   let obj
 
   if (_obj === undefined || _obj === null) {
     obj = mixin ? mixin({}) : {}
   } else {
-    obj = Object.assign(mixin ? mixin(_obj) : {}, _obj)
+    obj = mixinMergeStrategy(_obj, mixin ? mixin(_obj) : {})
     if (!msg && objError) {
       msg = _obj.message
     }

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -24,6 +24,7 @@ const endSym = Symbol('pino.end')
 const formatOptsSym = Symbol('pino.formatOpts')
 const messageKeySym = Symbol('pino.messageKey')
 const nestedKeySym = Symbol('pino.nestedKey')
+const mixinMergeStrategySym = Symbol('pino.mixinMergeStrategy')
 
 const wildcardFirstSym = Symbol('pino.wildcardFirst')
 
@@ -60,5 +61,6 @@ module.exports = {
   needsMetadataGsym,
   useOnlyCustomLevelsSym,
   formattersSym,
-  hooksSym
+  hooksSym,
+  mixinMergeStrategySym
 }

--- a/pino.js
+++ b/pino.js
@@ -17,6 +17,7 @@ const {
   noop
 } = require('./lib/tools')
 const { version } = require('./lib/meta')
+const { mixinMergeStrategySym } = require('./lib/symbols')
 const {
   chindingsSym,
   redactFmtSym,
@@ -91,6 +92,7 @@ function pino (...args) {
     changeLevelName,
     levelKey,
     mixin,
+    mixinMergeStrategy,
     useOnlyCustomLevels,
     formatters,
     hooks
@@ -173,6 +175,7 @@ function pino (...args) {
     [nestedKeySym]: nestedKey,
     [serializersSym]: serializers,
     [mixinSym]: mixin,
+    [mixinMergeStrategySym]: mixinMergeStrategy,
     [chindingsSym]: chindings,
     [formattersSym]: allFormatters,
     [hooksSym]: hooks,

--- a/test/mixin-merge-strategy.test.js
+++ b/test/mixin-merge-strategy.test.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const { test } = require('tap')
+const { sink, once } = require('./helper')
+const pino = require('../')
+
+const level = 50
+const name = 'error'
+
+test('default merge strategy', async ({ ok, same }) => {
+  const stream = sink()
+  const instance = pino({
+    base: {},
+    mixin () {
+      return { tag: 'k8s' }
+    }
+  }, stream)
+  instance.level = name
+  instance[name]({
+    tag: 'local'
+  }, 'test')
+  const result = await once(stream, 'data')
+  ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
+  delete result.time
+  same(result, {
+    level,
+    msg: 'test',
+    tag: 'local'
+  })
+})
+
+test('custom merge strategy with mixin priority', async ({ ok, same }) => {
+  const stream = sink()
+  const instance = pino({
+    base: {},
+    mixin () {
+      return { tag: 'k8s' }
+    },
+    mixinMergeStrategy (mergeObject, mixinObject) {
+      return Object.assign(mergeObject, mixinObject)
+    }
+  }, stream)
+  instance.level = name
+  instance[name]({
+    tag: 'local'
+  }, 'test')
+  const result = await once(stream, 'data')
+  ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
+  delete result.time
+  same(result, {
+    level,
+    msg: 'test',
+    tag: 'k8s'
+  })
+})


### PR DESCRIPTION
Added new option `mixinMergeStrategy` for define custom strategy merge `mergeObject` from log method argument and `mixin`


Example:
```js
// Custom muttable strategy, `mixin` has priority
const logger = pino({
    mixin() {
        return { tag: 'k8s' }
    },
    mixinMergeStrategy(mergeObject, mixinObject) {
        return Object.assign(mergeObject, mixinObject)
    }
})
logger.info({
    tag: 'local'
}, 'Message')
// {"level":30,"time":1591195061437,"pid":16012,"hostname":"x","tag":"k8s","msg":"Message"}
```