### PR TITLE
feat: bump fast-redact from 3.1.1 to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   },
   "dependencies": {
     "atomic-sleep": "^1.0.0",
-    "fast-redact": "^3.1.1",
+    "fast-redact": "^3.3.0",
     "on-exit-leak-free": "^2.1.0",
     "pino-abstract-transport": "v1.1.0",
     "pino-std-serializers": "^6.0.0",


### PR DESCRIPTION
Updating fast-redact version to include the changes in this PR https://github.com/davidmarkclements/fast-redact/pull/59

Tested this versions and this issue is fixed https://github.com/pinojs/pino/issues/1745

Also in the project where this happened to me it doesn't happen with the new version