### PR TITLE
test: move browser-early-console.test.js to the Node test runner

### DIFF
--- a/test/browser-early-console-freeze.test.js
+++ b/test/browser-early-console-freeze.test.js
@@ -1,9 +1,9 @@
 'use strict'
 Object.freeze(console)
-const test = require('tape')
+const test = require('node:test')
 const pino = require('../browser')
 
-test('silent level', ({ end, fail, pass }) => {
+test('silent level', (_, end) => {
   pino({
     level: 'silent',
     browser: { }


### PR DESCRIPTION
This PR moves `browser-early-console.test.js` to the Node test runner