### PR TITLE
fix: type of child logger with custom levels

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -630,7 +630,7 @@ declare namespace pino {
         /**
          * Optional child creation callback.
          */
-        onChild?: OnChildCallback;
+        onChild?: OnChildCallback<CustomLevels>;
 
         /**
          * logs newline delimited JSON with `\r\n` instead of `\n`. Default: `false`.
@@ -799,7 +799,7 @@ declare function pino<CustomLevels extends string = never>(optionsOrStream?: Log
  * relative protocol is enabled. Default: process.stdout
  * @returns a new logger instance.
  */
-declare function pino<CustomLevels extends string>(options: LoggerOptions<CustomLevels>, stream: DestinationStream): Logger<CustomLevels>;
+declare function pino<CustomLevels extends string = never>(options: LoggerOptions<CustomLevels>, stream: DestinationStream): Logger<CustomLevels>;
 
 
 // Pass through all the top-level exports, allows `import {version} from "pino"`

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -404,3 +404,23 @@ expectType<Logger<'log'>>(pino({
     },
   },
 }))
+
+const parentLogger1 = pino({
+  customLevels: { myLevel: 90 },
+  onChild: (child) => { const a = child.myLevel; }
+}, process.stdout)
+parentLogger1.onChild = (child) => { child.myLevel(''); }
+
+const childLogger1 = parentLogger1.child({});
+childLogger1.myLevel('');
+expectError(childLogger1.doesntExist(''));
+
+const parentLogger2 = pino({}, process.stdin);
+expectError(parentLogger2.onChild = (child) => { const b = child.doesntExist; });
+
+const childLogger2 = parentLogger2.child({});
+expectError(childLogger2.doesntExist);
+
+expectError(pino({
+  onChild: (child) => { const a = child.doesntExist; }
+}, process.stdout));


### PR DESCRIPTION
fixes child logger types so that stuff like this doesn't error anymore
```
const parentLogger = pino({
  customLevels: { myLevel: 90 },
  onChild: (child) => { const a = child.myLevel; }
}, process.stdout);
parentLogger.onChild = (child) => { child.myLevel(''); };
```