### PR TITLE
Improve documentation for use with Google Cloud Logging

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -244,7 +244,6 @@ const PinoLevelToSeverityLookup = {
 const defaultPinoConf = {
   messageKey: 'message',
   formatters: {
-    messageKey: 'message',
     level(label, number) {
       return {
         severity: PinoLevelToSeverityLookup[label] || PinoLevelToSeverityLookup['info'],


### PR DESCRIPTION
Based on the documentation `messageKey` can only be configured in the main config and is not a valid configuration option for a formater.

See formaters documentation: https://getpino.io/#/docs/api?id=formatters-object