### PR TITLE
test: custom-levels.test.js to node test runner

### DIFF
--- a/test/custom-levels.test.js
+++ b/test/custom-levels.test.js
@@ -2,7 +2,7 @@
 
 /* eslint no-prototype-builtins: 0 */
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { sink, once } = require('./helper')
 const pino = require('../')
 
@@ -10,7 +10,7 @@ const pino = require('../')
 process.removeAllListeners('warning')
 process.on('warning', () => {})
 
-test('adds additional levels', async ({ equal }) => {
+test('adds additional levels', async (t) => {
   const stream = sink()
   const logger = pino({
     customLevels: {
@@ -21,10 +21,10 @@ test('adds additional levels', async ({ equal }) => {
 
   logger.foo('test')
   const { level } = await once(stream, 'data')
-  equal(level, 35)
+  t.assert.strictEqual(level, 35)
 })
 
-test('custom levels does not override default levels', async ({ equal }) => {
+test('custom levels does not override default levels', async (t) => {
   const stream = sink()
   const logger = pino({
     customLevels: {
@@ -34,10 +34,10 @@ test('custom levels does not override default levels', async ({ equal }) => {
 
   logger.info('test')
   const { level } = await once(stream, 'data')
-  equal(level, 30)
+  t.assert.strictEqual(level, 30)
 })
 
-test('default levels can be redefined using custom levels', async ({ equal }) => {
+test('default levels can be redefined using custom levels', async (t) => {
   const stream = sink()
   const logger = pino({
     customLevels: {
@@ -47,14 +47,14 @@ test('default levels can be redefined using custom levels', async ({ equal }) =>
     useOnlyCustomLevels: true
   }, stream)
 
-  equal(logger.hasOwnProperty('info'), true)
+  t.assert.strictEqual(logger.hasOwnProperty('info'), true)
 
   logger.info('test')
   const { level } = await once(stream, 'data')
-  equal(level, 35)
+  t.assert.strictEqual(level, 35)
 })
 
-test('custom levels overrides default level label if use useOnlyCustomLevels', async ({ equal }) => {
+test('custom levels overrides default level label if use useOnlyCustomLevels', async (t) => {
   const stream = sink()
   const logger = pino({
     customLevels: {
@@ -64,10 +64,10 @@ test('custom levels overrides default level label if use useOnlyCustomLevels', a
     level: 'foo'
   }, stream)
 
-  equal(logger.hasOwnProperty('info'), false)
+  t.assert.strictEqual(logger.hasOwnProperty('info'), false)
 })
 
-test('custom levels overrides default level value if use useOnlyCustomLevels', async ({ equal }) => {
+test('custom levels overrides default level value if use useOnlyCustomLevels', async (t) => {
   const stream = sink()
   const logger = pino({
     customLevels: {
@@ -77,10 +77,10 @@ test('custom levels overrides default level value if use useOnlyCustomLevels', a
     level: 35
   }, stream)
 
-  equal(logger.hasOwnProperty('info'), false)
+  t.assert.strictEqual(logger.hasOwnProperty('info'), false)
 })
 
-test('custom levels are inherited by children', async ({ equal }) => {
+test('custom levels are inherited by children', async (t) => {
   const stream = sink()
   const logger = pino({
     customLevels: {
@@ -90,12 +90,12 @@ test('custom levels are inherited by children', async ({ equal }) => {
 
   logger.child({ childMsg: 'ok' }).foo('test')
   const { msg, childMsg, level } = await once(stream, 'data')
-  equal(level, 35)
-  equal(childMsg, 'ok')
-  equal(msg, 'test')
+  t.assert.strictEqual(level, 35)
+  t.assert.strictEqual(childMsg, 'ok')
+  t.assert.strictEqual(msg, 'test')
 })
 
-test('custom levels can be specified on child bindings', async ({ equal }) => {
+test('custom levels can be specified on child bindings', async (t) => {
   const stream = sink()
   const logger = pino(stream).child({
     childMsg: 'ok'
@@ -107,12 +107,12 @@ test('custom levels can be specified on child bindings', async ({ equal }) => {
 
   logger.foo('test')
   const { msg, childMsg, level } = await once(stream, 'data')
-  equal(level, 35)
-  equal(childMsg, 'ok')
-  equal(msg, 'test')
+  t.assert.strictEqual(level, 35)
+  t.assert.strictEqual(childMsg, 'ok')
+  t.assert.strictEqual(msg, 'test')
 })
 
-test('customLevels property child bindings does not get logged', async ({ equal }) => {
+test('customLevels property child bindings does not get logged', async (t) => {
   const stream = sink()
   const logger = pino(stream).child({
     childMsg: 'ok'
@@ -124,12 +124,12 @@ test('customLevels property child bindings does not get logged', async ({ equal 
 
   logger.foo('test')
   const { customLevels } = await once(stream, 'data')
-  equal(customLevels, undefined)
+  t.assert.strictEqual(customLevels, undefined)
 })
 
-test('throws when specifying pre-existing parent labels via child bindings', async ({ throws }) => {
+test('throws when specifying pre-existing parent labels via child bindings', async (t) => {
   const stream = sink()
-  throws(() => pino({
+  t.assert.throws(() => pino({
     customLevels: {
       foo: 35
     }
@@ -137,12 +137,14 @@ test('throws when specifying pre-existing parent labels via child bindings', asy
     customLevels: {
       foo: 45
     }
-  }), 'levels cannot be overridden')
+  }), {
+    message: 'levels cannot be overridden'
+  })
 })
 
-test('throws when specifying pre-existing parent values via child bindings', async ({ throws }) => {
+test('throws when specifying pre-existing parent values via child bindings', async (t) => {
   const stream = sink()
-  throws(() => pino({
+  t.assert.throws(() => pino({
     customLevels: {
       foo: 35
     }
@@ -150,68 +152,74 @@ test('throws when specifying pre-existing parent values via child bindings', asy
     customLevels: {
       bar: 35
     }
-  }), 'pre-existing level values cannot be used for new levels')
+  }), {
+    message: 'pre-existing level values cannot be used for new levels'
+  })
 })
 
-test('throws when specifying core values via child bindings', async ({ throws }) => {
+test('throws when specifying core values via child bindings', async (t) => {
   const stream = sink()
-  throws(() => pino(stream).child({}, {
+  t.assert.throws(() => pino(stream).child({}, {
     customLevels: {
       foo: 30
     }
-  }), 'pre-existing level values cannot be used for new levels')
+  }), {
+    message: 'pre-existing level values cannot be used for new levels'
+  })
 })
 
-test('throws when useOnlyCustomLevels is set true without customLevels', async ({ throws }) => {
+test('throws when useOnlyCustomLevels is set true without customLevels', async (t) => {
   const stream = sink()
-  throws(() => pino({
+  t.assert.throws(() => pino({
     useOnlyCustomLevels: true
-  }, stream), 'customLevels is required if useOnlyCustomLevels is set true')
+  }, stream), {
+    message: 'customLevels is required if useOnlyCustomLevels is set true'
+  })
 })
 
-test('custom level on one instance does not affect other instances', async ({ equal }) => {
+test('custom level on one instance does not affect other instances', async (t) => {
   pino({
     customLevels: {
       foo: 37
     }
   })
-  equal(typeof pino().foo, 'undefined')
+  t.assert.strictEqual(typeof pino().foo, 'undefined')
 })
 
-test('setting level below or at custom level will successfully log', async ({ equal }) => {
+test('setting level below or at custom level will successfully log', async (t) => {
   const stream = sink()
   const instance = pino({ customLevels: { foo: 35 } }, stream)
   instance.level = 'foo'
   instance.info('nope')
   instance.foo('bar')
   const { msg } = await once(stream, 'data')
-  equal(msg, 'bar')
+  t.assert.strictEqual(msg, 'bar')
 })
 
-test('custom level below level threshold will not log', async ({ equal }) => {
+test('custom level below level threshold will not log', async (t) => {
   const stream = sink()
   const instance = pino({ customLevels: { foo: 15 } }, stream)
   instance.level = 'info'
   instance.info('bar')
   instance.foo('nope')
   const { msg } = await once(stream, 'data')
-  equal(msg, 'bar')
+  t.assert.strictEqual(msg, 'bar')
 })
 
-test('does not share custom level state across siblings', async ({ doesNotThrow }) => {
+test('does not share custom level state across siblings', async (t) => {
   const stream = sink()
   const logger = pino(stream)
   logger.child({}, {
     customLevels: { foo: 35 }
   })
-  doesNotThrow(() => {
+  t.assert.doesNotThrow(() => {
     logger.child({}, {
       customLevels: { foo: 35 }
     })
   })
 })
 
-test('custom level does not affect the levels serializer', async ({ equal }) => {
+test('custom level does not affect the levels serializer', async (t) => {
   const stream = sink()
   const logger = pino({
     customLevels: {
@@ -227,10 +235,10 @@ test('custom level does not affect the levels serializer', async ({ equal }) => 
 
   logger.foo('test')
   const { priority } = await once(stream, 'data')
-  equal(priority, 35)
+  t.assert.strictEqual(priority, 35)
 })
 
-test('When useOnlyCustomLevels is set to true, the level formatter should only get custom levels', async ({ equal }) => {
+test('When useOnlyCustomLevels is set to true, the level formatter should only get custom levels', async (t) => {
   const stream = sink()
   const logger = pino({
     customLevels: {
@@ -240,8 +248,8 @@ test('When useOnlyCustomLevels is set to true, the level formatter should only g
     level: 42,
     formatters: {
       level (label, number) {
-        equal(label, 'answer')
-        equal(number, 42)
+        t.assert.strictEqual(label, 'answer')
+        t.assert.strictEqual(number, 42)
         return { level: number }
       }
     }
@@ -249,5 +257,5 @@ test('When useOnlyCustomLevels is set to true, the level formatter should only g
 
   logger.answer('test')
   const { level } = await once(stream, 'data')
-  equal(level, 42)
+  t.assert.strictEqual(level, 42)
 })


### PR DESCRIPTION
This PR moves `custom-levels.test.js` to the node test runner