### PR TITLE
docs: remove reference to make-promises-safe

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -76,8 +76,6 @@ npm install hapi-pino
 ```js
 'use strict'
 
-require('make-promises-safe')
-
 const Hapi = require('@hapi/hapi')
 const Pino = require('hapi-pino');
 


### PR DESCRIPTION
make-promises-safe is not necessary since Node.js 15