### PR TITLE
fix: destination docs and types

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -575,13 +575,15 @@ parent.child(bindings)
 
 
 <a id="destination"></a>
-### `destination` (SonicBoom | WritableStream | String | Object)
+### `destination` (Number | String | Object | DestinationStream | SonicBoomOpts | WritableStream)
 
 Default: `pino.destination(1)` (STDOUT)
 
-The `destination` parameter, at a minimum must be an object with a `write` method.
-An ordinary Node.js `stream` can be passed as the destination (such as the result
-of `fs.createWriteStream`) but for peak log writing performance it is strongly
+The `destination` parameter can be a file descriptor, a file path, or an
+object with `dest` property pointing to a fd or path.
+An ordinary Node.js `stream` file descriptor can be passed as the
+destination (such as the result 
+of `fs.createWriteStream`) but for peak log writing performance, it is strongly
 recommended to use `pino.destination` to create the destination stream.
 Note that the `destination` parameter can be the result of `pino.transport()`.
 

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -765,13 +765,13 @@ declare namespace pino {
 
     /**
      * Create a Pino Destination instance: a stream-like object with significantly more throughput (over 30%) than a standard Node.js stream.
-     * @param [dest]: The `destination` parameter, at a minimum must be an object with a `write` method. An ordinary Node.js
-     *                `stream` can be passed as the destination (such as the result of `fs.createWriteStream`) but for peak log
-     *                writing performance it is strongly recommended to use `pino.destination` to create the destination stream.
+     * @param [dest]: The `destination` parameter, can be a file descriptor, a file path, or an object with `dest` property pointing to a fd or path.
+     *                An ordinary Node.js `stream` file descriptor can be passed as the destination (such as the result of `fs.createWriteStream`)
+     *                but for peak log writing performance, it is strongly recommended to use `pino.destination` to create the destination stream.
      * @returns A Sonic-Boom  stream to be used as destination for the pino function
      */
     export function destination(
-        dest?: string | number | SonicBoomOpts | DestinationStream | NodeJS.WritableStream,
+        dest?: number | object | string | DestinationStream | NodeJS.WritableStream | SonicBoomOpts,
     ): SonicBoom;
 
     export function transport<TransportOptions = Record<string, any>>(


### PR DESCRIPTION
- Resolves #1312 
- Updates documentation for `pino.destination()`
- Updates types for `pino.destination()`