### PR TITLE
Fixing browser side child log issue (#960) child level can now be set at cr…

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -195,7 +195,7 @@ function pino (opts) {
     // must happen before the level is assigned
     appendChildLogger(this, newLogger)
     // required to actually initialize the logger functions for any given child
-    newLogger.level = this.level
+    newLogger.level = childOptions.level || this.level // allow level to be set by childOptions
 
     return newLogger
   }

--- a/test/browser-child.test.js
+++ b/test/browser-child.test.js
@@ -14,6 +14,18 @@ test('child has parent level', ({ end, same, is }) => {
   end()
 })
 
+test('child can set level at creation time', ({ end, same, is }) => {
+  const instance = pino({
+    level: 'error',
+    browser: {}
+  })
+
+  const child = instance.child({}, { level: 'info' }) // first bindings, then options
+
+  same(child.level, 'info')
+  end()
+})
+
 test('changing child level does not affect parent', ({ end, same, is }) => {
   const instance = pino({
     level: 'error',


### PR DESCRIPTION
With this PR, a browser side child logger level can now be set at creation time. More discussions and sample code to demonstrate this problem are in #960.