### PR TITLE
Default fd=1 in pino.destination if stdout has no file descriptor

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -350,6 +350,11 @@ function normalizeDestFileDescriptor (destination) {
   if (typeof destination === 'string' && Number.isFinite(fd)) {
     return fd
   }
+  // destination could be undefined if we are in a worker
+  if (destination === undefined) {
+    // This is stdout in UNIX systems
+    return 1
+  }
   return destination
 }
 

--- a/test/stdout-protection.test.js
+++ b/test/stdout-protection.test.js
@@ -30,3 +30,10 @@ test('do not crash if process.stdout has no fd', async ({ teardown }) => {
   teardown(function () { process.stdout.fd = fd })
   pino()
 })
+
+test('use fd=1 if process.stdout has no fd in pino.destination() (worker case)', async ({ teardown }) => {
+  const fd = process.stdout.fd
+  delete process.stdout.fd
+  teardown(function () { process.stdout.fd = fd })
+  pino.destination()
+})


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>

Fixes #1502 