### PR TITLE
Update pino types for browser.formatters

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -427,6 +427,17 @@ declare namespace pino {
              * pino.info('hi') // creates and logs {msg: 'hi', level: 30, time: <ts>}
              */
             asObject?: boolean;
+            formatters?: {
+                /**
+                 * Changes the shape of the log level.
+                 * The default shape is { level: number }.
+                 */
+                level?: (label: string, number: number) => object;
+                /**
+                 * Changes the shape of the log object.
+                 */
+                log?: (object: Record<string, unknown>) => Record<string, unknown>;
+            }
             /**
              * Instead of passing log messages to `console.log` they can be passed to a supplied function. If `write` is
              * set to a single function, all logging objects are passed to this function. If `write` is an object, it

--- a/test/types/pino-type-only.test-d.ts
+++ b/test/types/pino-type-only.test-d.ts
@@ -1,7 +1,7 @@
 import { expectAssignable, expectType, expectNotAssignable } from "tsd";
 
 import pino from "../../";
-import type {LevelWithSilent, Logger, LogFn, P, DestinationStreamWithMetadata,  Level, LevelOrString, LevelWithSilentOrString, LoggerExtras } from "../../pino";
+import type {LevelWithSilent, Logger, LogFn, P, DestinationStreamWithMetadata,  Level, LevelOrString, LevelWithSilentOrString, LoggerExtras, LoggerOptions } from "../../pino";
 
 // NB: can also use `import * as pino`, but that form is callable as `pino()`
 // under `esModuleInterop: false` or `pino.default()` under `esModuleInterop: true`.
@@ -46,3 +46,19 @@ const needsMetadata: typeof pino.symbols.needsMetadataGsym = pino.symbols.needsM
 if (stream[needsMetadata]) {
     expectType<number>(stream.lastLevel);
 }
+
+const loggerOptions:LoggerOptions = {
+    browser: {
+        formatters: {
+            log(obj) {
+                return obj
+            },
+            level(label, number) {
+                return { label, number}
+            }
+
+        }
+    }
+}
+
+expectType<LoggerOptions>(loggerOptions)


### PR DESCRIPTION
Add the missing types for the `browser.formatters` option.