### PR TITLE
update pino-datadog-transport repository

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -653,7 +653,7 @@ const transport = pino.transport({
 pino(transport)
 ```
 
-[pino-datadog-transport]: https://github.com/theogravity/pino-datadog-transport
+[pino-datadog-transport]: https://github.com/theogravity/datadog-transports
 [Datadog]: https://www.datadoghq.com/
 
 #### Logstash


### PR DESCRIPTION
The repository for `pino-datadog-transport` has moved from

from: https://github.com/theogravity/pino-datadog-transport
to: https://github.com/theogravity/datadog-transports

See original repository's README for verification: https://github.com/theogravity/pino-datadog-transport?tab=readme-ov-file#pino-datadog-transport