### PR TITLE
docs: Clarify how to log both to a custom transport and to stdout

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -195,13 +195,13 @@ callback is called or the returned promise resolves. Otherwise, log lines will b
 
 ### Combining transport with writing to an stdout
 
-In case you want to both use a custom transport, and output the unprocessed log entries to stdout, you can use 'pino/file' transport configured with `destination: 1`:
+In case you want to both use a custom transport, and output the log entries with default processing to STDOUT, you can use 'pino/file' transport configured with `destination: 1`:
 
 ```js
     const transports = [
       {
         target: 'pino/file',
-        options: { destination: 1 } // this writes to stdout
+        options: { destination: 1 } // this writes to STDOUT
       },
       {
         target: 'my-custom-transport',
@@ -257,7 +257,7 @@ const logger = pino({
     pipeline: [{
       target: './my-transform.js'
     }, {
-      // Use target: 'pino/file' with 'options: { destination: 1 }' to write to stdout
+      // Use target: 'pino/file' with 'options: { destination: 1 }' to write to STDOUT
       // without any change.
       target: 'pino-pretty'
     }]
@@ -382,7 +382,7 @@ const split = require('split2')
 
 const myTransportStream = new Writable({
   write (chunk, enc, cb) {
-  // apply a transform and send to stdout
+  // apply a transform and send to STDOUT
   console.log(chunk.toString().toUpperCase())
   cb()
   }

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -193,6 +193,25 @@ To consume async iterators in batches, consider using the [hwp](https://github.c
 The `close()` function is needed to make sure that the stream is closed and flushed when its
 callback is called or the returned promise resolves. Otherwise, log lines will be lost.
 
+### Combining transport with writing to an stdout
+
+In case you want to both use a custom transport, and output the unprocessed log entries to stdout, you can use 'pino/file' transport configured with `destination: 1`:
+
+```js
+    const transports = [
+      {
+        target: 'pino/file',
+        options: { destination: 1 } // this writes to stdout
+      },
+      {
+        target: 'my-custom-transport',
+        options: { someParameter: true } 
+      }
+    ]
+
+    const logger = pino(pino.transport({ targets: transports })
+```
+
 ### Creating a transport pipeline
 
 As an example, the following transport returns a `Transform` stream:
@@ -238,7 +257,7 @@ const logger = pino({
     pipeline: [{
       target: './my-transform.js'
     }, {
-      // Use target: 'pino/file' to write to stdout
+      // Use target: 'pino/file' with 'options: { destination: 1 }' to write to stdout
       // without any change.
       target: 'pino-pretty'
     }]

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -257,9 +257,10 @@ const logger = pino({
     pipeline: [{
       target: './my-transform.js'
     }, {
-      // Use target: 'pino/file' with 'options: { destination: 1 }' to write to STDOUT
-      // without any change.
-      target: 'pino-pretty'
+      // Use target: 'pino/file' with STDOUT descriptor 1 to write
+      // logs without any change.
+      target: 'pino/file',
+      options: { destination: 1 }
     }]
   }
 })


### PR DESCRIPTION
As evidenced by https://github.com/pinojs/pino/issues/1741, and also by myself failing to understand how to do this despite trying to read documentation, this (fairly common) use-case might benefit from a more explicit section.

Yes, it is also mentioned in documentation for destination of "pino/file", but I've skipped the whole section because it's called "file" and its description says "The `pino/file` transport routes logs to a file (or file descriptor).". Not everyone knows that stdout is a file descriptor - maybe we should make that part more clear as well, e. g. saying "(or file descriptor, such as 1 for stdout)".