### PR TITLE
apply serializers to args once before asObject or transmit

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -144,7 +144,7 @@ Unlike server pino the serializers apply to every object passed to the logger me
 if the `asObject` option is `true`, this results in the serializers applying to the
 first object (as in server pino).
 
-For more info on serializers see https://github.com/pinojs/pino/blob/master/docs/api.md#parameters.
+For more info on serializers see https://github.com/pinojs/pino/blob/master/docs/api.md#mergingobject.
 
 ### `transmit` (Object)
 

--- a/test/browser-serializers.test.js
+++ b/test/browser-serializers.test.js
@@ -284,7 +284,6 @@ test('children inherit parent serializers', ({ end, is }) => {
 
 test('children serializers get called', ({ end, is }) => {
   const parent = pino({
-    test: 'this',
     browser: {
       serialize: true,
       write (o) {
@@ -301,7 +300,6 @@ test('children serializers get called', ({ end, is }) => {
 
 test('children serializers get called when inherited from parent', ({ end, is }) => {
   const parent = pino({
-    test: 'this',
     serializers: parentSerializers,
     browser: {
       serialize: true,


### PR DESCRIPTION
- Fixes https://github.com/pinojs/pino/issues/1970 
  -  `applySerializers` functioin mutates `args` to logger.*, this cause args to be updated twice in `asObject` and `transmit`  
  - Apply serializers once before `asObject`

- Also includes fix for https://github.com/pinojs/pino/issues/1966
  - Current tests were already failing on the main branch, since `formatters.level` does not spread the returned object, but updates `logData.level = { level: 30, label: 'info' }`
  
  
 