### PR TITLE
Add script to bump version

### DIFF
--- a/inc-version.sh
+++ b/inc-version.sh
@@ -1,0 +1,42 @@
+#!/bin/bash 
+
+set -e
+
+PATH=./node_modules/.bin:${PATH}
+CURRENT_VERSION=$(jq -r .version package.json)
+
+case ${1} in
+  Major | MAJOR | major)
+    LEVEL=major
+    ;;
+
+  Minor | MINOR | minor)
+    LEVEL=minor
+    ;;
+
+  Patch | PATCH | patch)
+    LEVEL=patch
+    ;;
+
+  *)
+    LEVEL=patch
+    ;;
+esac
+
+NEW_VERSION=$(semver -i ${LEVEL} ${CURRENT_VERSION})
+echo "${CURRENT_VERSION} => ${NEW_VERSION}"
+read -n 1 -s -r -p "Press any key to continue (ctrl+c to abort)..."
+echo ""
+
+echo "Patching package.json..."
+cat package.json | \
+  jq --arg vers "${NEW_VERSION}" '.version = $vers' | \
+  tee package.json 1>/dev/null
+
+echo "Patching lib/meta.js ..."
+SED_SCRIPT=$(printf 's/%s/%s/' ${CURRENT_VERSION//\./\\.} ${NEW_VERSION//\./\\.})
+cat ./lib/meta.js | \
+  sed -e ${SED_SCRIPT} | \
+  tee ./lib/meta.js 1>/dev/null
+
+echo "Done."


### PR DESCRIPTION
Since we are saddled with maintain the version number in code, I propose this script to make releases easier. All three of the following are valid:

```sh
$ ./inc-version.sh major
$ ./inc-version.sh minor
$ ./inc-version.sh patch
```

By default, the following will bump for a patch release:

```sh
$ ./inc-version.sh
```