### PR TITLE
Add formatters log option

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -109,6 +109,7 @@ function pino (opts) {
     transmit,
     serialize,
     asObject: opts.browser.asObject,
+    formatters: opts.browser.formatters,
     levels,
     timestamp: getTimeFunction(opts)
   }
@@ -299,8 +300,9 @@ function createWrap (self, opts, rootLogger, level) {
       if (opts.serialize && !opts.asObject) {
         applySerializers(args, this._serialize, this.serializers, this._stdErrSerialize)
       }
-      if (opts.asObject) write.call(proto, asObject(this, level, args, ts))
-      else write.apply(proto, args)
+      if (opts.asObject || opts.formatters) {
+        write.call(proto, asObject(this, level, args, ts, opts.formatters))
+      } else write.apply(proto, args)
 
       if (opts.transmit) {
         const transmitLevel = opts.transmit.level || self._level
@@ -321,7 +323,10 @@ function createWrap (self, opts, rootLogger, level) {
   })(self[baseLogFunctionSymbol][level])
 }
 
-function asObject (logger, level, args, ts) {
+function asObject (logger, level, args, ts, formatters = {}) {
+  const {
+    level: levelFormatter
+  } = formatters
   if (logger._serialize) applySerializers(args, logger._serialize, logger.serializers, logger._stdErrSerialize)
   const argsCloned = args.slice()
   let msg = argsCloned[0]
@@ -329,7 +334,12 @@ function asObject (logger, level, args, ts) {
   if (ts) {
     o.time = ts
   }
-  o.level = logger.levels.values[level]
+  if (levelFormatter) {
+    const formattedLevel = levelFormatter(level, logger.levels.values[level])
+    Object.assign(o, formattedLevel)
+  } else {
+    o.level = logger.levels.values[level]
+  }
   let lvl = (logger._childLevel | 0) + 1
   if (lvl < 1) lvl = 1
   // deliberate, catching objects, arrays

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -27,6 +27,25 @@ pino.info('hi') // creates and logs {msg: 'hi', level: 30, time: <ts>}
 
 When `write` is set, `asObject` will always be `true`.
 
+### `formatters` (Object)
+
+An object containing functions for formatting the shape of the log lines. When provided, it enables the logger to produce a pino-like log object with customized formatting. Currently, it supports formatting for the `level` object only.
+
+##### `level`
+
+Changes the shape of the log level. The default shape is `{ level: number }`.
+The function takes two arguments, the label of the level (e.g. `'info'`)
+and the numeric value (e.g. `30`).
+
+```js
+const formatters = {
+  level (label, number) {
+    return { level: number }
+  }
+}
+```
+
+
 ### `write` (Function | Object)
 
 Instead of passing log messages to `console.log` they can be passed to

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -166,6 +166,29 @@ test('opts.browser.asObject logs pino-like object to console', ({ end, ok, is })
   end()
 })
 
+test('opts.browser.formatters logs pino-like object to console', ({ end, ok, is }) => {
+  const info = console.info
+  console.info = function (o) {
+    is(o.level, 30)
+    is(o.label, 'info')
+    is(o.msg, 'test')
+    ok(o.time)
+    console.info = info
+  }
+  const instance = require('../browser')({
+    browser: {
+      formatters: {
+        level (label, number) {
+          return { label, level: number }
+        }
+      }
+    }
+  })
+
+  instance.info('test')
+  end()
+})
+
 test('opts.browser.write func log single string', ({ end, ok, is }) => {
   const instance = pino({
     browser: {

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -189,6 +189,30 @@ test('opts.browser.formatters logs pino-like object to console', ({ end, ok, is 
   end()
 })
 
+test('opts.browser.formatters logs pino-like object to console', ({ end, ok, is }) => {
+  const info = console.info
+  console.info = function (o) {
+    is(o.level, 30)
+    is(o.msg, 'test')
+    is(o.hello, 'world')
+    is(o.newField, 'test')
+    ok(o.time, `Logged at ${o.time}`)
+    console.info = info
+  }
+  const instance = require('../browser')({
+    browser: {
+      formatters: {
+        log (o) {
+          return { ...o, newField: 'test', time: `Logged at ${o.time}` }
+        }
+      }
+    }
+  })
+
+  instance.info({ hello: 'world' }, 'test')
+  end()
+})
+
 test('opts.browser.write func log single string', ({ end, ok, is }) => {
   const instance = pino({
     browser: {


### PR DESCRIPTION
### Description

In a previous ticket, I added the `formatters` option to the browser pino ([related PR](https://github.com/pinojs/pino/pull/1898)). This is in continuation of that ticket to fully replicate the behavior of the formatters option in the non-browser pino in its browser counterpart. 

Closes #1904 


### Testing plan

Create a logger with a `log` function supplied to the `browser.formatters` option. Something like:

```
const logger = pino({
  browser: {
    formatters: {
      log (obj) {
        return {...obj, newField: 'awesome!', level: 'testlevel'}
      }
    }
  }
})

logger.info({ hello: 'world' }, 'Logging')
```

Ensure the correct log is output. For the example above, it should look something like:

```
{
  time: 1707885379287,
  level: 'testlevel',
  hello: 'world',
  msg: 'Logging',
  newField: 'awesome!'
}
```





