### PR TITLE
fix: Throw when using custom level formatters with multiple transports (#1353)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -293,6 +293,8 @@ Changes the shape of the log level. The default shape is `{ level: number }`.
 The function takes two arguments, the label of the level (e.g. `'info'`)
 and the numeric value (e.g. `30`).
 
+ps: The log level cannot be customized when using multiple transports
+
 ```js
 const formatters = {
   level (label, number) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -409,6 +409,9 @@ function createArgsNormalizer (defaultOptions) {
       if (opts.transport instanceof SonicBoom || opts.transport.writable || opts.transport._writableState) {
         throw Error('option.transport do not allow stream, please pass to option directly. e.g. pino(transport)')
       }
+      if (opts.transport.targets && opts.transport.targets.length && opts.formatters && typeof opts.formatters.level === 'function') {
+        throw Error('option.transport.targets do not allow custom level formatters')
+      }
       stream = transport({ caller, ...opts.transport })
     }
     opts = Object.assign({}, defaultOptions, opts)

--- a/test/formatters.test.js
+++ b/test/formatters.test.js
@@ -335,3 +335,30 @@ test('formatter with transport', async ({ match, equal }) => {
     nested: { object: true }
   })
 })
+
+test('throws when custom level formatter is used with transport.targets', async ({ throws }) => {
+  const destination = join(
+    os.tmpdir(),
+    '_' + Math.random().toString(36).substr(2, 9)
+  )
+
+  throws(() => {
+    pino({
+      formatters: {
+        level (label) {
+          return label
+        }
+      },
+      transport: {
+        targets: [
+          {
+            target: 'pino/file',
+            options: { destination }
+          }
+        ]
+      }
+    }
+    )
+  },
+  Error('option.transport.targets do not allow custom level formatters'))
+})


### PR DESCRIPTION
This PR aim to fix an [issue](https://github.com/pinojs/pino/issues/1353) where if the user is using a custom level formatter and multiple transports at the same time logs will not be written and the user will not be notified.

Instead of failing silently the new behavior is to throw an error when both options are used at the same time (as mentioned [here](https://github.com/pinojs/pino/issues/1353#issuecomment-1059203373))