### PR TITLE
export the LoggerExtras interface

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -45,7 +45,7 @@ interface redactOptions {
     remove?: boolean;
 }
 
-interface LoggerExtras<Options = LoggerOptions> extends EventEmitter {
+export interface LoggerExtras<Options = LoggerOptions> extends EventEmitter {
     /**
      * Exposes the Pino package version. Also available on the exported pino function.
      */

--- a/test/types/pino-type-only.test-d.ts
+++ b/test/types/pino-type-only.test-d.ts
@@ -1,11 +1,12 @@
 import { expectAssignable, expectType } from "tsd";
 
 import pino from "../../";
-import type {LevelWithSilent, Logger, LogFn, P, DestinationStreamWithMetadata } from "../../pino";
+import type {LevelWithSilent, Logger, LogFn, P, DestinationStreamWithMetadata, LoggerExtras } from "../../pino";
 
 // NB: can also use `import * as pino`, but that form is callable as `pino()`
 // under `esModuleInterop: false` or `pino.default()` under `esModuleInterop: true`.
 const log = pino();
+expectAssignable<LoggerExtras>(log);
 expectType<Logger>(log);
 expectType<LogFn>(log.info);
 


### PR DESCRIPTION
I have been using elysia-logger, which uses pino and have had some type issues: bogeychan/elysia-logger#4

the most recent issue is this:
![image](https://github.com/pinojs/pino/assets/100045248/4e31798d-34a6-448a-aadf-d1d3f816eb9b)

which I found was solved by going into node modules and exporting the type in question

so this pr:

- exports the `LoggerExtras` interface