### PR TITLE
call onChild when instanciating new child browser logger

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -112,7 +112,8 @@ function pino (opts) {
     formatters: opts.browser.formatters,
     levels,
     timestamp: getTimeFunction(opts),
-    messageKey: opts.messageKey || 'msg'
+    messageKey: opts.messageKey || 'msg',
+    onChild: opts.onChild || noop
   }
   logger.levels = getLevels(opts)
   logger.level = level
@@ -127,7 +128,7 @@ function pino (opts) {
   logger.serializers = serializers
   logger._serialize = serialize
   logger._stdErrSerialize = stdErrSerialize
-  logger.child = child
+  logger.child = function (...args) { return child.call(this, setOpts, ...args) }
 
   if (transmit) logger._logEvent = createLogEventShape()
 
@@ -156,7 +157,7 @@ function pino (opts) {
     })
   }
 
-  function child (bindings, childOptions) {
+  function child (setOpts, bindings, childOptions) {
     if (!bindings) {
       throw new Error('missing bindings for child Pino')
     }
@@ -194,8 +195,10 @@ function pino (opts) {
 
     // must happen before the level is assigned
     appendChildLogger(this, newLogger)
+    newLogger.child = function (...args) { return child.call(this, setOpts, ...args) }
     // required to actually initialize the logger functions for any given child
     newLogger.level = childOptions.level || this.level // allow level to be set by childOptions
+    setOpts.onChild(newLogger)
 
     return newLogger
   }

--- a/test/browser-child.test.js
+++ b/test/browser-child.test.js
@@ -106,6 +106,20 @@ test('changing child log level should not affect parent log behavior', ({ end, s
   end()
 })
 
+test('onChild callback should be called when new child is created', ({ end, pass, plan }) => {
+  plan(1)
+  const instance = pino({
+    level: 'error',
+    browser: {},
+    onChild: (_child) => {
+      pass('onChild callback was called')
+      end()
+    }
+  })
+
+  instance.child({})
+})
+
 function checkLogObjects (is, same, actual, expected) {
   is(actual.time <= Date.now(), true, 'time is greater than Date.now()')
 


### PR DESCRIPTION
onChild callback is currently not called when instanciating a child broser logger.
This PR corrects this by passing the callback passed to the parent pino ops into the browser context and calling it on new Child.

Test also included.