### PR TITLE
use pino/file instead of pino-pretty for caller transport tests

### DIFF
--- a/test/fixtures/eval/index.js
+++ b/test/fixtures/eval/index.js
@@ -5,7 +5,7 @@ const pino = require('../../../')
 
 const logger = pino(
   pino.transport({
-    target: 'pino-pretty'
+    target: 'pino/file'
   })
 )
 

--- a/test/fixtures/eval/node_modules/file14.js
+++ b/test/fixtures/eval/node_modules/file14.js
@@ -3,7 +3,7 @@ const pino = require("../../../../");
 module.exports = function() {
     const logger = pino(
         pino.transport({
-            target: 'pino-pretty'
+            target: 'pino/file'
         })
     )
 

--- a/test/transport/caller.test.js
+++ b/test/transport/caller.test.js
@@ -1,53 +1,23 @@
 'use strict'
 
-const writer = require('flush-write-stream')
 const { join } = require('path')
 const { test } = require('tap')
 const execa = require('execa')
 
-const { once } = require('../helper')
-
 test('when using a custom transport outside node_modules, the first file outside node_modules should be used', async function (t) {
   const evalApp = join(__dirname, '../', '/fixtures/eval/index.js')
-  const child = execa(process.argv[0], [evalApp])
-
-  let actual = ''
-  child.stdout.pipe(writer((s, enc, cb) => {
-    actual += s
-    cb()
-  }))
-
-  await once(child, 'close')
-
-  t.match(actual, /done!/)
+  const { stdout } = await execa(process.argv[0], [evalApp])
+  t.match(stdout, /done!/)
 })
 
 test('when using a custom transport where some files in stacktrace are in the node_modules, the first file outside node_modules should be used', async function (t) {
   const evalApp = join(__dirname, '../', '/fixtures/eval/node_modules/2-files.js')
-  const child = execa(process.argv[0], [evalApp])
-
-  let actual = ''
-  child.stdout.pipe(writer((s, enc, cb) => {
-    actual += s
-    cb()
-  }))
-
-  await once(child, 'close')
-
-  t.match(actual, /done!/)
+  const { stdout } = await execa(process.argv[0], [evalApp])
+  t.match(stdout, /done!/)
 })
 
 test('when using a custom transport where all files in stacktrace are in the node_modules, the first file inside node_modules should be used', async function (t) {
   const evalApp = join(__dirname, '../', '/fixtures/eval/node_modules/14-files.js')
-  const child = execa(process.argv[0], [evalApp])
-
-  let actual = ''
-  child.stdout.pipe(writer((s, enc, cb) => {
-    actual += s
-    cb()
-  }))
-
-  await once(child, 'close')
-
-  t.match(actual, /done!/)
+  const { stdout } = await execa(process.argv[0], [evalApp])
+  t.match(stdout, /done!/)
 })


### PR DESCRIPTION
This is due to https://github.com/pinojs/pino-pretty/issues/304 which
might trigger under severe load and short-lived scripts. The fix
on pino-pretty will happen on its own time but there is no need
to use pino-pretty in these tests.

Fixes #1368