### PR TITLE
feat: Add support for multiple pipelines & using pipelines with static targets

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -86,8 +86,20 @@ function transport (fullOptions) {
   }
 
   if (targets) {
-    target = bundlerOverrides['pino-worker'] || join(__dirname, 'worker.js')
+    target = bundlerOverrides['pino-worker'] || join(__dirname, 'worker-mixed.js')
+
     options.targets = targets.map((dest) => {
+      if (dest.pipeline) {
+        dest.targets = dest.targets.map((pTarget) => {
+          // parse pipeline target paths
+          return {
+            ...pTarget,
+            target: fixTarget(pTarget.target)
+          }
+        })
+        return { ...dest }
+      }
+
       return {
         ...dest,
         target: fixTarget(dest.target)

--- a/lib/worker-mixed.js
+++ b/lib/worker-mixed.js
@@ -2,10 +2,8 @@
 
 const pino = require('../pino.js')
 const build = require('pino-abstract-transport')
-const buildPipelineStream = require('./worker-pipeline.js') 
+const buildPipelineStream = require('./worker-pipeline.js')
 const loadTransportStreamBuilder = require('./transport-stream')
-
-
 // This file is not checked by the code coverage tool,
 // as it is not reliable.
 
@@ -14,13 +12,12 @@ const loadTransportStreamBuilder = require('./transport-stream')
 module.exports = async function ({ targets, levels, dedupe }) {
   // build target streams
   targets = await Promise.all(targets.map(async (t) => {
-    if(t.pipeline){
+    if (t.pipeline) {
       return {
         level: t.level,
         stream: await buildPipelineStream(t)
       }
-    }
-    else {
+    } else {
       const fn = await loadTransportStreamBuilder(t.target)
       const stream = await fn(t.options)
       return {
@@ -28,8 +25,7 @@ module.exports = async function ({ targets, levels, dedupe }) {
         stream
       }
     }
-
-  }));
+  }))
 
   return build(process, {
     parse: 'lines',

--- a/lib/worker-mixed.js
+++ b/lib/worker-mixed.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const pino = require('../pino.js')
+const build = require('pino-abstract-transport')
+const buildPipelineStream = require('./worker-pipeline.js') 
+const loadTransportStreamBuilder = require('./transport-stream')
+
+
+// This file is not checked by the code coverage tool,
+// as it is not reliable.
+
+/* istanbul ignore file */
+
+module.exports = async function ({ targets, levels, dedupe }) {
+  // build target streams
+  targets = await Promise.all(targets.map(async (t) => {
+    if(t.pipeline){
+      return {
+        level: t.level,
+        stream: await buildPipelineStream(t)
+      }
+    }
+    else {
+      const fn = await loadTransportStreamBuilder(t.target)
+      const stream = await fn(t.options)
+      return {
+        level: t.level,
+        stream
+      }
+    }
+
+  }));
+
+  return build(process, {
+    parse: 'lines',
+    metadata: true,
+    close (err, cb) {
+      let expected = 0
+      for (const transport of targets) {
+        expected++
+        transport.stream.on('close', closeCb)
+        transport.stream.end()
+      }
+
+      function closeCb () {
+        if (--expected === 0) {
+          cb(err)
+        }
+      }
+    }
+  })
+
+  function process (stream) {
+    const multi = pino.multistream(targets, { levels, dedupe })
+    // TODO manage backpressure
+    stream.on('data', function (chunk) {
+      const { lastTime, lastMsg, lastObj, lastLevel } = this
+      multi.lastLevel = lastLevel
+      multi.lastTime = lastTime
+      multi.lastMsg = lastMsg
+      multi.lastObj = lastObj
+
+      // TODO handle backpressure
+      multi.write(chunk + '\n')
+    })
+  }
+}


### PR DESCRIPTION
Hi all!


This PR will add support for the usage of regular transports alongside pipelines, as well as the usage of multiple pipelines. 

Currently it
- Adds `lib/worker-mixed.js` which handles the new `targets` format
  - Creates target streams the same as `worker.js` for static targets
  - Utilizes `lib/worker-pipeline.js` to create the pipeline streams. 
- Modifies `lib/transport.js` to properly parse the new API.

**RFC:** @mcollina mentioned in #1302 that he was interested in a new `mixed-worker.js` file, but I think it might be better off just being added to `lib/worker.js`. My reasoning being that it's actually not that substantial of a change, and it probably leads to the least overall API change. 

Currently, I just have `worker-mixed.js` shoehorned in where `worker.js` was previously in `lib/transport.js` as proof-of-concept, but it shows my point pretty succinctly. I don't immediately see a case where it's useful to have a `worker.js` that can't handle the pipeline targets, unless a different API is desired. 

Suggestions and/or critiques on the topic would be appreciated. 

## API Change
Allow pipelines to be provided in the `targets: [{},{},(...)]` array in `pino({})` or `pino.transport({})` options objects.

<details>
<summary> Object structure example </summary>

```javascript
opts = {
  targets: [
    { target: 'path/to/target1', options: {/*(...)*/} },
    { target: 'path/to/target2', options: {/*(...)*/} },
    { pipeline: true, targets: {/* pipelineable targets, as in a normal pipeline def */} },
  ]
}
```
</details>

The existing pipeline logic in `lib/transport.js` can be left untouched for backwards compat. The only real break would be if someone was manually creating `pipeline` properties on their targets for arbitrary usage. Relevant [XKCD](https://xkcd.com/1172/)

## Draft stage checklist
- [ ] Finalize location of worker logic (worker.js or new worker-mixed.js?)
- [ ] Add tests for new transport.js code
- [ ] Update option typings