### PR TITLE
docs->add appsignal pino transport

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -218,7 +218,7 @@ In case you want to both use a custom transport, and output the log entries with
       },
       {
         target: 'my-custom-transport',
-        options: { someParameter: true } 
+        options: { someParameter: true }
       }
     ]
 
@@ -423,6 +423,7 @@ PRs to this document are welcome for any new transports!
 
 ### Pino v7+ Compatible
 
++ [@appsignal/nodejs pino](#@appsignal/nodejs-pino)
 + [@axiomhq/pino](#@axiomhq/pino)
 + [@logtail/pino](#@logtail/pino)
 + [@macfja/pino-fingers-crossed](#macfja-pino-fingers-crossed)
@@ -467,6 +468,22 @@ PRs to this document are welcome for any new transports!
 + [pino-syslog](#pino-syslog)
 + [pino-websocket](#pino-websocket)
 
+<a id="@appsignal/nodejs-pino"></a>
+### @appsignal/nodejs
+
+[@appsignal/nodejs](https://www.npmjs.com/package/@appsignal/nodejs) [`AppsignalPinoTransport`](https://github.com/appsignal/appsignal-nodejs/blob/0fffae87ebe269bb86b6adafba23388ecb802979/src/pino_transport.ts) is the official [AppSignal](https://appsignal.com/) transport for Pino.
+
+```javascript
+import pino from 'pino';
+import { Appsignal, AppsignalPinoTransport } from '@appsignal/nodejs';
+
+const logger = pino({
+  AppsignalPinoTransport({
+    client: Appsignal.client,
+    group: "optional-group-name",
+  })
+});
+```
 
 <a id="@axiomhq/pino"></a>
 ### @axiomhq/pino
@@ -575,9 +592,9 @@ const pino = require('pino')
 const transport = pino.transport({
   target: 'pino-axiom',
   options: {
-    orgId: 'YOUR-ORG-ID', 
-    token: 'YOUR-TOKEN', 
-    dataset: 'YOUR-DATASET', 
+    orgId: 'YOUR-ORG-ID',
+    token: 'YOUR-TOKEN',
+    dataset: 'YOUR-DATASET',
   },
 })
 pino(transport)
@@ -697,7 +714,7 @@ https://github.com/deviantony/docker-elk to setup an ELK stack.
 <a id="pino-discord-webhook"></a>
 ### pino-discord-webhook
 
-[pino-discord-webhook](https://github.com/fabulousgk/pino-discord-webhook) is a  Pino v7+ compatible transport to forward log events to a [Discord](http://discord.com) webhook from a dedicated worker. 
+[pino-discord-webhook](https://github.com/fabulousgk/pino-discord-webhook) is a  Pino v7+ compatible transport to forward log events to a [Discord](http://discord.com) webhook from a dedicated worker.
 
 ```js
 import pino from 'pino'
@@ -1117,7 +1134,7 @@ Example output for the "hello world" log:
 <a id="pino-telegram-webhook"></a>
 ### pino-telegram-webhook
 
-[pino-telegram-webhook](https://github.com/Jhon-Mosk/pino-telegram-webhook) is a Pino v7+ transport for sending messages to [Telegram](https://telegram.org/). 
+[pino-telegram-webhook](https://github.com/Jhon-Mosk/pino-telegram-webhook) is a Pino v7+ transport for sending messages to [Telegram](https://telegram.org/).
 
 ```js
 const pino = require('pino');


### PR DESCRIPTION
Hi there! 👋🏼 

We've created an [AppSignal pino transport](https://github.com/appsignal/appsignal-nodejs/blob/0fffae87ebe269bb86b6adafba23388ecb802979/src/pino_transport.ts) and recently released it as part of our [v3.5.1 integration](https://www.npmjs.com/package/@appsignal/nodejs/v/3.5.1).

This PR adds the transport to the v7+ compatible list.