### PR TITLE
fix: export `redactOptions` type

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -39,7 +39,7 @@ type CustomLevelLogger<Options> = Options extends { customLevels: Record<string,
 */
 type OnChildCallback<Options = LoggerOptions> = <ChildOptions extends pino.ChildLoggerOptions>(child: pino.Logger<Options & ChildOptions>) => void
 
-interface redactOptions {
+export interface redactOptions {
     paths: string[];
     censor?: string | ((value: any, path: string[]) => any);
     remove?: boolean;


### PR DESCRIPTION
Because it is used elsewhere in an exported type, it needs to be exported as well or else TypeScript throws an error

Fixes #1840