### PR TITLE
fix: type `formatters.log` with a Record type

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -586,7 +586,7 @@ declare namespace pino {
              * All arguments passed to the log method, except the message, will be pass to this function.
              * By default it does not change the shape of the log object.
              */
-            log?: (object: object) => object;
+            log?: (object: Record<string, unknown>) => Record<string, unknown>;
         };
 
         /**


### PR DESCRIPTION
We have a `massageLogData` which takes an object with some custom types - `object` is not assignable to it. `object` just means non-primitive - it doesn't mean `Object` (which is discouraged, see https://github.com/typescript-eslint/typescript-eslint/blob/739479692bedb4aeca8c3d0c657f88d9c60f1fe0/packages/eslint-plugin/src/rules/ban-types.ts#L86-L88)