### PR TITLE
fix: browser respect child logger log level 

### DIFF
--- a/test/browser-child.test.js
+++ b/test/browser-child.test.js
@@ -1,0 +1,106 @@
+'use strict'
+const test = require('tape')
+const pino = require('../browser')
+
+test('child has parent level', ({ end, same, is }) => {
+  const instance = pino({
+    level: 'error',
+    browser: {}
+  })
+
+  const child = instance.child({})
+
+  same(child.level, instance.level)
+  end()
+})
+
+test('changing child level does not affect parent', ({ end, same, is }) => {
+  const instance = pino({
+    level: 'error',
+    browser: {}
+  })
+
+  const child = instance.child({})
+  child.level = 'info'
+
+  same(instance.level, 'error')
+  end()
+})
+
+test('child should log, if its own level allows it', ({ end, same, is }) => {
+  const expected = [
+    {
+      level: 30,
+      msg: 'this is info'
+    },
+    {
+      level: 40,
+      msg: 'this is warn'
+    },
+    {
+      level: 50,
+      msg: 'this is an error'
+    }
+  ]
+  const instance = pino({
+    level: 'error',
+    browser: {
+      write (actual) {
+        checkLogObjects(is, same, actual, expected.shift())
+      }
+    }
+  })
+
+  const child = instance.child({})
+  child.level = 'info'
+
+  child.debug('this is debug')
+  child.info('this is info')
+  child.warn('this is warn')
+  child.error('this is an error')
+
+  same(expected.length, 0, 'not all messages were read')
+  end()
+})
+
+test('changing child log level should not affect parent log behavior', ({ end, same, is }) => {
+  const expected = [
+    {
+      level: 50,
+      msg: 'this is an error'
+    },
+    {
+      level: 60,
+      msg: 'this is fatal'
+    }
+  ]
+  const instance = pino({
+    level: 'error',
+    browser: {
+      write (actual) {
+        checkLogObjects(is, same, actual, expected.shift())
+      }
+    }
+  })
+
+  const child = instance.child({})
+  child.level = 'info'
+
+  instance.warn('this is warn')
+  instance.error('this is an error')
+  instance.fatal('this is fatal')
+
+  same(expected.length, 0, 'not all messages were read')
+  end()
+})
+
+function checkLogObjects (is, same, actual, expected) {
+  is(actual.time <= Date.now(), true, 'time is greater than Date.now()')
+
+  const actualCopy = Object.assign({}, actual)
+  const expectedCopy = Object.assign({}, expected)
+  delete actualCopy.time
+  delete expectedCopy.time
+
+  same(actualCopy, expectedCopy)
+}


### PR DESCRIPTION
This PR addresses #960.

> not yet completed, only a draft

# Goal of this PR:

Child level determines which logs of the child are logged.

# Implementation before this PR

- the `prototype` of `logger` contains the actual log functions which should be used
- the `prototype` log functions are assigned to the `logger` whenever the `setLevel` function is called
- for log functions which level  is to low, `noop` is assigned instead

> problem: only the main `logger` actually changes, even if the level of a child is changed

# What this PR changes

- introduce a property which contains all the base logger functions (only the root logger has it) -> `Symbol('pino.logFuncs')`
  - the base log functions need to be callable independently by the child loggers and this property allows to access them all the time
- introduce a property which contains the hierarchy of the logger (pointing to the parent) -> `Symbol('pino.hierarchy')`
  - whenever a child logs, it needs all bindings as they are prepend to the log arguments.
    before this PR, it was handled via the prototype chain.
- move the responsibility of prepending the bindings into the `set` functions (for changing the log level)
  - as the `set` function is mainly responsible for defining the actual log functions that are usable, it felt like a logical step to also include the binding in it. 
- add a `bindings` property to each child that stores the bindings of the child.
  - this is needed to walk up the hierarchy, get all bindings and then use it to prepend the log arguments.
  - there are restrictions to this property: it is only considered once, when calling the `set` function. 
    so, reassigning it only takes affect if the `level` is changed and then it *only* is updated for this one logger.

# Insights I want to share

There is a specific order in which a log is processed:

1. the outer log function is called with whatever should be logged
2. the bindings are prepended to the arguments
3. the `LOG` function is used to transform the arguments to the desired structure (can be found in `createWrap`)
4. the actual logging function is called with the transformed arguments

Before this PR, the prototype chain was used the ensure that the bindings are prepended one after another.
Now they are collected once and then prepended at once.

Another improvement that comes with this PR as well is, that now in case of `noop` the logger actually does nothing.
Before this PR, it always prepended the bindings and transformed the arguments no matter if the `noop` function was used or not.

> there is a valid case as well and that is if a `transmit` exists, but this is properly handled

Finally, the base log functions are now only once defined in the `setupBaseLogFunctions` instead of in every `set` call.