### PR TITLE
fix: Ensure silent log level is respected with browser.transmit option

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -280,8 +280,8 @@ function set (self, opts, rootLogger, level) {
     if (!opts.transmit) return
 
     const transmitLevel = opts.transmit.level || self.level
-    const transmitValue = rootLogger.levels.values[transmitLevel]
-    const methodValue = rootLogger.levels.values[level]
+    const transmitValue = levelToValue(transmitLevel, rootLogger)
+    const methodValue = levelToValue(level, rootLogger)
     if (methodValue < transmitValue) return
   }
 
@@ -322,8 +322,8 @@ function createWrap (self, opts, rootLogger, level) {
 
       if (opts.transmit) {
         const transmitLevel = opts.transmit.level || self._level
-        const transmitValue = rootLogger.levels.values[transmitLevel]
-        const methodValue = rootLogger.levels.values[level]
+        const transmitValue = levelToValue(transmitLevel, rootLogger)
+        const methodValue = levelToValue(level, rootLogger)
         if (methodValue < transmitValue) return
         transmit(this, {
           ts,

--- a/test/browser-transmit.test.js
+++ b/test/browser-transmit.test.js
@@ -367,3 +367,51 @@ test('does not log below configured level', ({ end, is }) => {
 
   end()
 })
+
+test('silent level prevents logging even with transmit', ({ end, fail }) => {
+  const logger = pino({
+    level: 'silent',
+    browser: {
+      write () {
+        fail('no data should be logged by the write method')
+      },
+      transmit: {
+        send () {
+          fail('no data should be logged by the send method')
+        }
+      }
+    }
+  })
+
+  Object.keys(pino.levels.values).forEach((level) => {
+    logger[level]('ignored')
+  })
+
+  end()
+})
+
+test('does not call send when transmit.level is set to silent', ({ end, fail, is }) => {
+  let c = 0
+  const logger = pino({
+    level: 'trace',
+    browser: {
+      write () {
+        c++
+      },
+      transmit: {
+        level: 'silent',
+        send () {
+          fail('no data should be logged by the transmit method')
+        }
+      }
+    }
+  })
+
+  const levels = Object.keys(pino.levels.values)
+  levels.forEach((level) => {
+    logger[level]('message')
+  })
+
+  is(c, levels.length, 'write must be called exactly once per level')
+  end()
+})


### PR DESCRIPTION
The silent log level currently does not work in the browser when the `browser.transmit` option is used.

- When `options.level` is set to `"silent"` and `options.browser.transmit` is used, everything gets logged as if `options.level` was the most verbose.
- When `options.level` is non-silent (e.g. `"info"`) and `options.browser.transmit.level` is `"silent"`, the `options.browser.transmit.send` method is called for every log event above `options.level`, which should not occur.

This PR uses the `levelToValue` method which correctly handles the silent level to determine the `transmitValue` and `methodValue`, so the silent level works even when `options.browser.transmit` is used. 