### PR TITLE
Disable FinalizationRegistry if node code coverage is active

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -231,11 +231,15 @@ function hasBeenTampered (stream) {
   return stream.write !== stream.constructor.prototype.write
 }
 
+const hasNodeCodeCoverage = process.env.NODE_V8_COVERAGE || process.env.V8_COVERAGE
+
 function buildSafeSonicBoom (opts) {
   const stream = new SonicBoom(opts)
   stream.on('error', filterBrokenPipe)
-  // if we are sync: false, we must flush on exit
-  if (!opts.sync && isMainThread) {
+  // If we are sync: false, we must flush on exit
+  // We must disable this if there is node code coverage due to
+  // https://github.com/nodejs/node/issues/49344#issuecomment-1741776308.
+  if (!hasNodeCodeCoverage && !opts.sync && isMainThread) {
     onExit.register(stream, autoEnd)
 
     stream.on('close', function () {


### PR DESCRIPTION
See https://github.com/nodejs/node/issues/49344#issuecomment-1741776308 for more details, this has been the source of some of the flakyness we have been seeing.