### PR TITLE
Make options and level optional for TransportTargetOptions

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -241,8 +241,8 @@ declare namespace pino {
 
     interface TransportTargetOptions<TransportOptions = Record<string, any>> {
         target: string
-        options: TransportOptions
-        level: LevelWithSilent | string
+        options?: TransportOptions
+        level?: LevelWithSilent | string
     }
 
     interface TransportBaseOptions<TransportOptions = Record<string, any>> {


### PR DESCRIPTION
Hey,
I saw that TypeScript requires `options` and `level`, while it seems I don't really need to provide them.
I've changed types in `pino.d.ts` so I don't need to do `@ts-ignore`.
Please take a look