### PR TITLE
Add missing type browser.disabled

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -543,6 +543,11 @@ declare namespace pino {
                  */
                 send: (level: Level, logEvent: LogEvent) => void;
             };
+
+            /**
+             * The `disabled` option will disable logging in browser if set to `true`. Default is set to `false`.
+             */
+            disabled?: boolean;
         };
         /**
          * key-value object added as child logger to each log line. If set to null the base child logger is not added

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -108,6 +108,9 @@ pino({
 });
 
 pino({ base: null });
+
+pino({ browser: { disabled: true }});
+
 // @ts-expect-error
 if ("pino" in log) console.log(`pino version: ${log.pino}`);
 


### PR DESCRIPTION
Add missing `disabled` as an exported type for TypeScript.