### PR TITLE
build(dependabot): reduce npm updates to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,5 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Same reasoning as https://github.com/fastify/fastify/pull/5939.