### PR TITLE
fix: make transports.options and transports.level optional

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -244,8 +244,8 @@ declare namespace pino {
 
     interface TransportTargetOptions<TransportOptions = Record<string, any>> {
         target: string
-        options: TransportOptions
-        level: LevelWithSilentOrString
+        options?: TransportOptions
+        level?: LevelWithSilentOrString
     }
 
     interface TransportBaseOptions<TransportOptions = Record<string, any>> {

--- a/test/types/pino-transport.test-d.ts
+++ b/test/types/pino-transport.test-d.ts
@@ -74,6 +74,23 @@ expectType<pino.Logger>(pino({
     },
 }))
 
+const transportsWithoutOptions = pino.transport({
+    targets: [
+        { target: '#pino/pretty' },
+        { target: '#pino/file' }
+    ], levels: { foo: 35 }
+})
+pino(transports)
+
+expectType<pino.Logger>(pino({
+    transport: {
+        targets: [
+            { target: '#pino/pretty' },
+            { target: '#pino/file' }
+        ], levels: { foo: 35 }
+    },
+}))
+
 const pipelineTransport = pino.transport({
     pipeline: [{
         target: './my-transform.js'


### PR DESCRIPTION
According to https://github.com/pinojs/pino/blob/HEAD/docs/transports.md#v7-transports, the options and level are non-required properties for a transport