### PR TITLE
fix(browser): should respect log level with transmit

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -276,8 +276,13 @@ function set (self, opts, rootLogger, level) {
     configurable: true
   })
 
-  if (!opts.transmit && self[level] === noop) {
-    return
+  if (self[level] === noop) {
+    if (!opts.transmit) return
+
+    const transmitLevel = opts.transmit.level || self.level
+    const transmitValue = rootLogger.levels.values[transmitLevel]
+    const methodValue = rootLogger.levels.values[level]
+    if (methodValue < transmitValue) return
   }
 
   // make sure the log format is correct

--- a/test/browser-transmit.test.js
+++ b/test/browser-transmit.test.js
@@ -347,3 +347,23 @@ test('extracts correct bindings and raw messages over multiple transmits', ({ en
 
   end()
 })
+
+test('does not log below configured level', ({ end, is }) => {
+  let message = null
+  const logger = pino({
+    level: 'info',
+    browser: {
+      write (o) {
+        message = o.msg
+      },
+      transmit: {
+        send () { }
+      }
+    }
+  })
+
+  logger.debug('this message is silent')
+  is(message, null)
+
+  end()
+})


### PR DESCRIPTION
Potential fix for https://github.com/pinojs/pino/issues/1861

Added early return in the case level of the message is below transmit level

Added unit test for the case