### PR TITLE
docs: add @openobserve/openobserve-pino transports

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -426,6 +426,7 @@ PRs to this document are welcome for any new transports!
 + [@axiomhq/pino](#@axiomhq/pino)
 + [@logtail/pino](#@logtail/pino)
 + [@macfja/pino-fingers-crossed](#macfja-pino-fingers-crossed)
++ [@openobserve/pino-openobserve](#pino-openobserve)
 + [pino-airbrake-transport](#pino-airbrake-transport)
 + [pino-axiom](#pino-axiom)
 + [pino-datadog-transport](#pino-datadog-transport)
@@ -525,6 +526,33 @@ logger.info('Will NOT appear')
 logger.info({ [enable]: false }, 'Will appear immedialty')
 logger.info('Will NOT appear')
 ```
+<a id="pino-openobserve"></a>
+### @openobserve/pino-openobserve
+
+[@openobserve/pino-openobserve](https://github.com/openobserve/pino-openobserve) is a Pino v7+ transport that can send the logs to [OpenObserve](https://openobserve.ai) Instance.
+
+```
+import pino from 'pino';
+import OpenobserveTransport from '@openobserve/pino-openobserve';
+
+const logger = pino({
+  level: 'info',
+  transport: {
+    target: OpenobserveTransport,
+    options: {
+      url: 'https://your-openobserve-server.com',
+      organization: 'your-organization',
+      streamName: 'your-stream',
+      auth: {
+        username: 'your-username',
+        password: 'your-password',
+      },
+    },
+  },
+});
+```
+
+For full documentation check the [README](https://github.com/openobserve/pino-openobserve)
 
 <a id="pino-airbrake-transport"></a>
 ### pino-airbrake-transport


### PR DESCRIPTION
Hello,

We have written [@openobserve/openobserve-pino](https://github.com/openobserve/pino-openobserve) v7+ transport for sending logs to [OpenObserve](https://openobserve.ai)

Feel free to review this and let us know if you have any questions.

Kirtan