### PR TITLE
Add asObjectBindingsOnly, allowing write to receive only the bindings as object

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -352,6 +352,17 @@ function asObject (logger, level, args, ts, opts) {
   let lvl = (logger._childLevel | 0) + 1
   if (lvl < 1) lvl = 1
 
+  if (ts) {
+    logObject.time = ts
+  }
+
+  if (levelFormatter) {
+    const formattedLevel = levelFormatter(level, logger.levels.values[level])
+    Object.assign(logObject, formattedLevel)
+  } else {
+    logObject.level = logger.levels.values[level]
+  }
+
   if (opts.asObjectBindingsOnly) {
     if (msg !== null && typeof msg === 'object') {
       while (lvl-- && typeof argsCloned[0] === 'object') {
@@ -362,17 +373,6 @@ function asObject (logger, level, args, ts, opts) {
     const formattedLogObject = logObjectFormatter(logObject)
     return [formattedLogObject, ...argsCloned]
   } else {
-    if (ts) {
-      logObject.time = ts
-    }
-
-    if (levelFormatter) {
-      const formattedLevel = levelFormatter(level, logger.levels.values[level])
-      Object.assign(logObject, formattedLevel)
-    } else {
-      logObject.level = logger.levels.values[level]
-    }
-
     // deliberate, catching objects, arrays
     if (msg !== null && typeof msg === 'object') {
       while (lvl-- && typeof argsCloned[0] === 'object') {

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -27,6 +27,21 @@ pino.info('hi') // creates and logs {msg: 'hi', level: 30, time: <ts>}
 
 When `write` is set, `asObject` will always be `true`.
 
+### `asObjectBindingsOnly` (Boolean)
+
+```js
+const pino = require('pino')({browser: {asObjectBindingsOnly: true}})
+```
+
+The `asObjectBindingsOnly` is similar to `asObject` but will keep the message
+and arguments unformatted, this allows to defer formatting the message to the
+actual call to `console` methods, where browsers then have richer formatting in
+their devtools then when pino will format the message to a string first.
+
+```js
+pino.info('hello %s', 'world') // creates and logs {level: 30, time: <ts>}, 'hello %s', 'world'
+```
+
 ### `formatters` (Object)
 
 An object containing functions for formatting the shape of the log lines. When provided, it enables the logger to produce a pino-like log object with customized formatting. Currently, it supports formatting for the `level` object only.

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -165,6 +165,7 @@ test('opts.browser.asObject logs pino-like object to console', ({ end, ok, is })
   instance.info('test')
   end()
 })
+
 test('opts.browser.asObject uses opts.messageKey in logs', ({ end, ok, is }) => {
   const messageKey = 'message'
   const instance = require('../browser')({
@@ -180,6 +181,25 @@ test('opts.browser.asObject uses opts.messageKey in logs', ({ end, ok, is }) => 
   })
 
   instance.info('test')
+  end()
+})
+
+test('opts.browser.asObjectBindingsOnly passes the bindings but keep the message unformatted', ({ end, ok, is, deepEqual }) => {
+  const messageKey = 'message'
+  const instance = require('../browser')({
+    messageKey,
+    browser: {
+      asObjectBindingsOnly: true,
+      write: function (o, msg, ...args) {
+        is(o.level, 30)
+        ok(o.time)
+        is(msg, 'test %s')
+        deepEqual(args, ['foo'])
+      }
+    }
+  })
+
+  instance.info('test %s', 'foo')
   end()
 })
 


### PR DESCRIPTION
This allows to pass the format string and args as
is the underlying console when to keep their
special handling, for when using `write` to only
modify the default way the printing to the console
looks rather than writing to an alternate
destination entirely.

The name of the option and its behavior is obviously open for discussion

Part of #1556