### PR TITLE
Include pino-roll in Pino transports list​

### DIFF
--- a/docs/transports.md
+++ b/docs/transports.md
@@ -437,12 +437,12 @@ PRs to this document are welcome for any new transports!
 + [pino-loki](#pino-loki)
 + [pino-opentelemetry-transport](#pino-opentelemetry-transport)
 + [pino-pretty](#pino-pretty)
++ [pino-roll](#pino-roll)
 + [pino-seq-transport](#pino-seq-transport)
 + [pino-sentry-transport](#pino-sentry-transport)
 + [pino-slack-webhook](#pino-slack-webhook)
 + [pino-telegram-webhook](#pino-telegram-webhook)
 + [pino-yc-transport](#pino-yc-transport)
-+ [pino-roll](#pino-roll)
 
 ### Legacy
 
@@ -978,6 +978,30 @@ node yourapp.js | pino-papertrail --host bar.papertrailapp.com --port 12345 --ap
 
 for full documentation of command line switches read [README](https://github.com/ovhemert/pino-papertrail#readme)
 
+<a id="pino-roll"></a>
+### pino-roll
+
+`pino-roll` is a Pino transport that automatically rolls your log files based on size or time frequency.
+
+```js
+import { join } from 'path';
+import pino from 'pino';
+
+const transport = pino.transport({
+  target: 'pino-roll',
+  options: { file: join('logs', 'log'), frequency: 'daily', mkdir: true }
+});
+
+const logger = pino(transport);
+```
+
+then you can use the logger as usual:
+
+```js
+logger.info('Hello from pino-roll!');
+```
+For full documentation check the [README](https://github.com/mcollina/pino-roll?tab=readme-ov-file#pino-roll).
+
 <a id="pino-pg"></a>
 ### pino-pg
 [pino-pg](https://www.npmjs.com/package/pino-pg) stores logs into PostgreSQL.
@@ -1182,30 +1206,6 @@ $ node app.js | pino-websocket -a my-websocket-server.example.com -p 3004
 ```
 
 For full documentation of command line switches read the [README](https://github.com/abeai/pino-websocket#readme).
-
-<a id="pino-roll"></a>
-### pino-roll
-
-`pino-roll` is a Pino transport that automatically rolls your log files based on size or time frequency.
-
-```js
-import { join } from 'path';
-import pino from 'pino';
-
-const transport = pino.transport({
-  target: 'pino-roll',
-  options: { file: join('logs', 'log'), frequency: 'daily', mkdir: true }
-});
-
-const logger = pino(transport);
-```
-
-then you can use the logger as usual:
-
-```js
-logger.info('Hello from pino-roll!');
-```
-For full documentation check the [README](https://github.com/mcollina/pino-roll?tab=readme-ov-file#pino-roll).
 
 <a id="pino-yc-transport"></a>
 ### pino-yc-transport

--- a/docs/transports.md
+++ b/docs/transports.md
@@ -442,6 +442,7 @@ PRs to this document are welcome for any new transports!
 + [pino-slack-webhook](#pino-slack-webhook)
 + [pino-telegram-webhook](#pino-telegram-webhook)
 + [pino-yc-transport](#pino-yc-transport)
++ [pino-roll](#pino-roll)
 
 ### Legacy
 
@@ -1181,6 +1182,30 @@ $ node app.js | pino-websocket -a my-websocket-server.example.com -p 3004
 ```
 
 For full documentation of command line switches read the [README](https://github.com/abeai/pino-websocket#readme).
+
+<a id="pino-roll"></a>
+### pino-roll
+
+`pino-roll` is a Pino transport that automatically rolls your log files based on size or time frequency.
+
+```js
+import { join } from 'path';
+import pino from 'pino';
+
+const transport = pino.transport({
+  target: 'pino-roll',
+  options: { file: join('logs', 'log'), frequency: 'daily', mkdir: true }
+});
+
+const logger = pino(transport);
+```
+
+then you can use the logger as usual:
+
+```js
+logger.info('Hello from pino-roll!');
+```
+For full documentation check the [README](https://github.com/mcollina/pino-roll?tab=readme-ov-file#pino-roll).
 
 <a id="pino-yc-transport"></a>
 ### pino-yc-transport


### PR DESCRIPTION
This PR adds documentation for the `pino-roll` transport in `docs/transports.md`, as requested in issue #2153 (see https://github.com/pinojs/pino/issues/2153#issuecomment-2833391961)
