### PR TITLE
Update pino.d.ts

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -317,8 +317,8 @@ declare namespace pino {
         // TODO: why is this different from `obj: object` or `obj: any`?
         /* tslint:disable:no-unnecessary-generics */
         <T extends object>(obj: T, msg?: string, ...args: any[]): void;
-        (obj: unknown, msg?: string, ...args: any[]): void;
-        (msg: string, ...args: any[]): void;
+        (msg: string): void;
+        (msg: `${string}%${'s' | 'd' | 'O' | 'o' | 'j'}${string}`, ...args: any[]): void;
     }
 
     interface LoggerOptions<CustomLevels extends string = never> {


### PR DESCRIPTION
Made it so you can't put objects after msg unless it has %s etc in it.

I keep making the mistake of putting the metadata object after the msg. This makes it so you can't do that unless you were intending on using the values in an interpreted output.