### PR TITLE
Fix hasOwnProperty usage

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -290,7 +290,7 @@ function prettifierMetaWrapper (pretty, dest, opts) {
       const formattedObj = formatters.log ? formatters.log(lastObj) : lastObj
 
       const messageKey = lastLogger[messageKeySym]
-      if (lastMsg && formattedObj && !Object.prototype.hasOwnProperty(formattedObj, messageKey)) {
+      if (lastMsg && formattedObj && !Object.prototype.hasOwnProperty.call(formattedObj, messageKey)) {
         formattedObj[messageKey] = lastMsg
       }
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -108,7 +108,6 @@ function asJson (obj, msg, num, time) {
   data = data + chindings
 
   let value
-  const notHasOwnProperty = obj.hasOwnProperty === undefined
   if (formatters.log) {
     obj = formatters.log(obj)
   }
@@ -116,7 +115,7 @@ function asJson (obj, msg, num, time) {
   let propStr = ''
   for (const key in obj) {
     value = obj[key]
-    if ((notHasOwnProperty || obj.hasOwnProperty(key)) && value !== undefined) {
+    if (Object.prototype.hasOwnProperty.call(obj, key) && value !== undefined) {
       value = serializers[key] ? serializers[key](value) : value
 
       const stringifier = stringifiers[key] || wildcardStringifier
@@ -291,7 +290,7 @@ function prettifierMetaWrapper (pretty, dest, opts) {
       const formattedObj = formatters.log ? formatters.log(lastObj) : lastObj
 
       const messageKey = lastLogger[messageKeySym]
-      if (lastMsg && formattedObj && !formattedObj.hasOwnProperty(messageKey)) {
+      if (lastMsg && formattedObj && !Object.prototype.hasOwnProperty(formattedObj, messageKey)) {
         formattedObj[messageKey] = lastMsg
       }
 

--- a/test/fixtures/pretty/null-prototype.js
+++ b/test/fixtures/pretty/null-prototype.js
@@ -1,0 +1,8 @@
+global.process = { __proto__: process, pid: 123456 }
+Date.now = function () { return 1459875739796 }
+require('os').hostname = function () { return 'abcdefghijklmnopqr' }
+const pino = require(require.resolve('./../../../'))
+const log = pino({ prettyPrint: true })
+const obj = Object.create(null)
+Object.assign(obj, { foo: 'bar' })
+log.info(obj, 'hello')

--- a/test/pretty.test.js
+++ b/test/pretty.test.js
@@ -341,6 +341,18 @@ test('works as expected with an object with the msg prop', async ({ not }) => {
   not(strip(actual).match(/\(123456 on abcdefghijklmnopqr\): hello/), null)
 })
 
+test('handles objects with null prototypes', async ({ not }) => {
+  let actual = ''
+  const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'pretty', 'null-prototype.js')])
+
+  child.stdout.pipe(writer((s, enc, cb) => {
+    actual += s
+    cb()
+  }))
+  await once(child, 'close')
+  not(strip(actual).match(/\(123456 on abcdefghijklmnopqr\): hello\s+foo: "bar"/), null)
+})
+
 test('should not lose stream metadata for streams with `needsMetadataGsym` flag', async ({ not }) => {
   const dest = new Writable({
     objectMode: true,


### PR DESCRIPTION
Under certain circumstances, the user's mergingObject may be passed through as is to `write`. If the mergingObject was created with no prototype (`Object.create(null)`), then calling hasOwnProperty will fail.

Sample problematic code:

```js
const PinoMS = require('pino-multi-stream');
const pino = require('pino');
const logger = pino({}, pino.multistream([
  { stream: PinoMS.prettyStream({ prettyPrint: { colorize: true, translateTime: 'SYS:standard' } }) }
]));

const example = Object.create(null);
Object.assign(example, { hello: 'world' });
logger.info(example, 'hello world');
```

(This worked prior to Pino 7.8.0.)

For consistency, I also updated another usage of hasOwnProperty to match the new style.