### PR TITLE
docs: add esbuild-plugin-pino to bundling.md

### DIFF
--- a/docs/bundling.md
+++ b/docs/bundling.md
@@ -1,4 +1,4 @@
-# Bundling 
+# Bundling
 
 Due to its internal architecture based on Worker Threads, it is not possible to bundle Pino *without* generating additional files.
 
@@ -31,4 +31,8 @@ Note that `pino/file`, `pino-worker`, `pino-pipeline-worker` and `thread-stream-
 
 ## Webpack Plugin
 
-If you are a Webpack user, you can achieve this with [pino-webpack-plugin](https://github.com/pinojs/pino-webpack-plugin) without manual configuration of `__bundlerPathsOverrides`; however, you still need to configure it manually if you are using other bundlers. 
+If you are a Webpack user, you can achieve this with [pino-webpack-plugin](https://github.com/pinojs/pino-webpack-plugin) without manual configuration of `__bundlerPathsOverrides`; however, you still need to configure it manually if you are using other bundlers.
+
+## Esbuild Plugin
+
+[esbuild-plugin-pino](https://github.com/davipon/esbuild-plugin-pino) is the esbuild plugin to generate extra pino files for bundling.


### PR DESCRIPTION
This PR adds the Esbuild Plugin section in the `bundling.md`.

I'm the author of `esbuild-plugin-pino` and it's inspired by @ShogunPanda's work of [pino-esbuild.js](https://gist.github.com/ShogunPanda/752cce88659a09bff827ef8d2ecf8c80).