### PR TITLE
test: move browser-is-level-enabled.test.js to the Node test runner

### DIFF
--- a/test/browser-is-level-enabled.test.js
+++ b/test/browser-is-level-enabled.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test, describe } = require('node:test')
 const pino = require('../browser')
 
 const customLevels = {
@@ -12,93 +12,89 @@ const customLevels = {
   fatal: 60
 }
 
-test('Default levels suite', ({ test, end }) => {
-  test('can check if current level enabled', async ({ equal }) => {
+describe('Default levels suite', () => {
+  test('can check if current level enabled', async (t) => {
     const log = pino({ level: 'debug' })
-    equal(true, log.isLevelEnabled('debug'))
+    t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  test('can check if current level enabled when as object', async ({ equal }) => {
+  test('can check if current level enabled when as object', async (t) => {
     const log = pino({ asObject: true, level: 'debug' })
-    equal(true, log.isLevelEnabled('debug'))
+    t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  test('can check if level enabled after level set', async ({ equal }) => {
+  test('can check if level enabled after level set', async (t) => {
     const log = pino()
-    equal(false, log.isLevelEnabled('debug'))
+    t.assert.strictEqual(false, log.isLevelEnabled('debug'))
     log.level = 'debug'
-    equal(true, log.isLevelEnabled('debug'))
+    t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  test('can check if higher level enabled', async ({ equal }) => {
+  test('can check if higher level enabled', async (t) => {
     const log = pino({ level: 'debug' })
-    equal(true, log.isLevelEnabled('error'))
+    t.assert.strictEqual(true, log.isLevelEnabled('error'))
   })
 
-  test('can check if lower level is disabled', async ({ equal }) => {
+  test('can check if lower level is disabled', async (t) => {
     const log = pino({ level: 'error' })
-    equal(false, log.isLevelEnabled('trace'))
+    t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  test('ASC: can check if child has current level enabled', async ({ equal }) => {
+  test('ASC: can check if child has current level enabled', async (t) => {
     const log = pino().child({}, { level: 'debug' })
-    equal(true, log.isLevelEnabled('debug'))
-    equal(true, log.isLevelEnabled('error'))
-    equal(false, log.isLevelEnabled('trace'))
+    t.assert.strictEqual(true, log.isLevelEnabled('debug'))
+    t.assert.strictEqual(true, log.isLevelEnabled('error'))
+    t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  test('can check if custom level is enabled', async ({ equal }) => {
+  test('can check if custom level is enabled', async (t) => {
     const log = pino({
       customLevels: { foo: 35 },
       level: 'debug'
     })
-    equal(true, log.isLevelEnabled('foo'))
-    equal(true, log.isLevelEnabled('error'))
-    equal(false, log.isLevelEnabled('trace'))
+    t.assert.strictEqual(true, log.isLevelEnabled('foo'))
+    t.assert.strictEqual(true, log.isLevelEnabled('error'))
+    t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
-
-  end()
 })
 
-test('Custom levels suite', ({ test, end }) => {
-  test('can check if current level enabled', async ({ equal }) => {
+describe('Custom levels suite', () => {
+  test('can check if current level enabled', async (t) => {
     const log = pino({ level: 'debug', customLevels })
-    equal(true, log.isLevelEnabled('debug'))
+    t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  test('can check if level enabled after level set', async ({ equal }) => {
+  test('can check if level enabled after level set', async (t) => {
     const log = pino({ customLevels })
-    equal(false, log.isLevelEnabled('debug'))
+    t.assert.strictEqual(false, log.isLevelEnabled('debug'))
     log.level = 'debug'
-    equal(true, log.isLevelEnabled('debug'))
+    t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  test('can check if higher level enabled', async ({ equal }) => {
+  test('can check if higher level enabled', async (t) => {
     const log = pino({ level: 'debug', customLevels })
-    equal(true, log.isLevelEnabled('error'))
+    t.assert.strictEqual(true, log.isLevelEnabled('error'))
   })
 
-  test('can check if lower level is disabled', async ({ equal }) => {
+  test('can check if lower level is disabled', async (t) => {
     const log = pino({ level: 'error', customLevels })
-    equal(false, log.isLevelEnabled('trace'))
+    t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  test('can check if child has current level enabled', async ({ equal }) => {
+  test('can check if child has current level enabled', async (t) => {
     const log = pino().child({ customLevels }, { level: 'debug' })
-    equal(true, log.isLevelEnabled('debug'))
-    equal(true, log.isLevelEnabled('error'))
-    equal(false, log.isLevelEnabled('trace'))
+    t.assert.strictEqual(true, log.isLevelEnabled('debug'))
+    t.assert.strictEqual(true, log.isLevelEnabled('error'))
+    t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  test('can check if custom level is enabled', async ({ equal }) => {
+  test('can check if custom level is enabled', async (t) => {
     const log = pino({
       customLevels: { foo: 35, ...customLevels },
       level: 'debug'
     })
-    equal(true, log.isLevelEnabled('foo'))
-    equal(true, log.isLevelEnabled('error'))
-    equal(false, log.isLevelEnabled('trace'))
+    t.assert.strictEqual(true, log.isLevelEnabled('foo'))
+    t.assert.strictEqual(true, log.isLevelEnabled('error'))
+    t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
-
-  end()
 })

--- a/test/browser-is-level-enabled.test.js
+++ b/test/browser-is-level-enabled.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, describe } = require('node:test')
+const { test } = require('node:test')
 const pino = require('../browser')
 
 const customLevels = {
@@ -12,42 +12,42 @@ const customLevels = {
   fatal: 60
 }
 
-describe('Default levels suite', () => {
-  test('can check if current level enabled', async (t) => {
+test('Default levels suite', async t => {
+  await t.test('can check if current level enabled', async (t) => {
     const log = pino({ level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  test('can check if current level enabled when as object', async (t) => {
+  await t.test('can check if current level enabled when as object', async (t) => {
     const log = pino({ asObject: true, level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  test('can check if level enabled after level set', async (t) => {
+  await t.test('can check if level enabled after level set', async (t) => {
     const log = pino()
     t.assert.strictEqual(false, log.isLevelEnabled('debug'))
     log.level = 'debug'
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  test('can check if higher level enabled', async (t) => {
+  await t.test('can check if higher level enabled', async (t) => {
     const log = pino({ level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
   })
 
-  test('can check if lower level is disabled', async (t) => {
+  await t.test('can check if lower level is disabled', async (t) => {
     const log = pino({ level: 'error' })
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  test('ASC: can check if child has current level enabled', async (t) => {
+  await t.test('ASC: can check if child has current level enabled', async (t) => {
     const log = pino().child({}, { level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  test('can check if custom level is enabled', async (t) => {
+  await t.test('can check if custom level is enabled', async (t) => {
     const log = pino({
       customLevels: { foo: 35 },
       level: 'debug'
@@ -58,37 +58,37 @@ describe('Default levels suite', () => {
   })
 })
 
-describe('Custom levels suite', () => {
-  test('can check if current level enabled', async (t) => {
+test('Custom levels suite', async t => {
+  await t.test('can check if current level enabled', async (t) => {
     const log = pino({ level: 'debug', customLevels })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  test('can check if level enabled after level set', async (t) => {
+  await t.test('can check if level enabled after level set', async (t) => {
     const log = pino({ customLevels })
     t.assert.strictEqual(false, log.isLevelEnabled('debug'))
     log.level = 'debug'
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  test('can check if higher level enabled', async (t) => {
+  await t.test('can check if higher level enabled', async (t) => {
     const log = pino({ level: 'debug', customLevels })
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
   })
 
-  test('can check if lower level is disabled', async (t) => {
+  await t.test('can check if lower level is disabled', async (t) => {
     const log = pino({ level: 'error', customLevels })
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  test('can check if child has current level enabled', async (t) => {
+  await t.test('can check if child has current level enabled', async (t) => {
     const log = pino().child({ customLevels }, { level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  test('can check if custom level is enabled', async (t) => {
+  await t.test('can check if custom level is enabled', async (t) => {
     const log = pino({
       customLevels: { foo: 35, ...customLevels },
       level: 'debug'


### PR DESCRIPTION
This PR moves `browser-is-level-enabled.test.js` to the Node test runner