### PR TITLE
fix: correct type of `args` passed to `hooks.logMethod`

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -600,7 +600,7 @@ declare namespace pino {
              * log method and method is the log method itself, and level is the log level. This hook must invoke the method function by
              * using apply, like so: method.apply(this, newArgumentsArray).
              */
-            logMethod?: (this: Logger, args: any[], method: LogFn, level: number) => void;
+            logMethod?: (this: Logger, args: Parameters<LogFn>, method: LogFn, level: number) => void;
         };
 
         /**

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -230,7 +230,7 @@ const withHooks = pino({
     hooks: {
         logMethod(args, method, level) {
             expectType<pino.Logger>(this);
-            return method.apply(this, ['msg', ...args]);
+            return method.apply(this, args);
         },
     },
 });


### PR DESCRIPTION
Using `any[]` produces a type error when using `method.apply(this, inputArgs)`.

<img width="945" alt="image" src="https://user-images.githubusercontent.com/1404810/190413352-048aa44d-3a78-41e5-86c9-5b17cdcad0df.png">