### PR TITLE
Correct type of `pino`'s `stream` parameter

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -799,7 +799,7 @@ declare function pino<CustomLevels extends string = never>(optionsOrStream?: Log
  * relative protocol is enabled. Default: process.stdout
  * @returns a new logger instance.
  */
-declare function pino<CustomLevels extends string = never>(options: LoggerOptions<CustomLevels>, stream: DestinationStream): Logger<CustomLevels>;
+declare function pino<CustomLevels extends string = never>(options: LoggerOptions<CustomLevels>, stream?: DestinationStream | undefined): Logger<CustomLevels>;
 
 
 // Pass through all the top-level exports, allows `import {version} from "pino"`

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -107,6 +107,8 @@ pino({
     },
 });
 
+pino({}, undefined);
+
 pino({ base: null });
 if ("pino" in log) console.log(`pino version: ${log.pino}`);
 


### PR DESCRIPTION
The second parameter of the `pino` function can be set to `undefined`. This is relevant when dependency injecting a stream:

```ts
function create(stream: DestinationStream | undefined): Logger {
  return pino({ level: 'debug' }, stream); // <-- second parameter is incorrectly marked as invalid
}
```

This allows me to use `create(undefined)` for default behavior (stdio), but also `create({ write: jest.fn() })` for mocked behavior in unit tests, _without creating a new branch_.

With the definition prior to this PR, the following code is required:

```ts
function create(stream: DestinationStream | undefined): Logger {
  if (typeof stream === 'undefined') { // <-- this branch shouldn't be required, because it does nothing different
    return pino({ level: 'debug' });
  }
  return pino({ level: 'debug' }, stream);
}
```

This creates an unnecessary code branch, as it's the same runtime behavior.