### PR TITLE
Support file URLs when configuring multiple transports

### DIFF
--- a/lib/transport-stream.js
+++ b/lib/transport-stream.js
@@ -13,7 +13,7 @@ module.exports = loadTransportStreamBuilder
 async function loadTransportStreamBuilder (target) {
   let fn
   try {
-    const toLoad = 'file://' + target
+    const toLoad = target.startsWith('file://') ? target : 'file://' + target
 
     if (toLoad.endsWith('.ts') || toLoad.endsWith('.cts')) {
       // TODO: add support for the TSM modules loader ( https://github.com/lukeed/tsm ).

--- a/test/transport/core.test.js
+++ b/test/transport/core.test.js
@@ -134,7 +134,7 @@ test('pino.transport with two files', async ({ same, teardown }) => {
   const transport = pino.transport({
     targets: [{
       level: 'info',
-      target: join(__dirname, '..', 'fixtures', 'to-file-transport.js'),
+      target: 'file://' + join(__dirname, '..', 'fixtures', 'to-file-transport.js'),
       options: { destination: dest1 }
     }, {
       level: 'info',


### PR DESCRIPTION
pino currently supports file URLs in single transports

```ts
pino.transport({ target: "file:///path/to/transport.js" });
```

but in multiple transports it does not:

```ts
pino.transport({ targets: [{ target: "file:///path/to/transport.js" }] });
```

throws

```ts
{
  code: "ERR_INVALID_URL",
  input: "file://file:///path/to/transport.js",
}
```

This PR adds a check for the presence of the `file://` prefix before prepending it to the target.