### PR TITLE
fix incorrect type definition of censor function

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -38,7 +38,7 @@ type CustomLevelLogger<Options> = Options extends { customLevels: Record<string,
 
 interface redactOptions {
     paths: string[];
-    censor?: string | ((v: any) => any);
+    censor?: string | ((value: any, path: string[]) => any);
     remove?: boolean;
 }
 

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -64,6 +64,14 @@ pino({
 });
 
 pino({
+    redact: { paths: [], censor: (value) => value },
+});
+
+pino({
+    redact: { paths: [], censor: (value, path) => path.join() },
+});
+
+pino({
     depthLimit: 1
 });
 


### PR DESCRIPTION
`censor` takes two arguments: value and path