### PR TITLE
Fix transports doc pipeline example

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -200,7 +200,7 @@ export default async function (options) {
         chunk.service = 'pino'
 
         // stringify the payload again
-        this.push(JSON.stringify(chunk))
+        this.push(`${JSON.stringify(chunk)}\n`)
         cb()
       }
     })


### PR DESCRIPTION
[This thread](https://github.com/pinojs/pino-syslog/issues/15) gave me the clue I needed to get this example working. It seems like `pino-pretty` requires `NDJSON` input. In the example the newline is omitted which means the logs will never be emitted.

This PR updates the example to include a newline after the `JSON.stringify` to fix that.