### PR TITLE
test: formatters.test.js to the node test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "homepage": "https://getpino.io",
   "devDependencies": {
+    "@jsumners/assert-match": "^1.0.0",
     "@jsumners/line-reporter": "^1.0.1",
     "@types/flush-write-stream": "^1.0.0",
     "@types/node": "^22.0.0",


### PR DESCRIPTION
This PR moves `formatters.test.js` to the node test runner