### PR TITLE
docs(API): add description to `level` constructor option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -57,6 +57,8 @@ The name of the logger. When set adds a `name` field to every JSON line logged.
 
 Default: `'info'`
 
+The minimum level to log: Pino will not log messages with a lower level. Setting this option reduces the load, as typically, debug and trace logs are only valid for development, and not needed in production.
+
 One of `'fatal'`, `'error'`, `'warn'`, `'info`', `'debug'`, `'trace'` or `'silent'`.
 
 Additional levels can be added to the instance via the `customLevels` option.


### PR DESCRIPTION
This option is described in [`logger.levels`](https://github.com/pinojs/pino/blob/master/docs/api.md#loggerlevels-object) but not in its own section.