### PR TITLE
fix loading .js with pkg

### DIFF
--- a/lib/transport-stream.js
+++ b/lib/transport-stream.js
@@ -24,8 +24,6 @@ async function loadTransportStreamBuilder (target) {
       }
       // TODO: Support ES imports once tsc, tap & ts-node provide better compatibility guarantees.
       fn = realRequire(decodeURIComponent(target))
-    } else if (toLoad.endsWith('.js')) {
-      fn = realRequire(decodeURIComponent(target))
     } else {
       fn = (await realImport(toLoad))
     }
@@ -33,6 +31,9 @@ async function loadTransportStreamBuilder (target) {
     // See this PR for details: https://github.com/pinojs/thread-stream/pull/34
     if ((error.code === 'ENOTDIR' || error.code === 'ERR_MODULE_NOT_FOUND')) {
       fn = realRequire(target)
+    } else if (error.code === undefined) {
+      // When bundled with pkg, an undefined error is thrown when called with realImport
+      fn = realRequire(decodeURIComponent(target))
     } else {
       throw error
     }

--- a/lib/transport-stream.js
+++ b/lib/transport-stream.js
@@ -24,6 +24,8 @@ async function loadTransportStreamBuilder (target) {
       }
       // TODO: Support ES imports once tsc, tap & ts-node provide better compatibility guarantees.
       fn = realRequire(decodeURIComponent(target))
+    } else if (toLoad.endsWith('.js')) {
+      fn = realRequire(decodeURIComponent(target))
     } else {
       fn = (await realImport(toLoad))
     }

--- a/test/transport/bundlers-support.test.js
+++ b/test/transport/bundlers-support.test.js
@@ -66,6 +66,36 @@ test('pino.transport with worker destination overridden by bundler', async ({ sa
   globalThis.__bundlerPathsOverrides = undefined
 })
 
+test('pino.transport with worker destination overridden by bundler and mjs transport', async ({ same, teardown }) => {
+  globalThis.__bundlerPathsOverrides = {
+    'pino-worker': join(__dirname, '..', '..', 'lib/worker.js')
+  }
+
+  const destination = file()
+  const transport = pino.transport({
+    targets: [
+      {
+        target: join(__dirname, '..', 'fixtures', 'ts', 'to-file-transport.es2017.cjs'),
+        options: { destination }
+      }
+    ]
+  })
+  teardown(transport.end.bind(transport))
+  const instance = pino(transport)
+  instance.info('hello')
+  await watchFileCreated(destination)
+  const result = JSON.parse(await readFile(destination))
+  delete result.time
+  same(result, {
+    pid,
+    hostname,
+    level: 30,
+    msg: 'hello'
+  })
+
+  globalThis.__bundlerPathsOverrides = undefined
+})
+
 test('pino.transport with worker-pipeline destination overridden by bundler', async ({ same, teardown }) => {
   globalThis.__bundlerPathsOverrides = {
     'pino-pipeline-worker': join(__dirname, '..', '..', 'lib/worker-pipeline.js')


### PR DESCRIPTION
Fix https://github.com/pinojs/pino/issues/1237 : With pkg, .js files are not loaded correctly. This fix comes with a PR on thread-stream : https://github.com/pinojs/thread-stream/pull/95.

After a look at previous work by @rokku-x to fix this issue : 
https://github.com/pinojs/pino/pull/1254 (pino)
https://github.com/pinojs/thread-stream/pull/53 (thread-stream)
https://github.com/pinojs/real-require/pull/13 (real-require)

I think there is no need to change real-require and just load with realRequire .js files. These fix with the latest version of the pino lib seem to work with pkg bundler, but I'm not sure how it may impact others bundler. 