### PR TITLE
docs: Add correct link to Matteo Collina's github account in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ See [Bundling](docs/bundling.md) document for more information.
 
 ### Matteo Collina
 
-<https://github.com/pinojs>
+<https://github.com/mcollina>
 
 <https://www.npmjs.com/~matteo.collina>
 


### PR DESCRIPTION
The link to @mcollina 's github account in README.md was pointing to [https://github.com/pinojs](https://github.com/pinojs) updated it to point to towards [https://github.com/mcollina](https://github.com/mcollina) 