### PR TITLE
Add LevelWithSilent as an exported type

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -788,6 +788,7 @@ export const version: typeof pino.version;
 // Types
 export type Bindings = pino.Bindings;
 export type Level = pino.Level;
+export type LevelWithSilent = pino.LevelWithSilent;
 export type LevelChangeEventListener = pino.LevelChangeEventListener;
 export type LogDescriptor = pino.LogDescriptor;
 export type Logger<Options = LoggerOptions> = pino.Logger<Options>;

--- a/test/types/pino-type-only.test-d.ts
+++ b/test/types/pino-type-only.test-d.ts
@@ -1,7 +1,7 @@
-import { expectType } from "tsd";
+import { expectAssignable, expectType } from "tsd";
 
 import pino from "../../";
-import type {Logger, LogFn, P} from "../../pino";
+import type {LevelWithSilent, Logger, LogFn, P} from "../../pino";
 
 // NB: can also use `import * as pino`, but that form is callable as `pino()`
 // under `esModuleInterop: false` or `pino.default()` under `esModuleInterop: true`.
@@ -11,3 +11,6 @@ expectType<LogFn>(log.info);
 
 expectType<P.Logger>(log);
 expectType<P.LogFn>(log.info);
+
+const level: LevelWithSilent = 'silent';
+expectAssignable<P.LevelWithSilent>(level);


### PR DESCRIPTION
As per #1352, the community supported `@types/pino-multi-stream` package has a dependency on `LevelWithSilent`.

However, that PR is lacking any tests.

I've added a simple types test but open to feedback if there are bettter/different ways to test this.