### PR TITLE
Add `flush` function to types

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -102,6 +102,11 @@ interface LoggerExtras<Options = LoggerOptions> extends EventEmitter {
      * Returns an object containing all the current bindings, cloned from the ones passed in via logger.child().
      */
     bindings(): pino.Bindings;
+
+    /**
+     * Flushes the content of the buffer when using pino.destination({ sync: false }).
+     */
+    flush(): () => void;
 }
 
 

--- a/test/types/pino.ts
+++ b/test/types/pino.ts
@@ -1,6 +1,6 @@
 import { pino } from '../../pino'
 import { join } from 'path'
-import { tmpdir } from'os'
+import { tmpdir } from 'os'
 
 const destination = join(
     tmpdir(),
@@ -14,6 +14,7 @@ const transport = pino.transport({
 })
 const logger = pino(transport)
 logger.info('test2')
+logger.flush()
 
 const transport2 = pino.transport({
     target: 'pino-pretty',


### PR DESCRIPTION
After 5e31678 `Logger` doesn't allow arbitrary properties anymore, which
revealed that types are missing `.flush` function definition.
