### PR TITLE
Fix documentation example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -171,9 +171,9 @@ const logger = pino({
 logger.info({
     description: 'Ok'
 }, 'Message 1')
-// {"level":30,"time":1591195061437,"pid":16012,"hostname":"x","appName":"My app","description":"Ok","level-label":"info","msg":"Message 1"}
+// {"level":30,"time":1591195061437,"pid":16012,"hostname":"x","description":"Ok","level-label":"info","msg":"Message 1"}
 logger.error('Message 2')
-// {"level":30,"time":1591195061437,"pid":16012,"hostname":"x","appName":"My app","description":"Ok","level-label":"error","msg":"Message 2"}
+// {"level":30,"time":1591195061437,"pid":16012,"hostname":"x","level-label":"error","msg":"Message 2"}
 ```
 
 If the `mixin` feature is being used merely to add static metadata to each log message,


### PR DESCRIPTION
```
const logger = pino({
  mixin(_context, level) {
    return { 'level-label': logger.levels.labels[level] }
  }
})

logger.info({
    description: 'Ok'
}, 'Message 1')
// {"level":30,"time":1591195061437,"pid":16012,"hostname":"x","appName":"My app","description":"Ok","level-label":"info","msg":"Message 1"}
logger.error('Message 2')
// {"level":30,"time":1591195061437,"pid":16012,"hostname":"x","appName":"My app","description":"Ok","level-label":"error","msg":"Message 2"}
```
We are spinning a new logger at line 165
the mixin returns every time a new object, so i don't think for the second output (logger.error) the description: 'Ok' will be present and also the appName is not specified anywhere in either the mixin or the merge object info or error hence it should not come in output I think these lines were copied from the previous example, hence this error.