### PR TITLE
Add missing type for disabled in Logger options

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -557,6 +557,12 @@ declare namespace pino {
                  */
                 send: (level: Level, logEvent: LogEvent) => void;
             };
+            
+            /**
+             * The `disabled` option will disable logging in the browser if set
+             * to `true`.
+             */
+            disabled?: boolean;
         };
         /**
          * key-value object added as child logger to each log line. If set to null the base child logger is not added


### PR DESCRIPTION
Add missing type for disabled under the browser logger options.