### PR TITLE
test: crlf.test.js to node test runner

### DIFF
--- a/test/crlf.test.js
+++ b/test/crlf.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const writer = require('flush-write-stream')
 const pino = require('../')
 
@@ -13,20 +13,20 @@ function capture () {
   return ws
 }
 
-test('pino uses LF by default', async ({ ok }) => {
+test('pino uses LF by default', async (t) => {
   const stream = capture()
   const logger = pino(stream)
   logger.info('foo')
   logger.error('bar')
-  ok(/foo[^\r\n]+\n[^\r\n]+bar[^\r\n]+\n/.test(stream.data))
+  t.assert.ok(/foo[^\r\n]+\n[^\r\n]+bar[^\r\n]+\n/.test(stream.data))
 })
 
-test('pino can log CRLF', async ({ ok }) => {
+test('pino can log CRLF', async (t) => {
   const stream = capture()
   const logger = pino({
     crlf: true
   }, stream)
   logger.info('foo')
   logger.error('bar')
-  ok(/foo[^\n]+\r\n[^\n]+bar[^\n]+\r\n/.test(stream.data))
+  t.assert.ok(/foo[^\n]+\r\n[^\n]+bar[^\n]+\r\n/.test(stream.data))
 })


### PR DESCRIPTION
This PR moves `crlf.test.js` to node test runner