### PR TITLE
docs: add pino-slack-webhook to list of v7+ compatible transports

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -398,6 +398,7 @@ PRs to this document are welcome for any new transports!
 + [pino-sentry-transport](#pino-sentry-transport)
 + [pino-airbrake-transport](#pino-airbrake-transport)
 + [pino-datadog-transport](#pino-datadog-transport)
++ [pino-slack-webhook](#pino-slack-webhook)
 
 ### Legacy
 
@@ -907,6 +908,29 @@ $ node app.js | pino-websocket -a my-websocket-server.example.com -p 3004
 ```
 
 For full documentation of command line switches read the [README](https://github.com/abeai/pino-websocket#readme).
+
+<a id="pino-slack-webhook"></a>
+### pino-slack-webhook
+
+[pino-slack-webhook][pino-slack-webhook] is a Pino v7+ compatible transport to forward log events to [Slack][Slack]
+from a dedicated worker:
+
+```js
+const pino = require('pino')
+const transport = pino.transport({
+  target: '@youngkiu/pino-slack-webhook',
+  options: {
+    webhookUrl: 'https://hooks.slack.com/services/xxx/xxx/xxx',
+    channel: '#pino-log',
+    username: 'webhookbot',
+    icon_emoji: ':ghost:'
+  }
+})
+pino(transport)
+```
+
+[pino-slack-webhook]: https://github.com/youngkiu/pino-slack-webhook
+[Slack]: https://slack.com/
 
 [pino-pretty]: https://github.com/pinojs/pino-pretty
 


### PR DESCRIPTION
Hi!

I'm using Pino usefully in NestJS framework.

I have written a [v7+ compatible transport](https://github.com/youngkiu/pino-slack-webhook) (for use in a production environment.) for [Slack](https://slack.com/).
I thought it might be useful to others.

Thanks