### PR TITLE
Fix deprecated dependency notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "atomic-sleep": "^1.0.0",
     "fast-redact": "^3.1.1",
     "on-exit-leak-free": "^2.1.0",
-    "pino-abstract-transport": "v1.1.0",
+    "pino-abstract-transport": "1.1.0",
     "pino-std-serializers": "^6.0.0",
     "process-warning": "^3.0.0",
     "quick-format-unescaped": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "atomic-sleep": "^1.0.0",
     "fast-redact": "^3.1.1",
     "on-exit-leak-free": "^2.1.0",
-    "pino-abstract-transport": "1.1.0",
+    "pino-abstract-transport": "^1.1.0",
     "pino-std-serializers": "^6.0.0",
     "process-warning": "^3.0.0",
     "quick-format-unescaped": "^4.0.3",


### PR DESCRIPTION
Minor change to replaces a semver v1 notation (with leading `v`) with semver v2.

PS: The npm semver package most likely will deprecate semver v1 support in next major.