### PR TITLE
fix: use `messageKey` when giving message precedence over error

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -20,6 +20,7 @@ const {
   serializersSym,
   formattersSym,
   errorKeySym,
+  messageKeySym,
   useOnlyCustomLevelsSym,
   needsMetadataGsym,
   redactFmtSym,
@@ -181,6 +182,7 @@ function write (_obj, msg, num) {
   const t = this[timeSym]()
   const mixin = this[mixinSym]
   const errorKey = this[errorKeySym]
+  const messageKey = this[messageKeySym]
   const mixinMergeStrategy = this[mixinMergeStrategySym] || defaultMixinMergeStrategy
   let obj
 
@@ -193,7 +195,7 @@ function write (_obj, msg, num) {
     }
   } else {
     obj = _obj
-    if (msg === undefined && _obj.msg === undefined && _obj[errorKey]) {
+    if (msg === undefined && _obj[messageKey] === undefined && _obj[errorKey]) {
       msg = _obj[errorKey].message
     }
   }

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -376,3 +376,23 @@ test('msg should take precedence over error message on mergingObject', async ({ 
     msg: 'my message'
   })
 })
+
+test('considers messageKey when giving msg precedence over error', async ({ same }) => {
+  const err = new Error('myerror')
+  const stream = sink()
+  const instance = pino({ messageKey: 'message' }, stream)
+  instance.error({ message: 'my message', err })
+  const result = await once(stream, 'data')
+  delete result.time
+  same(result, {
+    pid,
+    hostname,
+    level: 50,
+    err: {
+      type: 'Error',
+      stack: err.stack,
+      message: err.message
+    },
+    message: 'my message'
+  })
+})


### PR DESCRIPTION
Follow-up to https://github.com/pinojs/pino/pull/1654. Ref: https://github.com/pinojs/pino/pull/1654/files#r1270564181.