### PR TITLE
remove: outdated/unused information from docs/pretty.md

### DIFF
--- a/docs/pretty.md
+++ b/docs/pretty.md
@@ -5,62 +5,6 @@ for production usage and long-term storage. It's not so great for development
 environments. Thus, Pino logs can be prettified by using a Pino prettifier
 module like [`pino-pretty`][pp]:
 
-```sh
-$ cat app.log | pino-pretty
-```
-
-For almost all situations, this is the recommended way to prettify logs. The
-programmatic API, described in the next section, is primarily for integration
-purposes with other CLI-based prettifiers.
-
-## Prettifier API
-
-Pino prettifier modules are extra modules that provide a CLI for parsing NDJSON
-log lines piped via `stdin` and expose an API that conforms to the Pino
-[metadata streams](/docs/api.md#metadata) API.
-
-The API requires modules provide a factory function that returns a prettifier
-function. This prettifier function must accept either a string of NDJSON or
-a Pino log object. A pseudo-example of such a prettifier is:
-
-The uninitialized Pino instance is passed as `this` into prettifier factory function,
-so it can be accessed via closure by the returned prettifier function.
-
-```js
-module.exports = function myPrettifier (options) {
-  // `this` is bound to the pino instance
-  // Deal with whatever options are supplied.
-  return function prettifier (inputData) {
-    let logObject
-    if (typeof inputData === 'string') {
-      logObject = someJsonParser(inputData)
-    } else if (isObject(inputData)) {
-      logObject = inputData
-    }
-    if (!logObject) return inputData
-    // implement prettification
-  }
-
-  function isObject (input) {
-    return Object.prototype.toString.apply(input) === '[object Object]'
-  }
-}
-```
-
-The reference implementation of such a module is the [`pino-pretty`][pp] module.
-To learn more about creating a custom prettifier module, refer to the
-`pino-pretty` source code.
-
-Note: if the prettifier returns `undefined`, instead of a formatted line, nothing
-will be written to the destination stream.
-
-### API Example
-
-> #### NOTE:
-> For general usage, it is highly recommended that logs are piped into
-> the prettifier instead. Prettified logs are not easily parsed and cannot
-> be easily investigated at a later date.
-
 1. Install a prettifier module as a separate dependency, e.g. `npm install pino-pretty`.
 2. Instantiate the logger with the `transport.target` option set to `'pino-pretty'`:
   ```js


### PR DESCRIPTION
Building on #1620

Changes:
 - Removed old/legacy piping logs example from 5 years ago since it isn't really relevant for new v7+ Pino with threaded transports. (it creates confusion for newcomers to this logger. legacy vs "new" transports are explained in greater detail on /transports page for anyone interested in deep dive)
 - Removed "Prettifier API" section since `prettifier` option no longer exists/not supported