### PR TITLE
docs: add syntax highlighting for typescript

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,5 +47,7 @@
 <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
 <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
 <script src="//unpkg.com/docsify/lib/plugins/ga.min.js"></script>
+<!-- To enable syntax highlighting on TypeScript codes: -->
+<script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-typescript.min.js"></script>
 
 </html>


### PR DESCRIPTION
According to [Docsify docs](https://docsify.js.org/#/language-highlight?id=language-highlighting) only few languages are supported by default by Prism (the underlying lib), and TypeScript is not. This PR adds such support on TypeScript snippets like the one at `web` page.

<table>
  <tr>
    <th>now</th>
    <th>then</th>
  </tr>
  <tr>
    <td valign="top"><img src="https://user-images.githubusercontent.com/13461315/155027871-999c24e1-6327-4822-9d74-709b4c11338d.png" alt="before" />
</td>
    <td valign="top"><img src="https://user-images.githubusercontent.com/13461315/155027889-033bd768-5618-468f-9be7-ed14a013f2fc.png" alt="after" /></td>
  </tr>
</table>