### PR TITLE
Add pino-opentelemetry-transport as a known plugin to transports.md

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -400,6 +400,7 @@ PRs to this document are welcome for any new transports!
 + [pino-datadog-transport](#pino-datadog-transport)
 + [pino-slack-webhook](#pino-slack-webhook) 
 + [pino-axiom](#pino-axiom)
++ [pino-opentelemetry-transport](#pino-opentelemetry-transport)
 
 ### Legacy
 
@@ -954,6 +955,29 @@ const transport = pino.transport({
 })
 pino(transport)
 ```
+
+<a id="pino-opentelemetry-transport"></a>
+### pino-opentelemetry-transport
+
+[pino-opentelemetry-transport](https://www.npmjs.com/package/pino-opentelemetry-transport) is a transport that will forward logs to an [OpenTelemetry log collector](https://opentelemetry.io/docs/collector/) using [OpenTelemetry JS instrumentation](https://opentelemetry.io/docs/instrumentation/js/).
+
+```javascript
+const pino = require('pino')
+
+const transport = pino.transport({
+  target: 'pino-opentelemetry-transport',
+  options: {
+    resourceAttributes: {
+      'service.name': 'test-service',
+      'service.version': '1.0.0'
+    }
+  }
+})
+
+pino(transport)
+```
+
+Documentation on running a minimal example is available in the [README](https://github.com/Vunovati/pino-opentelemetry-transport#minimalistic-example).
 
 <a id="communication-between-pino-and-transport"></a>
 ## Communication between Pino and Transports


### PR DESCRIPTION
Added a reference to [pino-opentelemetry-transport](https://www.npmjs.com/package/pino-opentelemetry-transport) in the docs

Closes #1292 