### PR TITLE
Pass logger instance as an argument in `level-change` event

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1003,12 +1003,13 @@ The logger instance is also an [`EventEmitter ⇗`](https://nodejs.org/dist/late
 
 A listener function can be attached to a logger via the `level-change` event
 
-The listener is passed four arguments:
+The listener is passed five arguments:
 
 * `levelLabel` – the new level string, e.g `trace`
 * `levelValue` – the new level number, e.g `10`
 * `previousLevelLabel` – the prior level string, e.g `info`
 * `previousLevelValue` – the prior level number, e.g `30`
+* `logger` – the logger instance from which the event originated
 
 ```js
 const logger = require('pino')()
@@ -1023,8 +1024,8 @@ fire a `level-change` event. These events can be ignored by writing an event han
 
 ```js
 const logger = require('pino')()
-logger.on('level-change', function (lvl, val, prevLvl, prevVal) {
-  if (logger !== this) {
+logger.on('level-change', function (lvl, val, prevLvl, prevVal, instance) {
+  if (logger !== instance) {
     return
   }
   console.log('%s (%d) was changed to %s (%d)', prevLvl, prevVal, lvl, val)

--- a/lib/levels.js
+++ b/lib/levels.js
@@ -105,7 +105,8 @@ function setLevel (level) {
     level,
     levelVal,
     labels[preLevelVal],
-    preLevelVal
+    preLevelVal,
+    this
   )
 }
 

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -228,6 +228,7 @@ declare namespace pino {
         val: number,
         prevLvl: LevelWithSilent | string,
         prevVal: number,
+        logger: Logger
     ) => void;
 
     type LogDescriptor = Record<string, any>;

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -96,12 +96,12 @@ interface LoggerExtras<Options = LoggerOptions> extends EventEmitter {
      * @param event: only ever fires the `'level-change'` event
      * @param listener: The listener is passed four arguments: `levelLabel`, `levelValue`, `previousLevelLabel`, `previousLevelValue`.
      */
-    on(event: "level-change", listener: pino.LevelChangeEventListener): this;
-    addListener(event: "level-change", listener: pino.LevelChangeEventListener): this;
-    once(event: "level-change", listener: pino.LevelChangeEventListener): this;
-    prependListener(event: "level-change", listener: pino.LevelChangeEventListener): this;
-    prependOnceListener(event: "level-change", listener: pino.LevelChangeEventListener): this;
-    removeListener(event: "level-change", listener: pino.LevelChangeEventListener): this;
+    on<Opts = Options>(event: "level-change", listener: pino.LevelChangeEventListener<Opts>): this;
+    addListener<Opts = Options>(event: "level-change", listener: pino.LevelChangeEventListener<Opts>): this;
+    once<Opts = Options>(event: "level-change", listener: pino.LevelChangeEventListener<Opts>): this;
+    prependListener<Opts = Options>(event: "level-change", listener: pino.LevelChangeEventListener<Opts>): this;
+    prependOnceListener<Opts = Options>(event: "level-change", listener: pino.LevelChangeEventListener<Opts>): this;
+    removeListener<Opts = Options>(event: "level-change", listener: pino.LevelChangeEventListener<Opts>): this;
 
     /**
      * A utility method for determining if a given log level will write to the destination.
@@ -223,12 +223,12 @@ declare namespace pino {
     type SerializerFn = (value: any) => any;
     type WriteFn = (o: object) => void;
 
-    type LevelChangeEventListener = (
+    type LevelChangeEventListener<Options = LoggerOptions> = (
         lvl: LevelWithSilent | string,
         val: number,
         prevLvl: LevelWithSilent | string,
         prevVal: number,
-        logger: Logger
+        logger: Logger<Options>
     ) => void;
 
     type LogDescriptor = Record<string, any>;

--- a/test/levels.test.js
+++ b/test/levels.test.js
@@ -96,11 +96,12 @@ test('set the level via exported pino function', async ({ equal }) => {
 
 test('level-change event', async ({ equal }) => {
   const instance = pino()
-  function handle (lvl, val, prevLvl, prevVal) {
+  function handle (lvl, val, prevLvl, prevVal, logger) {
     equal(lvl, 'trace')
     equal(val, 10)
     equal(prevLvl, 'info')
     equal(prevVal, 30)
+    equal(logger, instance)
   }
   instance.on('level-change', handle)
   instance.level = 'trace'
@@ -125,6 +126,12 @@ test('level-change event', async ({ equal }) => {
   instance.level = 'info'
 
   equal(count, 6)
+
+  instance.once('level-change', (lvl, val, prevLvl, prevVal, logger) => equal(logger, instance))
+  instance.level = 'info'
+  const child = instance.child({})
+  instance.once('level-change', (lvl, val, prevLvl, prevVal, logger) => equal(logger, child))
+  child.level = 'trace'
 })
 
 test('enable', async ({ fail }) => {

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -153,7 +153,7 @@ if (log.levelVal === 30) {
 const listener = (lvl: any, val: any, prevLvl: any, prevVal: any) => {
     console.log(lvl, val, prevLvl, prevVal);
 };
-log.on("level-change", (lvl, val, prevLvl, prevVal) => {
+log.on("level-change", (lvl, val, prevLvl, prevVal, logger) => {
     console.log(lvl, val, prevLvl, prevVal);
 });
 log.level = "trace";
@@ -303,6 +303,10 @@ log3.level = 'myLevel'
 log3.myLevel('')
 log3.child({}).myLevel('')
 
+log3.on('level-change', (lvl, val, prevLvl, prevVal, instance) => {
+    instance.myLevel('foo');
+});
+
 const clog3 = log3.child({}, { customLevels: { childLevel: 120 } })
 // child inherit parant
 clog3.myLevel('')
@@ -320,3 +324,4 @@ const withChildCallback = pino({
     onChild: (child: Logger) => {}
 })
 withChildCallback.onChild = (child: Logger) => {}
+


### PR DESCRIPTION
closes #1572 
