### PR TITLE
use boolean flag to ensure serializers are applied once

### DIFF
--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -255,6 +255,28 @@ test('opts.browser.serialize and opts.asObject only serializes log data once', (
   end()
 })
 
+test('opts.browser.serialize, opts.asObject and opts.browser.transmit only serializes log data once', ({ end, ok, is }) => {
+  const instance = require('../browser')({
+    serializers: {
+      extras (data) {
+        return { serializedExtras: data }
+      }
+    },
+    browser: {
+      serialize: ['extras'],
+      asObject: true,
+      transmit: {
+        send (level, o) {
+          is(o.messages[0].extras.serializedExtras, 'world')
+        }
+      }
+    }
+  })
+
+  instance.info({ extras: 'world' }, 'test')
+  end()
+})
+
 test('opts.browser.write func log single string', ({ end, ok, is }) => {
   const instance = pino({
     browser: {


### PR DESCRIPTION
```
var logger = pino({
  serializers: {
    extras(data) {
      return { serializedExtras: data };
    },
  },
  browser: {
    serialize: ['extras'],
    asObject: true,
    transmit: {
      send(level, o) {
        is(o.messages[0].extras.serializedExtras, 'world');
      },
    },
  },
})
```
When `opt.browser.transmit` is defined, serializers are not applied to `write`


Conditions when serializers should be applied
- when `opts.serialize` is `true` or `defined`
 - serializers should be applied to `write` and `transmit` operations
- when `opts.serialize` is `false` or `undefined`
 - serializers should be applied to `transmit` operation only


