### PR TITLE
Fix: TypeScript: Make TransportOptions optional

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -224,7 +224,7 @@ declare namespace pino {
 
     interface TransportTargetOptions<TransportOptions = Record<string, any>> {
         target: string
-        options: TransportOptions
+        options?: TransportOptions
         level: LevelWithSilent
     }
 


### PR DESCRIPTION
Options is not optional currently:
- https://github.com/pinojs/pino/blob/5d8eb719761003bce52d12ccc9e0a5b69ef9e185/pino.d.ts#L227