### PR TITLE
fix: Run parent bindings formatter when creating child logger

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -117,7 +117,12 @@ function child (bindings, options) {
   } else {
     instance[formattersSym] = buildFormatters(
       formatters.level,
-      resetChildingsFormatter,
+      formatters.bindings
+        ? (bindings) => ({
+            ...formatters.bindings(JSON.parse('{' + this[chindingsSym].substr(1) + '}')),
+            ...bindings
+          })
+        : resetChildingsFormatter,
       formatters.log
     )
   }

--- a/test/formatters.test.js
+++ b/test/formatters.test.js
@@ -201,6 +201,79 @@ test('Formatters in child logger', async ({ match }) => {
   })
 })
 
+test('Parent bindings in child logger', async ({ match }) => {
+  const stream = sink()
+
+  const logger = pino({
+    formatters: {
+      bindings (bindings) {
+        return {
+          ...bindings,
+          process: {
+            pid: bindings.pid
+          },
+          from: 'parent'
+        }
+      }
+    }
+  }, stream)
+
+  const child = logger.child({
+    foo: 'bar'
+  })
+
+  const childOut = once(stream, 'data')
+  child.info('hello world')
+
+  match(await childOut, {
+    process: {
+      pid: process.pid
+    },
+    from: 'parent',
+    foo: 'bar'
+  })
+})
+
+test('Parent bindings in child logger with it\'s own bindings', async ({ match }) => {
+  const stream = sink()
+  const logger = pino({
+    formatters: {
+      bindings (bindings) {
+        return {
+          process: {
+            pid: bindings.pid
+          },
+          from: 'parent'
+        }
+      }
+    }
+  }, stream)
+
+  const childWithBindings = logger.child({
+    foo: 'bar'
+  }, {
+    formatters: {
+      bindings (bindings) {
+        return {
+          ...bindings,
+          from: 'child'
+        }
+      }
+    }
+  })
+
+  const childWithBindingsOut = once(stream, 'data')
+  childWithBindings.info('hello world')
+
+  match(await childWithBindingsOut, {
+    process: {
+      pid: process.pid
+    },
+    foo: 'bar',
+    from: 'child'
+  })
+})
+
 test('Formatters without bindings in child logger', async ({ match }) => {
   const stream = sink()
   const logger = pino({


### PR DESCRIPTION
Should fix pinojs/pino#1212.

I'm not entirely sure about my approach here, specially the `JSON.parse` part, I ran the benchmarks and didn't notice any regressions, but also got some random variation so I'm not 100% sure, but I didn't found another way to pass the right `bindings` argument to the parent formatter.