### PR TITLE
Make sure Pino is run on the right minimum required Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,5 +123,8 @@
   },
   "tsd": {
     "directory": "test/types"
+  },
+  "engines": {
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
Lately, I had to install Pino on an old Node application. The Node version is 12. However, Pino couldn't be run as it uses `on-exit-leak-free` where `FinalizationRegistry` is being used which is only available since Node v14.

I was actually getting the following error coming from [on-exit-leak-free](https://github.com/pinojs/pino/blob/master/package.json#L114) since Pino is using it as a dependency.

```
ReferenceError: FinalizationRegistry is not defined
    at Object.<anonymous> (node_modules/on-exit-leak-free/index.js:11:18)
```