### PR TITLE
fix: remove pretty print in types, docs

### DIFF
--- a/docs/pretty.md
+++ b/docs/pretty.md
@@ -62,39 +62,11 @@ will be written to the destination stream.
 > be easily investigated at a later date.
 
 1. Install a prettifier module as a separate dependency, e.g. `npm install pino-pretty`.
-1. Instantiate the logger with pretty printing enabled:
+1. Instantiate the logger with the prettifier option:
   ```js
   const pino = require('pino')
   const log = pino({
-    prettyPrint: {
-      levelFirst: true
-    },
     prettifier: require('pino-pretty')
-  })
-  ```
-  Note: the default prettifier module is `pino-pretty`, so the preceding
-  example could be:
-  ```js
-  const pino = require('pino')
-  const log = pino({
-    prettyPrint: {
-      levelFirst: true
-    }
-  })
-  ```
-  See the [`pino-pretty` documentation][pp] for more information on the options
-  that can be passed via `prettyPrint`.
-
-The default prettifier write stream does not guarantee final log writes.
-Correspondingly, a warning is written to logs on the first synchronous flushing.
-This warning may be suppressed by passing `suppressFlushSyncWarning : true` to
-`prettyPrint`:
-  ```js
-  const pino = require('pino')
-  const log = pino({
-    prettyPrint: {
-      suppressFlushSyncWarning: true
-    }
   })
   ```
 

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -17,8 +17,6 @@
 // TypeScript Version: 4.4
 
 import type { EventEmitter } from "events";
-// @ts-ignore -- gracefully falls back to `any` if not installed
-import type { PrettyOptions as PinoPrettyOptions } from "pino-pretty";
 import * as pinoStdSerializers from "pino-std-serializers";
 import type { SonicBoom, SonicBoomOpts } from "sonic-boom";
 import type { WorkerOptions } from "worker_threads";
@@ -318,8 +316,6 @@ declare namespace pino {
         (msg: string, ...args: any[]): void;
     }
 
-    interface PrettyOptions extends PinoPrettyOptions {}
-
     interface LoggerOptions {
         transport?: TransportSingleOptions | TransportMultiOptions | TransportPipelineOptions
         /**
@@ -405,11 +401,6 @@ declare namespace pino {
          * The string key to place any logged object under.
          */
         nestedKey?: string;
-        /**
-         * Enables pino.pretty. This is intended for non-production configurations. This may be set to a configuration
-         * object as outlined in http://getpino.io/#/docs/API?id=pretty. Default: `false`.
-         */
-        prettyPrint?: boolean | PrettyOptions;
         /**
          * Allows to optionally define which prettifier module to use.
          */
@@ -828,7 +819,6 @@ export interface LogFn extends pino.LogFn {}
 export interface LoggerOptions extends pino.LoggerOptions {}
 export interface MultiStreamOptions extends pino.MultiStreamOptions {}
 export interface MultiStreamRes extends pino.MultiStreamRes {}
-export interface PrettyOptions extends pino.PrettyOptions {}
 export interface StreamEntry extends pino.StreamEntry {}
 export interface TransportBaseOptions extends pino.TransportBaseOptions {}
 export interface TransportMultiOptions extends pino.TransportMultiOptions {}

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -192,32 +192,6 @@ anotherRedacted.info({
     anotherPath: "Not shown",
 });
 
-const pretty = pino({
-    prettyPrint: {
-        colorize: true,
-        crlf: false,
-        errorLikeObjectKeys: ["err", "error"],
-        errorProps: "",
-        messageFormat: false,
-        ignore: "",
-        levelFirst: false,
-        messageKey: "msg",
-        timestampKey: "timestamp",
-        translateTime: "UTC:h:MM:ss TT Z",
-    },
-});
-
-const withMessageFormatFunc = pino({
-    prettyPrint: {
-        ignore: "requestId",
-        messageFormat: (log, messageKey: string) => {
-            const message = log[messageKey] as string;
-            if (log.requestId) return `[${log.requestId}] ${message}`;
-            return message;
-        },
-    },
-});
-
 const withTimeFn = pino({
     timestamp: pino.stdTimeFunctions.isoTime,
 });


### PR DESCRIPTION
<img width="1127" alt="Screenshot 2022-09-27 at 5 15 43 PM" src="https://user-images.githubusercontent.com/9977146/194302055-de9f19f3-2ebb-42bc-8a3e-28e8ea326249.png">

`pretty-print` option was deprecated in older releases and is meant to throw an error in `normalizeArgs` method in latest releases. Hence removing it from types as typescript gives a wrong sense that the `pretty-print` option is allowed while the js script throws an error. 

This PR ensures ts throws an error if `pretty-print` is used in the application and corrects the `pretty` part of the documentation.

Test cases are already written ensuring `the Pino` instantiation throws an error for `pretty-print`.