### PR TITLE
chore: add pino lambda to ecosystem doc

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -72,3 +72,4 @@ prettifier inspired by the [logrus](https://github.com/sirupsen/logrus) logger.
 + [`pino-tiny`](https://github.com/holmok/pino-tiny): a tiny (and exentsible?) little log formatter for pino.
 + [`pino-dev`](https://github.com/dnjstrom/pino-dev): simple prettifier for pino with built-in support for common ecosystem packages.
 + [`@newrelic/pino-enricher`](https://github.com/newrelic/newrelic-node-log-extensions/blob/main/packages/pino-log-enricher): a log customization to add New Relic context to use [Logs In Context](https://docs.newrelic.com/docs/logs/logs-context/logs-in-context/)
++ [`pino-lamdba`](https://github.com/FormidableLabs/pino-lambda): log transport for cloudwatch support inside aws-lambda 


### PR DESCRIPTION
Add [`pino-lamdba`](https://github.com/FormidableLabs/pino-lambda) to community ecosystem documentation. 