### PR TITLE
Simplify Google logging-specific configuration example

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -224,14 +224,12 @@ const PinoLevelToSeverityLookup = {
 const defaultPinoConf = {
   messageKey: 'message',
   formatters: {
+    messageKey: 'message',
     level(label, number) {
       return {
         severity: PinoLevelToSeverityLookup[label] || PinoLevelToSeverityLookup['info'],
         level: number,
       }
-    },
-    log(message) {
-      return { message }
     }
   },
 }


### PR DESCRIPTION
Reuse the `messageKey` config key instead of custom formatter