### PR TITLE
[Chore] Cleanup npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,5 +116,11 @@
   },
   "tsd": {
     "directory": "test/types"
-  }
+  },
+  "files": [
+    "lib",
+    "*.js",
+    "*.d.ts",
+    "SECURITY.md"
+  ]
 }


### PR DESCRIPTION
Remove unnecessary files from npm package.

**Reasoning**:
For using `pino` as a dependency we just need basically `js` files. Right now in the package there is everything from the repo, which is not ideal. Most files won't be used at all and they lead to longer download times and unnecessary data transfer.

Before: **238KB** gzipped (1.3 MB and 211 files unpacked)
After: **37KB** gzipped (0.12 MB and 25 files unpacked)

## Tarball contents after this PR

```
Tarball Contents
----------------
1.2kB LICENSE
4.4kB README.md
2.5kB SECURITY.md
170B bin.js
13.8kB browser.js
358B file.js
551B lib/caller.js
375B lib/constants.js
183B lib/deprecations.js
6.7kB lib/levels.js
52B lib/meta.js
4.4kB lib/multistream.js
6.6kB lib/proto.js
3.3kB lib/redaction.js
2.1kB lib/symbols.js
328B lib/time.js
11.9kB lib/tools.js
2.2kB lib/transport-stream.js
3.9kB lib/transport.js
9.0kB lib/worker.js
4.3kB package.json
38.9kB pino.d.ts
6.1kB pino.js
```