### PR TITLE
fix: no early return in `loadTransportStreamBuilder`

### DIFF
--- a/lib/transport-stream.js
+++ b/lib/transport-stream.js
@@ -7,7 +7,7 @@ module.exports = loadTransportStreamBuilder
 /**
  * Loads & returns a function to build transport streams
  * @param {string} target
- * @returns {function(object): Promise<import('node:stream').Writable>}
+ * @returns {Promise<function(object): Promise<import('node:stream').Writable>>}
  * @throws {Error} In case the target module does not export a function
  */
 async function loadTransportStreamBuilder (target) {
@@ -31,7 +31,6 @@ async function loadTransportStreamBuilder (target) {
     // See this PR for details: https://github.com/pinojs/thread-stream/pull/34
     if ((error.code === 'ENOTDIR' || error.code === 'ERR_MODULE_NOT_FOUND')) {
       fn = realRequire(target)
-      return
     } else if (error.code === undefined || error.code === 'ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING') {
       // When bundled with pkg, an undefined error is thrown when called with realImport
       // When bundled with pkg and using node v20, an ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING error is thrown when called with realImport

--- a/test/transport-stream.test.js
+++ b/test/transport-stream.test.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const { test } = require('tap')
+
+test('should import', async (t) => {
+  t.plan(2)
+  const mockRealRequire = (target) => {
+    return {
+      default: {
+        default: () => {
+          t.equal(target, 'pino-pretty')
+          return Promise.resolve()
+        }
+      }
+    }
+  }
+  const mockRealImport = async () => { await Promise.resolve(); throw Object.assign(new Error(), { code: 'ERR_MODULE_NOT_FOUND' }) }
+
+  /** @type {typeof import('../lib/transport-stream.js')} */
+  const loadTransportStreamBuilder = t.mock('../lib/transport-stream.js', { 'real-require': { realRequire: mockRealRequire, realImport: mockRealImport } })
+
+  const fn = await loadTransportStreamBuilder('pino-pretty')
+
+  t.resolves(fn())
+  t.end()
+})


### PR DESCRIPTION
Don't return early in `loadTransportStreamBuilder`, it'll return undefined instead if the expected function.
I'll also fixed the type annotation to be a promise. 😉 

- closes #2012
- regression of #1990