### PR TITLE
test: move mixin-merge-strategy.test.js to node test

### DIFF
--- a/test/mixin-merge-strategy.test.js
+++ b/test/mixin-merge-strategy.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { sink, once } = require('./helper')
 const pino = require('../')
 
 const level = 50
 const name = 'error'
 
-test('default merge strategy', async ({ ok, same }) => {
+test('default merge strategy', async (t) => {
   const stream = sink()
   const instance = pino({
     base: {},
@@ -20,16 +20,16 @@ test('default merge strategy', async ({ ok, same }) => {
     tag: 'local'
   }, 'test')
   const result = await once(stream, 'data')
-  ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
+  t.assert.ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
   delete result.time
-  same(result, {
+  t.assert.deepStrictEqual(result, {
     level,
     msg: 'test',
     tag: 'local'
   })
 })
 
-test('custom merge strategy with mixin priority', async ({ ok, same }) => {
+test('custom merge strategy with mixin priority', async (t) => {
   const stream = sink()
   const instance = pino({
     base: {},
@@ -45,9 +45,9 @@ test('custom merge strategy with mixin priority', async ({ ok, same }) => {
     tag: 'local'
   }, 'test')
   const result = await once(stream, 'data')
-  ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
+  t.assert.ok(new Date(result.time) <= new Date(), 'time is greater than Date.now()')
   delete result.time
-  same(result, {
+  t.assert.deepStrictEqual(result, {
     level,
     msg: 'test',
     tag: 'k8s'


### PR DESCRIPTION
This PR moves `mixin-merge-strategy.test.js` to node test