### PR TITLE
test: browser.test.js to node test runner

### DIFF
--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -1,5 +1,5 @@
 'use strict'
-const test = require('tape')
+const test = require('node:test')
 const fresh = require('import-fresh')
 const pinoStdSerializers = require('pino-std-serializers')
 const pino = require('../browser')
@@ -11,68 +11,68 @@ levelTest('info')
 levelTest('debug')
 levelTest('trace')
 
-test('silent level', ({ end, fail, pass }) => {
+test('silent level', (t, end) => {
   const instance = pino({
     level: 'silent',
-    browser: { write: fail }
+    browser: { write: t.assert.fail }
   })
   instance.info('test')
   const child = instance.child({ test: 'test' })
   child.info('msg-test')
   // use setTimeout because setImmediate isn't supported in most browsers
   setTimeout(() => {
-    pass()
+    t.assert.ok('silent level is working')
     end()
   }, 0)
 })
 
-test('enabled false', ({ end, fail, pass }) => {
+test('enabled false', (t, end) => {
   const instance = pino({
     enabled: false,
-    browser: { write: fail }
+    browser: { write: t.assert.fail }
   })
   instance.info('test')
   const child = instance.child({ test: 'test' })
   child.info('msg-test')
   // use setTimeout because setImmediate isn't supported in most browsers
   setTimeout(() => {
-    pass()
+    t.assert.ok('enabled false is working')
     end()
   }, 0)
 })
 
-test('throw if creating child without bindings', ({ end, throws }) => {
+test('throw if creating child without bindings', (t, end) => {
   const instance = pino()
-  throws(() => instance.child())
+  t.assert.throws(() => instance.child())
   end()
 })
 
-test('stubs write, flush and ee methods on instance', ({ end, ok, is }) => {
+test('stubs write, flush and ee methods on instance', (t, end) => {
   const instance = pino()
 
-  ok(isFunc(instance.setMaxListeners))
-  ok(isFunc(instance.getMaxListeners))
-  ok(isFunc(instance.emit))
-  ok(isFunc(instance.addListener))
-  ok(isFunc(instance.on))
-  ok(isFunc(instance.prependListener))
-  ok(isFunc(instance.once))
-  ok(isFunc(instance.prependOnceListener))
-  ok(isFunc(instance.removeListener))
-  ok(isFunc(instance.removeAllListeners))
-  ok(isFunc(instance.listeners))
-  ok(isFunc(instance.listenerCount))
-  ok(isFunc(instance.eventNames))
-  ok(isFunc(instance.write))
-  ok(isFunc(instance.flush))
+  t.assert.ok(isFunc(instance.setMaxListeners))
+  t.assert.ok(isFunc(instance.getMaxListeners))
+  t.assert.ok(isFunc(instance.emit))
+  t.assert.ok(isFunc(instance.addListener))
+  t.assert.ok(isFunc(instance.on))
+  t.assert.ok(isFunc(instance.prependListener))
+  t.assert.ok(isFunc(instance.once))
+  t.assert.ok(isFunc(instance.prependOnceListener))
+  t.assert.ok(isFunc(instance.removeListener))
+  t.assert.ok(isFunc(instance.removeAllListeners))
+  t.assert.ok(isFunc(instance.listeners))
+  t.assert.ok(isFunc(instance.listenerCount))
+  t.assert.ok(isFunc(instance.eventNames))
+  t.assert.ok(isFunc(instance.write))
+  t.assert.ok(isFunc(instance.flush))
 
-  is(instance.on(), undefined)
+  t.assert.strictEqual(instance.on(), undefined)
 
   end()
 })
 
-test('exposes levels object', ({ end, same }) => {
-  same(pino.levels, {
+test('exposes levels object', (t, end) => {
+  t.assert.deepStrictEqual(pino.levels, {
     values: {
       fatal: 60,
       error: 50,
@@ -94,27 +94,27 @@ test('exposes levels object', ({ end, same }) => {
   end()
 })
 
-test('exposes faux stdSerializers', ({ end, ok, same }) => {
-  ok(pino.stdSerializers)
+test('exposes faux stdSerializers', (t, end) => {
+  t.assert.ok(pino.stdSerializers)
   // make sure faux stdSerializers match pino-std-serializers
   for (const serializer in pinoStdSerializers) {
-    ok(pino.stdSerializers[serializer], `pino.stdSerializers.${serializer}`)
+    t.assert.ok(pino.stdSerializers[serializer], `pino.stdSerializers.${serializer}`)
   }
   // confirm faux methods return empty objects
-  same(pino.stdSerializers.req(), {})
-  same(pino.stdSerializers.mapHttpRequest(), {})
-  same(pino.stdSerializers.mapHttpResponse(), {})
-  same(pino.stdSerializers.res(), {})
+  t.assert.deepStrictEqual(pino.stdSerializers.req(), {})
+  t.assert.deepStrictEqual(pino.stdSerializers.mapHttpRequest(), {})
+  t.assert.deepStrictEqual(pino.stdSerializers.mapHttpResponse(), {})
+  t.assert.deepStrictEqual(pino.stdSerializers.res(), {})
   // confirm wrapping function is a passthrough
   const noChange = { foo: 'bar', fuz: 42 }
-  same(pino.stdSerializers.wrapRequestSerializer(noChange), noChange)
-  same(pino.stdSerializers.wrapResponseSerializer(noChange), noChange)
+  t.assert.deepStrictEqual(pino.stdSerializers.wrapRequestSerializer(noChange), noChange)
+  t.assert.deepStrictEqual(pino.stdSerializers.wrapResponseSerializer(noChange), noChange)
   end()
 })
 
-test('exposes err stdSerializer', ({ end, ok }) => {
-  ok(pino.stdSerializers.err)
-  ok(pino.stdSerializers.err(Error()))
+test('exposes err stdSerializer', (t, end) => {
+  t.assert.ok(pino.stdSerializers.err)
+  t.assert.ok(pino.stdSerializers.err(Error()))
   end()
 })
 
@@ -132,28 +132,28 @@ absentConsoleMethodTest('trace', 'log')
 
 // do not run this with airtap
 if (process.title !== 'browser') {
-  test('in absence of console, log methods become noops', ({ end, ok }) => {
+  test('in absence of console, log methods become noops', (t, end) => {
     const console = global.console
     delete global.console
     const instance = fresh('../browser')()
     global.console = console
-    ok(fnName(instance.log).match(/noop/))
-    ok(fnName(instance.fatal).match(/noop/))
-    ok(fnName(instance.error).match(/noop/))
-    ok(fnName(instance.warn).match(/noop/))
-    ok(fnName(instance.info).match(/noop/))
-    ok(fnName(instance.debug).match(/noop/))
-    ok(fnName(instance.trace).match(/noop/))
+    t.assert.ok(fnName(instance.log).match(/noop/))
+    t.assert.ok(fnName(instance.fatal).match(/noop/))
+    t.assert.ok(fnName(instance.error).match(/noop/))
+    t.assert.ok(fnName(instance.warn).match(/noop/))
+    t.assert.ok(fnName(instance.info).match(/noop/))
+    t.assert.ok(fnName(instance.debug).match(/noop/))
+    t.assert.ok(fnName(instance.trace).match(/noop/))
     end()
   })
 }
 
-test('opts.browser.asObject logs pino-like object to console', ({ end, ok, is }) => {
+test('opts.browser.asObject logs pino-like object to console', (t, end) => {
   const info = console.info
   console.info = function (o) {
-    is(o.level, 30)
-    is(o.msg, 'test')
-    ok(o.time)
+    t.assert.strictEqual(o.level, 30)
+    t.assert.strictEqual(o.msg, 'test')
+    t.assert.ok(o.time)
     console.info = info
   }
   const instance = require('../browser')({
@@ -166,16 +166,16 @@ test('opts.browser.asObject logs pino-like object to console', ({ end, ok, is })
   end()
 })
 
-test('opts.browser.asObject uses opts.messageKey in logs', ({ end, ok, is }) => {
+test('opts.browser.asObject uses opts.messageKey in logs', (t, end) => {
   const messageKey = 'message'
   const instance = require('../browser')({
     messageKey,
     browser: {
       asObject: true,
       write: function (o) {
-        is(o.level, 30)
-        is(o[messageKey], 'test')
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o[messageKey], 'test')
+        t.assert.ok(o.time)
       }
     }
   })
@@ -184,17 +184,17 @@ test('opts.browser.asObject uses opts.messageKey in logs', ({ end, ok, is }) => 
   end()
 })
 
-test('opts.browser.asObjectBindingsOnly passes the bindings but keep the message unformatted', ({ end, ok, is, deepEqual }) => {
+test('opts.browser.asObjectBindingsOnly passes the bindings but keep the message unformatted', (t, end) => {
   const messageKey = 'message'
   const instance = require('../browser')({
     messageKey,
     browser: {
       asObjectBindingsOnly: true,
       write: function (o, msg, ...args) {
-        is(o.level, 30)
-        ok(o.time)
-        is(msg, 'test %s')
-        deepEqual(args, ['foo'])
+        t.assert.strictEqual(o.level, 30)
+        t.assert.ok(o.time)
+        t.assert.strictEqual(msg, 'test %s')
+        t.assert.deepStrictEqual(args, ['foo'])
       }
     }
   })
@@ -203,13 +203,13 @@ test('opts.browser.asObjectBindingsOnly passes the bindings but keep the message
   end()
 })
 
-test('opts.browser.formatters (level) logs pino-like object to console', ({ end, ok, is }) => {
+test('opts.browser.formatters (level) logs pino-like object to console', (t, end) => {
   const info = console.info
   console.info = function (o) {
-    is(o.level, 30)
-    is(o.label, 'info')
-    is(o.msg, 'test')
-    ok(o.time)
+    t.assert.strictEqual(o.level, 30)
+    t.assert.strictEqual(o.label, 'info')
+    t.assert.strictEqual(o.msg, 'test')
+    t.assert.ok(o.time)
     console.info = info
   }
   const instance = require('../browser')({
@@ -226,14 +226,14 @@ test('opts.browser.formatters (level) logs pino-like object to console', ({ end,
   end()
 })
 
-test('opts.browser.formatters (log) logs pino-like object to console', ({ end, ok, is }) => {
+test('opts.browser.formatters (log) logs pino-like object to console', (t, end) => {
   const info = console.info
   console.info = function (o) {
-    is(o.level, 30)
-    is(o.msg, 'test')
-    is(o.hello, 'world')
-    is(o.newField, 'test')
-    ok(o.time, `Logged at ${o.time}`)
+    t.assert.strictEqual(o.level, 30)
+    t.assert.strictEqual(o.msg, 'test')
+    t.assert.strictEqual(o.hello, 'world')
+    t.assert.strictEqual(o.newField, 'test')
+    t.assert.ok(o.time, `Logged at ${o.time}`)
     console.info = info
   }
   const instance = require('../browser')({
@@ -250,7 +250,7 @@ test('opts.browser.formatters (log) logs pino-like object to console', ({ end, o
   end()
 })
 
-test('opts.browser.serialize and opts.browser.transmit only serializes log data once', ({ end, ok, is }) => {
+test('opts.browser.serialize and opts.browser.transmit only serializes log data once', (t, end) => {
   const instance = require('../browser')({
     serializers: {
       extras (data) {
@@ -262,7 +262,7 @@ test('opts.browser.serialize and opts.browser.transmit only serializes log data 
       transmit: {
         level: 'info',
         send (level, o) {
-          is(o.messages[0].extras.serializedExtras, 'world')
+          t.assert.strictEqual(o.messages[0].extras.serializedExtras, 'world')
         }
       }
     }
@@ -272,7 +272,7 @@ test('opts.browser.serialize and opts.browser.transmit only serializes log data 
   end()
 })
 
-test('opts.browser.serialize and opts.asObject only serializes log data once', ({ end, ok, is }) => {
+test('opts.browser.serialize and opts.asObject only serializes log data once', (t, end) => {
   const instance = require('../browser')({
     serializers: {
       extras (data) {
@@ -283,7 +283,7 @@ test('opts.browser.serialize and opts.asObject only serializes log data once', (
       serialize: ['extras'],
       asObject: true,
       write: function (o) {
-        is(o.extras.serializedExtras, 'world')
+        t.assert.strictEqual(o.extras.serializedExtras, 'world')
       }
     }
   })
@@ -292,7 +292,7 @@ test('opts.browser.serialize and opts.asObject only serializes log data once', (
   end()
 })
 
-test('opts.browser.serialize, opts.asObject and opts.browser.transmit only serializes log data once', ({ end, ok, is }) => {
+test('opts.browser.serialize, opts.asObject and opts.browser.transmit only serializes log data once', (t, end) => {
   const instance = require('../browser')({
     serializers: {
       extras (data) {
@@ -304,7 +304,7 @@ test('opts.browser.serialize, opts.asObject and opts.browser.transmit only seria
       asObject: true,
       transmit: {
         send (level, o) {
-          is(o.messages[0].extras.serializedExtras, 'world')
+          t.assert.strictEqual(o.messages[0].extras.serializedExtras, 'world')
         }
       }
     }
@@ -314,13 +314,13 @@ test('opts.browser.serialize, opts.asObject and opts.browser.transmit only seria
   end()
 })
 
-test('opts.browser.write func log single string', ({ end, ok, is }) => {
+test('opts.browser.write func log single string', (t, end) => {
   const instance = pino({
     browser: {
       write: function (o) {
-        is(o.level, 30)
-        is(o.msg, 'test')
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o.msg, 'test')
+        t.assert.ok(o.time)
       }
     }
   })
@@ -329,13 +329,13 @@ test('opts.browser.write func log single string', ({ end, ok, is }) => {
   end()
 })
 
-test('opts.browser.write func string joining', ({ end, ok, is }) => {
+test('opts.browser.write func string joining', (t, end) => {
   const instance = pino({
     browser: {
       write: function (o) {
-        is(o.level, 30)
-        is(o.msg, 'test test2 test3')
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o.msg, 'test test2 test3')
+        t.assert.ok(o.time)
       }
     }
   })
@@ -344,14 +344,14 @@ test('opts.browser.write func string joining', ({ end, ok, is }) => {
   end()
 })
 
-test('opts.browser.write func string joining when asObject is true', ({ end, ok, is }) => {
+test('opts.browser.write func string joining when asObject is true', (t, end) => {
   const instance = pino({
     browser: {
       asObject: true,
       write: function (o) {
-        is(o.level, 30)
-        is(o.msg, 'test test2 test3')
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o.msg, 'test test2 test3')
+        t.assert.ok(o.time)
       }
     }
   })
@@ -360,13 +360,13 @@ test('opts.browser.write func string joining when asObject is true', ({ end, ok,
   end()
 })
 
-test('opts.browser.write func string object joining', ({ end, ok, is }) => {
+test('opts.browser.write func string object joining', (t, end) => {
   const instance = pino({
     browser: {
       write: function (o) {
-        is(o.level, 30)
-        is(o.msg, 'test {"test":"test2"} {"test":"test3"}')
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o.msg, 'test {"test":"test2"} {"test":"test3"}')
+        t.assert.ok(o.time)
       }
     }
   })
@@ -375,14 +375,14 @@ test('opts.browser.write func string object joining', ({ end, ok, is }) => {
   end()
 })
 
-test('opts.browser.write func string object joining when asObject is true', ({ end, ok, is }) => {
+test('opts.browser.write func string object joining when asObject is true', (t, end) => {
   const instance = pino({
     browser: {
       asObject: true,
       write: function (o) {
-        is(o.level, 30)
-        is(o.msg, 'test {"test":"test2"} {"test":"test3"}')
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o.msg, 'test {"test":"test2"} {"test":"test3"}')
+        t.assert.ok(o.time)
       }
     }
   })
@@ -391,13 +391,13 @@ test('opts.browser.write func string object joining when asObject is true', ({ e
   end()
 })
 
-test('opts.browser.write func string interpolation', ({ end, ok, is }) => {
+test('opts.browser.write func string interpolation', (t, end) => {
   const instance = pino({
     browser: {
       write: function (o) {
-        is(o.level, 30)
-        is(o.msg, 'test2 test ({"test":"test3"})')
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o.msg, 'test2 test ({"test":"test3"})')
+        t.assert.ok(o.time)
       }
     }
   })
@@ -406,13 +406,13 @@ test('opts.browser.write func string interpolation', ({ end, ok, is }) => {
   end()
 })
 
-test('opts.browser.write func number', ({ end, ok, is }) => {
+test('opts.browser.write func number', (t, end) => {
   const instance = pino({
     browser: {
       write: function (o) {
-        is(o.level, 30)
-        is(o.msg, 1)
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o.msg, 1)
+        t.assert.ok(o.time)
       }
     }
   })
@@ -421,13 +421,13 @@ test('opts.browser.write func number', ({ end, ok, is }) => {
   end()
 })
 
-test('opts.browser.write func log single object', ({ end, ok, is }) => {
+test('opts.browser.write func log single object', (t, end) => {
   const instance = pino({
     browser: {
       write: function (o) {
-        is(o.level, 30)
-        is(o.test, 'test')
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o.test, 'test')
+        t.assert.ok(o.time)
       }
     }
   })
@@ -436,14 +436,14 @@ test('opts.browser.write func log single object', ({ end, ok, is }) => {
   end()
 })
 
-test('opts.browser.write obj writes to methods corresponding to level', ({ end, ok, is }) => {
+test('opts.browser.write obj writes to methods corresponding to level', (t, end) => {
   const instance = pino({
     browser: {
       write: {
         error: function (o) {
-          is(o.level, 50)
-          is(o.test, 'test')
-          ok(o.time)
+          t.assert.strictEqual(o.level, 50)
+          t.assert.strictEqual(o.test, 'test')
+          t.assert.ok(o.time)
         }
       }
     }
@@ -453,14 +453,14 @@ test('opts.browser.write obj writes to methods corresponding to level', ({ end, 
   end()
 })
 
-test('opts.browser.asObject/write supports child loggers', ({ end, ok, is }) => {
+test('opts.browser.asObject/write supports child loggers', (t, end) => {
   const instance = pino({
     browser: {
       write (o) {
-        is(o.level, 30)
-        is(o.test, 'test')
-        is(o.msg, 'msg-test')
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o.test, 'test')
+        t.assert.strictEqual(o.msg, 'msg-test')
+        t.assert.ok(o.time)
       }
     }
   })
@@ -470,15 +470,15 @@ test('opts.browser.asObject/write supports child loggers', ({ end, ok, is }) => 
   end()
 })
 
-test('opts.browser.asObject/write supports child child loggers', ({ end, ok, is }) => {
+test('opts.browser.asObject/write supports child child loggers', (t, end) => {
   const instance = pino({
     browser: {
       write (o) {
-        is(o.level, 30)
-        is(o.test, 'test')
-        is(o.foo, 'bar')
-        is(o.msg, 'msg-test')
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o.test, 'test')
+        t.assert.strictEqual(o.foo, 'bar')
+        t.assert.strictEqual(o.msg, 'msg-test')
+        t.assert.ok(o.time)
       }
     }
   })
@@ -488,16 +488,16 @@ test('opts.browser.asObject/write supports child child loggers', ({ end, ok, is 
   end()
 })
 
-test('opts.browser.asObject/write supports child child child loggers', ({ end, ok, is }) => {
+test('opts.browser.asObject/write supports child child child loggers', (t, end) => {
   const instance = pino({
     browser: {
       write (o) {
-        is(o.level, 30)
-        is(o.test, 'test')
-        is(o.foo, 'bar')
-        is(o.baz, 'bop')
-        is(o.msg, 'msg-test')
-        ok(o.time)
+        t.assert.strictEqual(o.level, 30)
+        t.assert.strictEqual(o.test, 'test')
+        t.assert.strictEqual(o.foo, 'bar')
+        t.assert.strictEqual(o.baz, 'bop')
+        t.assert.strictEqual(o.msg, 'msg-test')
+        t.assert.ok(o.time)
       }
     }
   })
@@ -507,33 +507,33 @@ test('opts.browser.asObject/write supports child child child loggers', ({ end, o
   end()
 })
 
-test('opts.browser.asObject defensively mitigates naughty numbers', ({ end, pass }) => {
+test('opts.browser.asObject defensively mitigates naughty numbers', (t, end) => {
   const instance = pino({
     browser: { asObject: true, write: () => {} }
   })
   const child = instance.child({ test: 'test' })
   child._childLevel = -10
   child.info('test')
-  pass() // if we reached here, there was no infinite loop, so, .. pass.
+  t.assert.ok('no infinite loop') // if we reached here, there was no infinite loop, so, .. pass.
 
   end()
 })
 
-test('opts.browser.write obj falls back to console where a method is not supplied', ({ end, ok, is }) => {
+test('opts.browser.write obj falls back to console where a method is not supplied', (t, end) => {
   const info = console.info
   console.info = (o) => {
-    is(o.level, 30)
-    is(o.msg, 'test')
-    ok(o.time)
+    t.assert.strictEqual(o.level, 30)
+    t.assert.strictEqual(o.msg, 'test')
+    t.assert.ok(o.time)
     console.info = info
   }
   const instance = require('../browser')({
     browser: {
       write: {
         error (o) {
-          is(o.level, 50)
-          is(o.test, 'test')
-          ok(o.time)
+          t.assert.strictEqual(o.level, 50)
+          t.assert.strictEqual(o.test, 'test')
+          t.assert.ok(o.time)
         }
       }
     }
@@ -545,58 +545,58 @@ test('opts.browser.write obj falls back to console where a method is not supplie
 })
 
 function levelTest (name) {
-  test(name + ' logs', ({ end, is }) => {
+  test(name + ' logs', (t, end) => {
     const msg = 'hello world'
     sink(name, (args) => {
-      is(args[0], msg)
+      t.assert.strictEqual(args[0], msg)
       end()
     })
     pino({ level: name })[name](msg)
   })
 
-  test('passing objects at level ' + name, ({ end, is }) => {
+  test('passing objects at level ' + name, (t, end) => {
     const msg = { hello: 'world' }
     sink(name, (args) => {
-      is(args[0], msg)
+      t.assert.strictEqual(args[0], msg)
       end()
     })
     pino({ level: name })[name](msg)
   })
 
-  test('passing an object and a string at level ' + name, ({ end, is }) => {
+  test('passing an object and a string at level ' + name, (t, end) => {
     const a = { hello: 'world' }
     const b = 'a string'
     sink(name, (args) => {
-      is(args[0], a)
-      is(args[1], b)
+      t.assert.strictEqual(args[0], a)
+      t.assert.strictEqual(args[1], b)
       end()
     })
     pino({ level: name })[name](a, b)
   })
 
-  test('formatting logs as ' + name, ({ end, is }) => {
+  test('formatting logs as ' + name, (t, end) => {
     sink(name, (args) => {
-      is(args[0], 'hello %d')
-      is(args[1], 42)
+      t.assert.strictEqual(args[0], 'hello %d')
+      t.assert.strictEqual(args[1], 42)
       end()
     })
     pino({ level: name })[name]('hello %d', 42)
   })
 
-  test('passing error at level ' + name, ({ end, is }) => {
+  test('passing error at level ' + name, (t, end) => {
     const err = new Error('myerror')
     sink(name, (args) => {
-      is(args[0], err)
+      t.assert.strictEqual(args[0], err)
       end()
     })
     pino({ level: name })[name](err)
   })
 
-  test('passing error with a serializer at level ' + name, ({ end, is }) => {
+  test('passing error with a serializer at level ' + name, (t, end) => {
     // in browser - should have no effect (should not crash)
     const err = new Error('myerror')
     sink(name, (args) => {
-      is(args[0].err, err)
+      t.assert.strictEqual(args[0].err, err)
       end()
     })
     const instance = pino({
@@ -608,12 +608,12 @@ function levelTest (name) {
     instance[name]({ err })
   })
 
-  test('child logger for level ' + name, ({ end, is }) => {
+  test('child logger for level ' + name, (t, end) => {
     const msg = 'hello world'
     const parent = { hello: 'world' }
     sink(name, (args) => {
-      is(args[0], parent)
-      is(args[1], msg)
+      t.assert.strictEqual(args[0], parent)
+      t.assert.strictEqual(args[1], msg)
       end()
     })
     const instance = pino({ level: name })
@@ -621,14 +621,14 @@ function levelTest (name) {
     child[name](msg)
   })
 
-  test('child-child logger for level ' + name, ({ end, is }) => {
+  test('child-child logger for level ' + name, (t, end) => {
     const msg = 'hello world'
     const grandParent = { hello: 'world' }
     const parent = { hello: 'you' }
     sink(name, (args) => {
-      is(args[0], grandParent)
-      is(args[1], parent)
-      is(args[2], msg)
+      t.assert.strictEqual(args[0], grandParent)
+      t.assert.strictEqual(args[1], parent)
+      t.assert.strictEqual(args[2], msg)
       end()
     })
     const instance = pino({ level: name })
@@ -639,9 +639,9 @@ function levelTest (name) {
 
 function consoleMethodTest (level, method) {
   if (!method) method = level
-  test('pino().' + level + ' uses console.' + method, ({ end, is }) => {
+  test('pino().' + level + ' uses console.' + method, (t, end) => {
     sink(method, (args) => {
-      is(args[0], 'test')
+      t.assert.strictEqual(args[0], 'test')
       end()
     })
     const instance = require('../browser')({ level })
@@ -650,11 +650,11 @@ function consoleMethodTest (level, method) {
 }
 
 function absentConsoleMethodTest (method, fallback) {
-  test('in absence of console.' + method + ', console.' + fallback + ' is used', ({ end, is }) => {
+  test('in absence of console.' + method + ', console.' + fallback + ' is used', (t, end) => {
     const fn = console[method]
     console[method] = undefined
     sink(fallback, function (args) {
-      is(args[0], 'test')
+      t.assert.strictEqual(args[0], 'test')
       end()
       console[method] = fn
     })


### PR DESCRIPTION
This PR moves `browser.test.js` to node test runner