### PR TITLE
feat: keep parent formatters bindings function option

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -378,11 +378,30 @@ const hooks = {
 <a id=opt-formatters></a>
 #### `formatters` (Object)
 
-An object containing functions for formatting the shape of the log lines.
+An object containing an `options` object and functions for formatting
+the shape of the log lines.
 These functions should return a JSONifiable object and
 should never throw. These functions allow for full customization of
 the resulting log lines. For example, they can be used to change
 the level key name or to enrich the default metadata.
+
+##### `options`
+
+The formatters `options` object is passed to the child loggers, except if a new formatters `options` object is passed to the `child()` method.
+
+###### `keepParentBindings`
+
+If `true`, child loggers will keep their parent `bindings` formatters function.
+
+If `false` or `undefined`, child loggers will have their `bindings` formatters function reset to a "no-op" formatter function.
+
+```js
+const formatters = {
+  options: {
+    keepParentBindings: true
+  }
+}
+```
 
 ##### `level`
 

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -78,7 +78,7 @@ module.exports = function () {
   return Object.create(prototype)
 }
 
-const resetChildingsFormatter = bindings => bindings
+const noOpFormatter = bindings => bindings
 function child (bindings, options) {
   if (!bindings) {
     throw Error('missing bindings for child Pino')
@@ -110,17 +110,20 @@ function child (bindings, options) {
       instance[serializersSym][bks] = options.serializers[bks]
     }
   } else instance[serializersSym] = serializers
+  const keepParentBindings = typeof formatters.options === 'object' && formatters.options.keepParentBindings
   if (options.hasOwnProperty('formatters')) {
-    const { level, bindings: chindings, log } = options.formatters
+    const { options: formattersOptions, level, bindings: chindings, log } = options.formatters
     instance[formattersSym] = buildFormatters(
+      formattersOptions || formatters.options,
       level || formatters.level,
-      chindings || resetChildingsFormatter,
+      chindings || (keepParentBindings ? formatters.bindings || noOpFormatter : noOpFormatter),
       log || formatters.log
     )
   } else {
     instance[formattersSym] = buildFormatters(
+      formatters.options,
       formatters.level,
-      resetChildingsFormatter,
+      keepParentBindings ? formatters.bindings || noOpFormatter : noOpFormatter,
       formatters.log
     )
   }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -352,8 +352,9 @@ function stringify (obj, stringifySafeFn) {
   }
 }
 
-function buildFormatters (level, bindings, log) {
+function buildFormatters (options, level, bindings, log) {
   return {
+    options,
     level,
     bindings,
     log

--- a/pino.js
+++ b/pino.js
@@ -118,6 +118,7 @@ function pino (...args) {
   })
 
   const allFormatters = buildFormatters(
+    formatters.options,
     formatters.level,
     formatters.bindings,
     formatters.log


### PR DESCRIPTION
# Synopsis

I have the following code, which intent to make some property values upper case (it could also be stringified, etc.):

```javascript
const _ = require('lodash')
const pino = require('pino')

function shapeObject(object) {
  const propertyPaths = ['logger', 'method', 'partner', 'service']
  propertyPaths.forEach(path => {
    const value = _.get(object, path)
    if (typeof value === 'string') _.set(object, path, value.toUpperCase())
  })

  return object
}

const parent = pino({
  formatters: {
    log: shapeObject,
    bindings: shapeObject
  },
})
const child = parent.child({})

parent.setBindings({ logger: 'parent' })
child.setBindings({ logger: 'child' })

function testScenario(logger) {
  const partner = 'apple'
  const method = 'get'
  const service = 'foo'

  logger.setBindings({ service })
  logger.info('one')
  const childLogger = logger.child({ partner })
  childLogger.info({ method }, 'two')
}

testScenario(parent)
testScenario(child)
```

When I run this code, I actually get the following output:

```json
{"level":30,"time":1,"pid":7068,"hostname":"myMac","logger":"PARENT","service":"FOO","msg":"one"}
{"level":30,"time":1,"pid":7068,"hostname":"myMac","logger":"PARENT","service":"FOO","partner":"apple","method":"GET","msg":"two"}
{"level":30,"time":1,"pid":7068,"hostname":"myMac","logger":"child","service":"foo","msg":"one"}
{"level":30,"time":1,"pid":7068,"hostname":"myMac","logger":"child","service":"foo","partner":"apple","method":"GET","msg":"two"}
```

## Shape the `bindings` passed to the `child()` method

There are currently functions to shape the log `level`, the `log` object, the `bindings`, but I cannot see any function to shape the bindings passed to a child logger through the `child()` method.

I would like to be able to apply my shaping function to the `partner` property:

```json
{ "partner": "apple" }
```

## Keep the parent `bindings` formatters function in children loggers

In case of a global `bindings` formatters function, I would like to be able to keep that `bindings` formatters function in the logger children (and without having to pass it at each `child()` call).

I would like to be able to apply my shaping function to all my `propertyPaths` properties in my logger children too, so I can get the following:

```json
{"level":30,"time":1,"pid":7068,"hostname":"myMac","logger":"PARENT","service":"FOO","msg":"one"}
{"level":30,"time":1,"pid":7068,"hostname":"myMac","logger":"PARENT","service":"FOO","partner":"APPLE","method":"GET","msg":"two"}
{"level":30,"time":1,"pid":7068,"hostname":"myMac","logger":"CHILD","service":"FOO","msg":"one"}
{"level":30,"time":1,"pid":7068,"hostname":"myMac","logger":"CHILD","service":"FOO","partner":"APPLE","method":"GET","msg":"two"}
```

# Proposal

## Add an `options` object

Add a formatters `options` object, with a `keepParentBindings` option:

```javascript
pino({
  formatters: {
    log: shapeObject,
    bindings: shapeObject
    options: { keepParentBindings: true },
  },
})
```

The formatters `options` object would be passed to the child loggers, except if a new `options` object is passed to the `child()` method.

## The `keepParentBindings` option

If `true`, child loggers will keep their parent `bindings` formatters function.

If `false` or `undefined`, child loggers will have their `bindings` formatters function reset to a "no-op" formatter function, as today.

## The `child()` method

In the `child()` method, the parent `bindings` function will be passed or not to the child logger according to the `keepParentBindings` option, except if a new `bindings` formatters function is passed to the child logger.
