### PR TITLE
test: move exit.test.js to the node test runner

### DIFF
--- a/test/exit.test.js
+++ b/test/exit.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { join } = require('node:path')
 const execa = require('execa')
 const writer = require('flush-write-stream')
 const { once } = require('./helper')
 
 // https://github.com/pinojs/pino/issues/542
-test('pino.destination log everything when calling process.exit(0)', async ({ not }) => {
+test('pino.destination log everything when calling process.exit(0)', async (t) => {
   let actual = ''
   const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'destination-exit.js')])
 
@@ -18,11 +18,11 @@ test('pino.destination log everything when calling process.exit(0)', async ({ no
 
   await once(child, 'close')
 
-  not(actual.match(/hello/), null)
-  not(actual.match(/world/), null)
+  t.assert.notEqual(actual.match(/hello/), null)
+  t.assert.notEqual(actual.match(/world/), null)
 })
 
-test('pino with no args log everything when calling process.exit(0)', async ({ not }) => {
+test('pino with no args log everything when calling process.exit(0)', async (t) => {
   let actual = ''
   const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'default-exit.js')])
 
@@ -33,11 +33,11 @@ test('pino with no args log everything when calling process.exit(0)', async ({ n
 
   await once(child, 'close')
 
-  not(actual.match(/hello/), null)
-  not(actual.match(/world/), null)
+  t.assert.notEqual(actual.match(/hello/), null)
+  t.assert.notEqual(actual.match(/world/), null)
 })
 
-test('sync false logs everything when calling process.exit(0)', async ({ not }) => {
+test('sync false logs everything when calling process.exit(0)', async (t) => {
   let actual = ''
   const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'syncfalse-exit.js')])
 
@@ -48,11 +48,11 @@ test('sync false logs everything when calling process.exit(0)', async ({ not }) 
 
   await once(child, 'close')
 
-  not(actual.match(/hello/), null)
-  not(actual.match(/world/), null)
+  t.assert.notEqual(actual.match(/hello/), null)
+  t.assert.notEqual(actual.match(/world/), null)
 })
 
-test('sync false logs everything when calling flushSync', async ({ not }) => {
+test('sync false logs everything when calling flushSync', async (t) => {
   let actual = ''
   const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'syncfalse-flush-exit.js')])
 
@@ -63,15 +63,15 @@ test('sync false logs everything when calling flushSync', async ({ not }) => {
 
   await once(child, 'close')
 
-  not(actual.match(/hello/), null)
-  not(actual.match(/world/), null)
+  t.assert.notEqual(actual.match(/hello/), null)
+  t.assert.notEqual(actual.match(/world/), null)
 })
 
-test('transports exits gracefully when logging in exit', async ({ equal }) => {
+test('transports exits gracefully when logging in exit', async (t) => {
   const child = execa(process.argv[0], [join(__dirname, 'fixtures', 'transport-with-on-exit.js')])
   child.stdout.resume()
 
   const code = await once(child, 'close')
 
-  equal(code, 0)
+  t.assert.equal(code, 0)
 })


### PR DESCRIPTION
This PR moves `exit.test.js` to the node test runner