### PR TITLE
Skip writing a big file test in CI and CITGM

### DIFF
--- a/test/transport/big.test.js
+++ b/test/transport/big.test.js
@@ -13,7 +13,9 @@ const pipeline = promisify(stream.pipeline)
 const { Writable } = stream
 const sleep = promisify(setTimeout)
 
-test('eight million lines', async ({ equal, comment }) => {
+const skip = process.env.CI || process.env.CITGM
+
+test('eight million lines', { skip }, async ({ equal, comment }) => {
   const destination = file()
   await execa(process.argv[0], [join(__dirname, '..', 'fixtures', 'transport-many-lines.js'), destination])
 

--- a/test/transport/core.test.js
+++ b/test/transport/core.test.js
@@ -460,6 +460,7 @@ test('stdout in worker', async ({ not }) => {
   for await (const chunk of child.stdout) {
     actual += chunk
   }
+  await immediate()
   not(strip(actual).match(/Hello/), null)
 })
 
@@ -485,6 +486,7 @@ test('log and exit before ready', async ({ not }) => {
     cb()
   }))
   await once(child, 'close')
+  await immediate()
   not(strip(actual).match(/Hello/), null)
 })
 
@@ -508,6 +510,7 @@ test('string integer destination', async ({ not }) => {
     cb()
   }))
   await once(child, 'close')
+  await immediate()
   not(strip(actual).match(/Hello/), null)
 })
 


### PR DESCRIPTION
Apparently [CITGM](https://github.com/nodejs/citgm) has some problems in dealing with a big file on the temporary disk, so let's avoid it. Seems a good idea to do that also on our CI. 

Ref https://github.com/nodejs/citgm/pull/959