### PR TITLE
fix: avoid override mistake

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -264,13 +264,13 @@ function getBindingChain (logger) {
 function set (self, opts, rootLogger, level) {
   // override the current log functions with either `noop` or the base log function
   Object.defineProperty(self, level, {
-    value: levelToValue(self.level, rootLogger) > levelToValue(level, rootLogger)
+    value: (levelToValue(self.level, rootLogger) > levelToValue(level, rootLogger)
       ? noop
-      : rootLogger[baseLogFunctionSymbol][level],
+      : rootLogger[baseLogFunctionSymbol][level]),
     writable: true,
     enumerable: true,
-    configurable: true,
-  });
+    configurable: true
+  })
 
   if (!opts.transmit && self[level] === noop) {
     return

--- a/browser.js
+++ b/browser.js
@@ -263,9 +263,14 @@ function getBindingChain (logger) {
 
 function set (self, opts, rootLogger, level) {
   // override the current log functions with either `noop` or the base log function
-  self[level] = levelToValue(self.level, rootLogger) > levelToValue(level, rootLogger)
-    ? noop
-    : rootLogger[baseLogFunctionSymbol][level]
+  Object.defineProperty(self, level, {
+    value: levelToValue(self.level, rootLogger) > levelToValue(level, rootLogger)
+      ? noop
+      : rootLogger[baseLogFunctionSymbol][level],
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
 
   if (!opts.transmit && self[level] === noop) {
     return

--- a/test/browser-early-console-freeze.test.js
+++ b/test/browser-early-console-freeze.test.js
@@ -1,0 +1,12 @@
+'use strict'
+Object.freeze(console)
+const test = require('tape')
+const pino = require('../browser')
+
+test('silent level', ({ end, fail, pass }) => {
+  pino({
+    level: 'silent',
+    browser: { }
+  })
+  end()
+})


### PR DESCRIPTION
The assignment at this location was to a `self` object that inherits from the `console` (or what was the `console` before this code ran). This assignment was use to override properties typically inherited from `console` such as `error`,`warn`,`info`,`debug`,`trace`. However, if the `console` object it inherits from is frozen, as it is in the ses-shim of HardenedJS, then this assignment fails due to the so-called "override mistake".

Changing this assignment to use `Object.defineProperty` instead avoids hitting the override mistake. The additional attributes I include in this change
```js
    writable: true,
    enumerable: true,
    configurable: true,
```
are only there to preserve equivalence with assignment. But feel free to change them to whatever you'd like. Such changes would not affect the purpose of this PR.