### PR TITLE
fix: Lowercase the custom levels only when useOnlyCustomLevels is true

### DIFF
--- a/pino.js
+++ b/pino.js
@@ -90,12 +90,11 @@ function pino (...args) {
   const { opts, stream } = normalize(instance, caller(), ...args)
 
   if (
-    opts.level && 
-    typeof opts.level === 'string' && 
-    DEFAULT_LEVELS[opts.level.toLowerCase()] !== undefined && 
+    opts.level &&
+    typeof opts.level === 'string' &&
+    DEFAULT_LEVELS[opts.level.toLowerCase()] !== undefined &&
     !opts.useOnlyCustomLevels
-  ) 
-    opts.level = opts.level.toLowerCase()
+  ) { opts.level = opts.level.toLowerCase() }
 
   const {
     redact,

--- a/pino.js
+++ b/pino.js
@@ -89,7 +89,13 @@ function pino (...args) {
   const instance = {}
   const { opts, stream } = normalize(instance, caller(), ...args)
 
-  if (opts.level && typeof opts.level === 'string' && DEFAULT_LEVELS[opts.level.toLowerCase()] !== undefined) opts.level = opts.level.toLowerCase()
+  if (
+    opts.level && 
+    typeof opts.level === 'string' && 
+    DEFAULT_LEVELS[opts.level.toLowerCase()] !== undefined && 
+    !opts.useOnlyCustomLevels
+  ) 
+    opts.level = opts.level.toLowerCase()
 
   const {
     redact,


### PR DESCRIPTION
Typescript enums usually have uppercased keys. [This](https://github.com/pinojs/pino/pull/2034/files) change completely breaks implementation when the `useOnlyCustomLevels` option is set to `true` and the enum of custom levels includes `DEBUG` key.