### PR TITLE
Add option to pass custom levels down to `multistream()` from transport

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -96,6 +96,19 @@ const transport = pino.transport({
 pino(transport)
 ```
 
+If we're using custom levels, they should be passed in when using more than one transport.
+```js
+const pino = require('pino')
+const transport = pino.transport({
+  targets: [
+    { target: '/absolute/path/to/my-transport.mjs', level: 'error' },
+    { target: 'some-file-transport', options: { destination: '/dev/null' }
+  ],
+  levels: { foo: 35 }
+})
+pino(transport)
+```
+
 For more details on `pino.transport` see the [API docs for `pino.transport`][pino-transport].
 
 [pino-transport]: /docs/api.md#pino-transport

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -411,7 +411,12 @@ function createArgsNormalizer (defaultOptions) {
       if (opts.transport.targets && opts.transport.targets.length && opts.formatters && typeof opts.formatters.level === 'function') {
         throw Error('option.transport.targets do not allow custom level formatters')
       }
-      stream = transport({ caller, ...opts.transport, levels: opts.customLevels })
+
+      let customLevels
+      if (opts.customLevels) {
+        customLevels = opts.useOnlyCustomLevels ? opts.customLevels : Object.assign({}, opts.levels, opts.customLevels)
+      }
+      stream = transport({ caller, ...opts.transport, levels: customLevels })
     }
     opts = Object.assign({}, defaultOptions, opts)
     opts.serializers = Object.assign({}, defaultOptions.serializers, opts.serializers)

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -411,7 +411,7 @@ function createArgsNormalizer (defaultOptions) {
       if (opts.transport.targets && opts.transport.targets.length && opts.formatters && typeof opts.formatters.level === 'function') {
         throw Error('option.transport.targets do not allow custom level formatters')
       }
-      stream = transport({ caller, ...opts.transport })
+      stream = transport({ caller, ...opts.transport, levels: opts.customLevels })
     }
     opts = Object.assign({}, defaultOptions, opts)
     opts.serializers = Object.assign({}, defaultOptions.serializers, opts.serializers)

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -79,7 +79,7 @@ function autoEnd (stream) {
 }
 
 function transport (fullOptions) {
-  const { pipeline, targets, options = {}, worker = {}, caller = getCallers() } = fullOptions
+  const { pipeline, targets, levels, options = {}, worker = {}, caller = getCallers() } = fullOptions
 
   // Backwards compatibility
   const callers = typeof caller === 'string' ? [caller] : caller
@@ -101,7 +101,7 @@ function transport (fullOptions) {
         target: fixTarget(dest.target)
       }
     })
-  } else if (fullOptions.pipeline) {
+  } else if (pipeline) {
     target = bundlerOverrides['pino-pipeline-worker'] || join(__dirname, 'worker-pipeline.js')
     options.targets = pipeline.map((dest) => {
       return {
@@ -109,6 +109,10 @@ function transport (fullOptions) {
         target: fixTarget(dest.target)
       }
     })
+  }
+
+  if (levels) {
+    options.levels = levels
   }
 
   return buildStream(fixTarget(target), options, worker)

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -9,7 +9,7 @@ const { realImport, realRequire } = require('real-require')
 
 /* istanbul ignore file */
 
-module.exports = async function ({ targets }) {
+module.exports = async function ({ targets, levels }) {
   targets = await Promise.all(targets.map(async (t) => {
     let fn
     try {
@@ -49,7 +49,7 @@ module.exports = async function ({ targets }) {
   })
 
   function process (stream) {
-    const multi = pino.multistream(targets)
+    const multi = pino.multistream(targets, { levels })
     // TODO manage backpressure
     stream.on('data', function (chunk) {
       const { lastTime, lastMsg, lastObj, lastLevel } = this

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -225,7 +225,7 @@ declare namespace pino {
     interface TransportTargetOptions<TransportOptions = Record<string, any>> {
         target: string
         options: TransportOptions
-        level: LevelWithSilent
+        level: LevelWithSilent | string
     }
 
     interface TransportBaseOptions<TransportOptions = Record<string, any>> {
@@ -242,7 +242,8 @@ declare namespace pino {
     }
 
     interface TransportMultiOptions<TransportOptions = Record<string, any>> extends TransportBaseOptions<TransportOptions>{
-        targets: readonly TransportTargetOptions<TransportOptions>[]
+        targets: readonly TransportTargetOptions<TransportOptions>[],
+        levels?: Record<string, number>
     }
 
     interface MultiStreamOptions {

--- a/pino.js
+++ b/pino.js
@@ -8,7 +8,7 @@ const time = require('./lib/time')
 const proto = require('./lib/proto')
 const symbols = require('./lib/symbols')
 const { configure } = require('safe-stable-stringify')
-const { assertDefaultLevelFound, mappings, genLsCache } = require('./lib/levels')
+const { assertDefaultLevelFound, mappings, genLsCache, levels } = require('./lib/levels')
 const {
   createArgsNormalizer,
   asChindings,
@@ -48,6 +48,7 @@ const hostname = os.hostname()
 const defaultErrorSerializer = stdSerializers.err
 const defaultOptions = {
   level: 'info',
+  levels,
   messageKey: 'msg',
   nestedKey: null,
   enabled: true,

--- a/test/types/pino-transport.test-d.ts
+++ b/test/types/pino-transport.test-d.ts
@@ -44,6 +44,35 @@ expectType<pino.Logger>(pino({
         ]},
 }))
 
+const transportsWithCustomLevels = pino.transport({targets: [
+    {
+        level: 'info',
+        target: '#pino/pretty',
+        options: { some: 'options for', the: 'transport' }
+    },
+    {
+        level: 'foo',
+        target: '#pino/file',
+        options: { destination: './test.log' }
+    }
+], levels: { foo: 35 }})
+pino(transports)
+
+expectType<pino.Logger>(pino({
+    transport: {targets: [
+            {
+                level: 'info',
+                target: '#pino/pretty',
+                options: { some: 'options for', the: 'transport' }
+            },
+            {
+                level: 'trace',
+                target: '#pino/file',
+                options: { destination: './test.log' }
+            }
+        ], levels: { foo: 35 }
+    },
+}))
 
 const pipelineTransport = pino.transport({
     pipeline: [{


### PR DESCRIPTION
Closes #1189