### PR TITLE
Make license detectable by GitHub

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2019 Matteo Collina, David Mark Clements and the Pino contributors
-
-Pino contributors listed at https://github.com/pinojs/pino#the-team and in
-the README file.
+Copyright (c) 2016-2019 Matteo Collina, David Mark Clements and the Pino contributors listed at https://github.com/pinojs/pino#the-team and in the README file.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Currently, GitHub cannot detect the license for this project. The note about contributors in the LICENSE file prevents GitHub from being able to detect the license. The GitHub documentation notes the following:

> If your repository is using a license that is listed on the Choose a License website and it's not displaying clearly at the top of the repository page, it may contain multiple licenses or other complexity. To have your license detected, simplify your _LICENSE_ file and note the complexity somewhere else, such as your repository's _README_ file.

In order to keep the whole thing intact and allow the license to be detected, I combined the contributors note with the previous line.

GitHub [uses the ruby gem licensee](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository#detecting-a-license) to detect the license. I used that to test the changes.

### Before

```bash
$ licensee detect pino
License:        NOASSERTION
Matched files:  LICENSE, README.md, package.json
LICENSE:
  Content hash:  7d270c901a98319e9d1d03255294bff79f2aea1f
  License:       NOASSERTION
  Closest non-matching licenses:
    MIT similarity:    86.11%
    MIT-0 similarity:  66.93%
    NCSA similarity:   60.96%
README.md:
  Content hash:  7d85dff63928fc6afc58199dce25b10600c2e287
  Confidence:    90.00%
  Matcher:       Licensee::Matchers::Reference
  License:       MIT
  Closest non-matching licenses:
    Unlicense similarity:  0.54%
    MS-PL similarity:      0.52%
    OFL-1.1 similarity:    0.47%
package.json:
  Confidence:  90.00%
  Matcher:     Licensee::Matchers::NpmBower
  License:     MIT
```

### After

```bash
$ licensee detect pino
License:        MIT
Matched files:  LICENSE, README.md, package.json
LICENSE:
  Content hash:  4c2c763d64bbc7ef2e58b0ec6d06d90cee9755c9
  Attribution:   Copyright (c) 2016-2019 Matteo Collina, David Mark Clements and the Pino contributors listed at https://github.com/pinojs/pino#the-team and in the README file.
  Confidence:    100.00%
  Matcher:       Licensee::Matchers::Exact
  License:       MIT
README.md:
  Content hash:  7d85dff63928fc6afc58199dce25b10600c2e287
  Confidence:    90.00%
  Matcher:       Licensee::Matchers::Reference
  License:       MIT
  Closest non-matching licenses:
    Unlicense similarity:  0.54%
    MS-PL similarity:      0.52%
    OFL-1.1 similarity:    0.47%
package.json:
  Confidence:  90.00%
  Matcher:     Licensee::Matchers::NpmBower
  License:     MIT
```