### PR TITLE
Fix pino.multristream test failure.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jest": "^27.3.1",
     "log": "^6.0.0",
     "loglevel": "^1.6.7",
-    "pino-pretty": "^v7.5.1",
+    "pino-pretty": "^v7.5.3",
     "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
     "pump": "^3.0.0",

--- a/test/multistream.test.js
+++ b/test/multistream.test.js
@@ -221,11 +221,16 @@ test('supports pretty print', function (t) {
     cb()
   })
 
-  const pretty = proxyquire('pino-pretty', {
+  const nested = proxyquire('pino-pretty/lib/utils', {
     'sonic-boom': function () {
       t.pass('sonic created')
+      stream.flushSync = () => {}
+      stream.flush = () => {}
       return stream
     }
+  })
+  const pretty = proxyquire('pino-pretty', {
+    './lib/utils': nested
   })
 
   const log = pino({


### PR DESCRIPTION
Using proxyquire is really a bad pattern but it's needed sometimes. However in this cases it has bitten us :/