### PR TITLE
Add a basic `formatters` option to the browser pino

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -109,6 +109,7 @@ function pino (opts) {
     transmit,
     serialize,
     asObject: opts.browser.asObject,
+    formatters: opts.browser.formatters,
     levels,
     timestamp: getTimeFunction(opts)
   }
@@ -299,8 +300,9 @@ function createWrap (self, opts, rootLogger, level) {
       if (opts.serialize && !opts.asObject) {
         applySerializers(args, this._serialize, this.serializers, this._stdErrSerialize)
       }
-      if (opts.asObject) write.call(proto, asObject(this, level, args, ts))
-      else write.apply(proto, args)
+      if (opts.asObject || opts.formatters) {
+        write.call(proto, asObject(this, level, args, ts, opts.formatters))
+      } else write.apply(proto, args)
 
       if (opts.transmit) {
         const transmitLevel = opts.transmit.level || self._level
@@ -321,7 +323,10 @@ function createWrap (self, opts, rootLogger, level) {
   })(self[baseLogFunctionSymbol][level])
 }
 
-function asObject (logger, level, args, ts) {
+function asObject (logger, level, args, ts, formatters = {}) {
+  const {
+    level: levelFormatter
+  } = formatters
   if (logger._serialize) applySerializers(args, logger._serialize, logger.serializers, logger._stdErrSerialize)
   const argsCloned = args.slice()
   let msg = argsCloned[0]
@@ -329,7 +334,12 @@ function asObject (logger, level, args, ts) {
   if (ts) {
     o.time = ts
   }
-  o.level = logger.levels.values[level]
+  if (levelFormatter) {
+    const formattedLevel = levelFormatter(level, logger.levels.values[level])
+    Object.assign(o, formattedLevel)
+  } else {
+    o.level = logger.levels.values[level]
+  }
   let lvl = (logger._childLevel | 0) + 1
   if (lvl < 1) lvl = 1
   // deliberate, catching objects, arrays

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -27,6 +27,25 @@ pino.info('hi') // creates and logs {msg: 'hi', level: 30, time: <ts>}
 
 When `write` is set, `asObject` will always be `true`.
 
+### `formatters` (Object)
+
+An object containing functions for formatting the shape of the log lines. When provided, it enables the logger to produce a pino-like log object with customized formatting. Currently, it supports formatting for the `level` object only.
+
+##### `level`
+
+Changes the shape of the log level. The default shape is `{ level: number }`.
+The function takes two arguments, the label of the level (e.g. `'info'`)
+and the numeric value (e.g. `30`).
+
+```js
+const formatters = {
+  level (label, number) {
+    return { level: number }
+  }
+}
+```
+
+
 ### `write` (Function | Object)
 
 Instead of passing log messages to `console.log` they can be passed to

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -166,6 +166,29 @@ test('opts.browser.asObject logs pino-like object to console', ({ end, ok, is })
   end()
 })
 
+test('opts.browser.formatters logs pino-like object to console', ({ end, ok, is }) => {
+  const info = console.info
+  console.info = function (o) {
+    is(o.level, 30)
+    is(o.label, 'info')
+    is(o.msg, 'test')
+    ok(o.time)
+    console.info = info
+  }
+  const instance = require('../browser')({
+    browser: {
+      formatters: {
+        level (label, number) {
+          return { label, level: number }
+        }
+      }
+    }
+  })
+
+  instance.info('test')
+  end()
+})
+
 test('opts.browser.write func log single string', ({ end, ok, is }) => {
   const instance = pino({
     browser: {


### PR DESCRIPTION
### Description

Add a basic `formatters` option to the browser implementation of pino with the ability to format the `level` object. The formatting behavior for the `level` object should mirror that of the non-browser implementation.

This was requested in #1891.

### Testing with Next.js

1. Create a basic Next.js app: `npx create-next-app@latest`.
2. Link your app to the current version of the pino package (I use [yalc ](https://www.npmjs.com/package/yalc) for this)
3. Add a basic logger with `browser.formatters.level` option supplied:
```
// src/logger.js
import pino from 'pino'

const logger = pino({ 
  browser: {
    formatters: {
      level (label, number) {
        return { label, level: number}
      }
    }
  }
})

export default logger
```

4. Create a basic middleware
```
// src/middleware.js

import { NextResponse } from 'next/server'
import logger from './logger'

export function middleware(request) {
  logger.info('I am logging a message from the middleware')
  return NextResponse.next()
}
```

5. Run the app and check the terminal for the correct log format. For the above example, it should look like:
```
{
  time: 1707198967745,
  label: 'info',
  level: 30,
  msg: 'I am logging a message from the middleware'
}
```
