### PR TITLE
docs: Fixed options for loki transport example

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -599,7 +599,7 @@ Worker :
 const pino = require('pino')
 const transport = pino.transport({
   target: 'pino-loki',
-  options: { hostname: 'localhost:3100' }
+  options: { host: 'localhost:3100' }
 })
 pino(transport)
 ```


### PR DESCRIPTION
The correct option name is `host` rather than `hostname`. 
See https://github.com/Julien-R44/pino-loki/blob/a5111c8954f523c21fb2b1acc4a982b791775253/src/Contracts/index.ts#L38.

The transport does not throw an error at the unrecognised option name, so it can be  hard to debug problem. 