### PR TITLE
docs: add missing parenthesis to transport code example

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -222,7 +222,7 @@ In case you want to both use a custom transport, and output the log entries with
       }
     ]
 
-    const logger = pino(pino.transport({ targets: transports })
+    const logger = pino(pino.transport({ targets: transports }))
 ```
 
 ### Creating a transport pipeline


### PR DESCRIPTION
Trying to run this code example would generate the error `SyntaxError: missing ) after argument list`