### PR TITLE
remove type definition for pino 7.0 comment

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -1,4 +1,3 @@
-// Type definitions for pino 7.0
 // Project: https://github.com/pinojs/pino.git, http://getpino.io
 // Definitions by: Peter Snider <https://github.com/psnider>
 //                 BendingBender <https://github.com/BendingBender>


### PR DESCRIPTION
remove type definition for pino 7.0 comment as it's not being maintained with version updates
Related: #1680 