### PR TITLE
test: move redact.test.js to node test

### DIFF
--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -1,76 +1,76 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { sink, once } = require('./helper')
 const pino = require('../')
 
-test('redact option – throws if not array', async ({ throws }) => {
-  throws(() => {
+test('redact option – throws if not array', async (t) => {
+  t.assert.throws(() => {
     pino({ redact: 'req.headers.cookie' })
   })
 })
 
-test('redact option – throws if array does not only contain strings', async ({ throws }) => {
-  throws(() => {
+test('redact option – throws if array does not only contain strings', async (t) => {
+  t.assert.throws(() => {
     pino({ redact: ['req.headers.cookie', {}] })
   })
 })
 
-test('redact option – throws if array contains an invalid path', async ({ throws }) => {
-  throws(() => {
+test('redact option – throws if array contains an invalid path', async (t) => {
+  t.assert.throws(() => {
     pino({ redact: ['req,headers.cookie'] })
   })
 })
 
-test('redact.paths option – throws if not array', async ({ throws }) => {
-  throws(() => {
+test('redact.paths option – throws if not array', async (t) => {
+  t.assert.throws(() => {
     pino({ redact: { paths: 'req.headers.cookie' } })
   })
 })
 
-test('redact.paths option – throws if array does not only contain strings', async ({ throws }) => {
-  throws(() => {
+test('redact.paths option – throws if array does not only contain strings', async (t) => {
+  t.assert.throws(() => {
     pino({ redact: { paths: ['req.headers.cookie', {}] } })
   })
 })
 
-test('redact.paths option – throws if array contains an invalid path', async ({ throws }) => {
-  throws(() => {
+test('redact.paths option – throws if array contains an invalid path', async (t) => {
+  t.assert.throws(() => {
     pino({ redact: { paths: ['req,headers.cookie'] } })
   })
 })
 
-test('redact option – top level key', async ({ equal }) => {
+test('redact option – top level key', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['key'] }, stream)
   instance.info({
     key: { redact: 'me' }
   })
   const { key } = await once(stream, 'data')
-  equal(key, '[Redacted]')
+  t.assert.strictEqual(key, '[Redacted]')
 })
 
-test('redact option – top level key next level key', async ({ equal }) => {
+test('redact option – top level key next level key', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['key', 'key.foo'] }, stream)
   instance.info({
     key: { redact: 'me' }
   })
   const { key } = await once(stream, 'data')
-  equal(key, '[Redacted]')
+  t.assert.strictEqual(key, '[Redacted]')
 })
 
-test('redact option – next level key then top level key', async ({ equal }) => {
+test('redact option – next level key then top level key', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['key.foo', 'key'] }, stream)
   instance.info({
     key: { redact: 'me' }
   })
   const { key } = await once(stream, 'data')
-  equal(key, '[Redacted]')
+  t.assert.strictEqual(key, '[Redacted]')
 })
 
-test('redact option – object', async ({ equal }) => {
+test('redact option – object', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['req.headers.cookie'] }, stream)
   instance.info({
@@ -88,10 +88,10 @@ test('redact option – object', async ({ equal }) => {
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, '[Redacted]')
 })
 
-test('redact option – child object', async ({ equal }) => {
+test('redact option – child object', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['req.headers.cookie'] }, stream)
   instance.child({
@@ -109,10 +109,10 @@ test('redact option – child object', async ({ equal }) => {
     }
   }).info('message completed')
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, '[Redacted]')
 })
 
-test('redact option – interpolated object', async ({ equal }) => {
+test('redact option – interpolated object', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['req.headers.cookie'] }, stream)
 
@@ -131,10 +131,10 @@ test('redact option – interpolated object', async ({ equal }) => {
     }
   })
   const { msg } = await once(stream, 'data')
-  equal(JSON.parse(msg.replace(/test /, '')).req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(JSON.parse(msg.replace(/test /, '')).req.headers.cookie, '[Redacted]')
 })
 
-test('redact.paths option – object', async ({ equal }) => {
+test('redact.paths option – object', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'] } }, stream)
   instance.info({
@@ -152,10 +152,10 @@ test('redact.paths option – object', async ({ equal }) => {
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, '[Redacted]')
 })
 
-test('redact.paths option – child object', async ({ equal }) => {
+test('redact.paths option – child object', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'] } }, stream)
   instance.child({
@@ -173,10 +173,10 @@ test('redact.paths option – child object', async ({ equal }) => {
     }
   }).info('message completed')
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, '[Redacted]')
 })
 
-test('redact.paths option – interpolated object', async ({ equal }) => {
+test('redact.paths option – interpolated object', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'] } }, stream)
 
@@ -195,10 +195,10 @@ test('redact.paths option – interpolated object', async ({ equal }) => {
     }
   })
   const { msg } = await once(stream, 'data')
-  equal(JSON.parse(msg.replace(/test /, '')).req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(JSON.parse(msg.replace(/test /, '')).req.headers.cookie, '[Redacted]')
 })
 
-test('redact.censor option – sets the redact value', async ({ equal }) => {
+test('redact.censor option – sets the redact value', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'], censor: 'test' } }, stream)
   instance.info({
@@ -216,20 +216,20 @@ test('redact.censor option – sets the redact value', async ({ equal }) => {
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, 'test')
+  t.assert.strictEqual(req.headers.cookie, 'test')
 })
 
-test('redact.censor option – can be a function that accepts value and path arguments', async ({ equal }) => {
+test('redact.censor option – can be a function that accepts value and path arguments', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['topLevel'], censor: (value, path) => value + ' ' + path.join('.') } }, stream)
   instance.info({
     topLevel: 'test'
   })
   const { topLevel } = await once(stream, 'data')
-  equal(topLevel, 'test topLevel')
+  t.assert.strictEqual(topLevel, 'test topLevel')
 })
 
-test('redact.censor option – can be a function that accepts value and path arguments (nested path)', async ({ equal }) => {
+test('redact.censor option – can be a function that accepts value and path arguments (nested path)', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'], censor: (value, path) => value + ' ' + path.join('.') } }, stream)
   instance.info({
@@ -247,10 +247,10 @@ test('redact.censor option – can be a function that accepts value and path arg
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1; req.headers.cookie')
+  t.assert.strictEqual(req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1; req.headers.cookie')
 })
 
-test('redact.remove option – removes both key and value', async ({ equal }) => {
+test('redact.remove option – removes both key and value', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'], remove: true } }, stream)
   instance.info({
@@ -268,49 +268,49 @@ test('redact.remove option – removes both key and value', async ({ equal }) =>
     }
   })
   const { req } = await once(stream, 'data')
-  equal('cookie' in req.headers, false)
+  t.assert.strictEqual('cookie' in req.headers, false)
 })
 
-test('redact.remove – top level key - object value', async ({ equal }) => {
+test('redact.remove – top level key - object value', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['key'], remove: true } }, stream)
   instance.info({
     key: { redact: 'me' }
   })
   const o = await once(stream, 'data')
-  equal('key' in o, false)
+  t.assert.strictEqual('key' in o, false)
 })
 
-test('redact.remove – top level key - number value', async ({ equal }) => {
+test('redact.remove – top level key - number value', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['key'], remove: true } }, stream)
   instance.info({
     key: 1
   })
   const o = await once(stream, 'data')
-  equal('key' in o, false)
+  t.assert.strictEqual('key' in o, false)
 })
 
-test('redact.remove – top level key - boolean value', async ({ equal }) => {
+test('redact.remove – top level key - boolean value', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['key'], remove: true } }, stream)
   instance.info({
     key: false
   })
   const o = await once(stream, 'data')
-  equal('key' in o, false)
+  t.assert.strictEqual('key' in o, false)
 })
 
-test('redact.remove – top level key in child logger', async ({ equal }) => {
+test('redact.remove – top level key in child logger', async (t) => {
   const stream = sink()
   const opts = { redact: { paths: ['key'], remove: true } }
   const instance = pino(opts, stream).child({ key: { redact: 'me' } })
   instance.info('test')
   const o = await once(stream, 'data')
-  equal('key' in o, false)
+  t.assert.strictEqual('key' in o, false)
 })
 
-test('redact.paths preserves original object values after the log write', async ({ equal }) => {
+test('redact.paths preserves original object values after the log write', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['req.headers.cookie'] }, stream)
   const obj = {
@@ -329,11 +329,11 @@ test('redact.paths preserves original object values after the log write', async 
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o.req.headers.cookie, '[Redacted]')
-  equal(obj.req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
+  t.assert.strictEqual(o.req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(obj.req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
 })
 
-test('redact.paths preserves original object values after the log write', async ({ equal }) => {
+test('redact.paths preserves original object values after the log write', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'] } }, stream)
   const obj = {
@@ -352,11 +352,11 @@ test('redact.paths preserves original object values after the log write', async 
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o.req.headers.cookie, '[Redacted]')
-  equal(obj.req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
+  t.assert.strictEqual(o.req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(obj.req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
 })
 
-test('redact.censor preserves original object values after the log write', async ({ equal }) => {
+test('redact.censor preserves original object values after the log write', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'], censor: 'test' } }, stream)
   const obj = {
@@ -375,11 +375,11 @@ test('redact.censor preserves original object values after the log write', async
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o.req.headers.cookie, 'test')
-  equal(obj.req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
+  t.assert.strictEqual(o.req.headers.cookie, 'test')
+  t.assert.strictEqual(obj.req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
 })
 
-test('redact.remove preserves original object values after the log write', async ({ equal }) => {
+test('redact.remove preserves original object values after the log write', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['req.headers.cookie'], remove: true } }, stream)
   const obj = {
@@ -398,11 +398,11 @@ test('redact.remove preserves original object values after the log write', async
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal('cookie' in o.req.headers, false)
-  equal('cookie' in obj.req.headers, true)
+  t.assert.strictEqual('cookie' in o.req.headers, false)
+  t.assert.strictEqual('cookie' in obj.req.headers, true)
 })
 
-test('redact – supports last position wildcard paths', async ({ equal }) => {
+test('redact – supports last position wildcard paths', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['req.headers.*'] }, stream)
   instance.info({
@@ -420,12 +420,12 @@ test('redact – supports last position wildcard paths', async ({ equal }) => {
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, '[Redacted]')
-  equal(req.headers.host, '[Redacted]')
-  equal(req.headers.connection, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(req.headers.host, '[Redacted]')
+  t.assert.strictEqual(req.headers.connection, '[Redacted]')
 })
 
-test('redact – supports first position wildcard paths', async ({ equal }) => {
+test('redact – supports first position wildcard paths', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['*.headers'] }, stream)
   instance.info({
@@ -443,10 +443,10 @@ test('redact – supports first position wildcard paths', async ({ equal }) => {
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req.headers, '[Redacted]')
+  t.assert.strictEqual(req.headers, '[Redacted]')
 })
 
-test('redact – supports first position wildcards before other paths', async ({ equal }) => {
+test('redact – supports first position wildcards before other paths', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['*.headers.cookie', 'req.id'] }, stream)
   instance.info({
@@ -464,11 +464,11 @@ test('redact – supports first position wildcards before other paths', async ({
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, '[Redacted]')
-  equal(req.id, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(req.id, '[Redacted]')
 })
 
-test('redact – supports first position wildcards after other paths', async ({ equal }) => {
+test('redact – supports first position wildcards after other paths', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['req.id', '*.headers.cookie'] }, stream)
   instance.info({
@@ -486,11 +486,11 @@ test('redact – supports first position wildcards after other paths', async ({ 
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, '[Redacted]')
-  equal(req.id, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(req.id, '[Redacted]')
 })
 
-test('redact – supports first position wildcards after top level keys', async ({ equal }) => {
+test('redact – supports first position wildcards after top level keys', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['key', '*.headers.cookie'] }, stream)
   instance.info({
@@ -508,10 +508,10 @@ test('redact – supports first position wildcards after top level keys', async 
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, '[Redacted]')
 })
 
-test('redact – supports top level wildcard', async ({ equal }) => {
+test('redact – supports top level wildcard', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['*'] }, stream)
   instance.info({
@@ -529,10 +529,10 @@ test('redact – supports top level wildcard', async ({ equal }) => {
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req, '[Redacted]')
+  t.assert.strictEqual(req, '[Redacted]')
 })
 
-test('redact – supports top level wildcard with a censor function', async ({ equal }) => {
+test('redact – supports top level wildcard with a censor function', async (t) => {
   const stream = sink()
   const instance = pino({
     redact: {
@@ -555,10 +555,10 @@ test('redact – supports top level wildcard with a censor function', async ({ e
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req, '[Redacted]')
+  t.assert.strictEqual(req, '[Redacted]')
 })
 
-test('redact – supports top level wildcard and leading wildcard', async ({ equal }) => {
+test('redact – supports top level wildcard and leading wildcard', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['*', '*.req'] }, stream)
   instance.info({
@@ -576,10 +576,10 @@ test('redact – supports top level wildcard and leading wildcard', async ({ equ
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req, '[Redacted]')
+  t.assert.strictEqual(req, '[Redacted]')
 })
 
-test('redact – supports intermediate wildcard paths', async ({ equal }) => {
+test('redact – supports intermediate wildcard paths', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['req.*.cookie'] }, stream)
   instance.info({
@@ -597,10 +597,10 @@ test('redact – supports intermediate wildcard paths', async ({ equal }) => {
     }
   })
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, '[Redacted]')
 })
 
-test('redacts numbers at the top level', async ({ equal }) => {
+test('redacts numbers at the top level', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['id'] }, stream)
   const obj = {
@@ -608,10 +608,10 @@ test('redacts numbers at the top level', async ({ equal }) => {
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o.id, '[Redacted]')
+  t.assert.strictEqual(o.id, '[Redacted]')
 })
 
-test('redacts booleans at the top level', async ({ equal }) => {
+test('redacts booleans at the top level', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['maybe'] }, stream)
   const obj = {
@@ -619,10 +619,10 @@ test('redacts booleans at the top level', async ({ equal }) => {
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o.maybe, '[Redacted]')
+  t.assert.strictEqual(o.maybe, '[Redacted]')
 })
 
-test('redacts strings at the top level', async ({ equal }) => {
+test('redacts strings at the top level', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['s'] }, stream)
   const obj = {
@@ -630,10 +630,10 @@ test('redacts strings at the top level', async ({ equal }) => {
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o.s, '[Redacted]')
+  t.assert.strictEqual(o.s, '[Redacted]')
 })
 
-test('does not redact primitives if not objects', async ({ equal }) => {
+test('does not redact primitives if not objects', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['a.b'] }, stream)
   const obj = {
@@ -641,10 +641,10 @@ test('does not redact primitives if not objects', async ({ equal }) => {
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o.a, 42)
+  t.assert.strictEqual(o.a, 42)
 })
 
-test('redacts null at the top level', async ({ equal }) => {
+test('redacts null at the top level', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['n'] }, stream)
   const obj = {
@@ -652,10 +652,10 @@ test('redacts null at the top level', async ({ equal }) => {
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o.n, '[Redacted]')
+  t.assert.strictEqual(o.n, '[Redacted]')
 })
 
-test('supports bracket notation', async ({ equal }) => {
+test('supports bracket notation', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['a["b.b"]'] }, stream)
   const obj = {
@@ -663,10 +663,10 @@ test('supports bracket notation', async ({ equal }) => {
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o.a['b.b'], '[Redacted]')
+  t.assert.strictEqual(o.a['b.b'], '[Redacted]')
 })
 
-test('supports bracket notation with further nesting', async ({ equal }) => {
+test('supports bracket notation with further nesting', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['a["b.b"].c'] }, stream)
   const obj = {
@@ -674,10 +674,10 @@ test('supports bracket notation with further nesting', async ({ equal }) => {
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o.a['b.b'].c, '[Redacted]')
+  t.assert.strictEqual(o.a['b.b'].c, '[Redacted]')
 })
 
-test('supports bracket notation with empty string as path segment', async ({ equal }) => {
+test('supports bracket notation with empty string as path segment', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['a[""].c'] }, stream)
   const obj = {
@@ -685,10 +685,10 @@ test('supports bracket notation with empty string as path segment', async ({ equ
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o.a[''].c, '[Redacted]')
+  t.assert.strictEqual(o.a[''].c, '[Redacted]')
 })
 
-test('supports leading bracket notation (single quote)', async ({ equal }) => {
+test('supports leading bracket notation (single quote)', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['[\'a.a\'].b'] }, stream)
   const obj = {
@@ -696,10 +696,10 @@ test('supports leading bracket notation (single quote)', async ({ equal }) => {
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o['a.a'].b, '[Redacted]')
+  t.assert.strictEqual(o['a.a'].b, '[Redacted]')
 })
 
-test('supports leading bracket notation (double quote)', async ({ equal }) => {
+test('supports leading bracket notation (double quote)', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['["a.a"].b'] }, stream)
   const obj = {
@@ -707,10 +707,10 @@ test('supports leading bracket notation (double quote)', async ({ equal }) => {
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o['a.a'].b, '[Redacted]')
+  t.assert.strictEqual(o['a.a'].b, '[Redacted]')
 })
 
-test('supports leading bracket notation (backtick quote)', async ({ equal }) => {
+test('supports leading bracket notation (backtick quote)', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['[`a.a`].b'] }, stream)
   const obj = {
@@ -718,10 +718,10 @@ test('supports leading bracket notation (backtick quote)', async ({ equal }) => 
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o['a.a'].b, '[Redacted]')
+  t.assert.strictEqual(o['a.a'].b, '[Redacted]')
 })
 
-test('supports leading bracket notation (single-segment path)', async ({ equal }) => {
+test('supports leading bracket notation (single-segment path)', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['[`a.a`]'] }, stream)
   const obj = {
@@ -729,10 +729,10 @@ test('supports leading bracket notation (single-segment path)', async ({ equal }
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o['a.a'], '[Redacted]')
+  t.assert.strictEqual(o['a.a'], '[Redacted]')
 })
 
-test('supports leading bracket notation (single-segment path, wildcard)', async ({ equal }) => {
+test('supports leading bracket notation (single-segment path, wildcard)', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['[*]'] }, stream)
   const obj = {
@@ -740,10 +740,10 @@ test('supports leading bracket notation (single-segment path, wildcard)', async 
   }
   instance.info(obj)
   const o = await once(stream, 'data')
-  equal(o['a.a'], '[Redacted]')
+  t.assert.strictEqual(o['a.a'], '[Redacted]')
 })
 
-test('child bindings are redacted using wildcard path', async ({ equal }) => {
+test('child bindings are redacted using wildcard path', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['*.headers.cookie'] }, stream)
   instance.child({
@@ -756,10 +756,10 @@ test('child bindings are redacted using wildcard path', async ({ equal }) => {
     }
   }).info('message completed')
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, '[Redacted]')
 })
 
-test('child bindings are redacted using wildcard and plain path keys', async ({ equal }) => {
+test('child bindings are redacted using wildcard and plain path keys', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['req.method', '*.headers.cookie'] }, stream)
   instance.child({
@@ -772,11 +772,11 @@ test('child bindings are redacted using wildcard and plain path keys', async ({ 
     }
   }).info('message completed')
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, '[Redacted]')
-  equal(req.method, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, '[Redacted]')
+  t.assert.strictEqual(req.method, '[Redacted]')
 })
 
-test('redacts boolean at the top level', async ({ equal }) => {
+test('redacts boolean at the top level', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['msg'] }, stream)
   const obj = {
@@ -784,11 +784,11 @@ test('redacts boolean at the top level', async ({ equal }) => {
   }
   instance.info(obj, true)
   const o = await once(stream, 'data')
-  equal(o.s, 's')
-  equal(o.msg, '[Redacted]')
+  t.assert.strictEqual(o.s, 's')
+  t.assert.strictEqual(o.msg, '[Redacted]')
 })
 
-test('child can customize redact', async ({ equal }) => {
+test('child can customize redact', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['req.method', '*.headers.cookie'] }, stream)
   instance.child({
@@ -803,12 +803,12 @@ test('child can customize redact', async ({ equal }) => {
     redact: ['req.url']
   }).info('message completed')
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
-  equal(req.method, 'GET')
-  equal(req.url, '[Redacted]')
+  t.assert.strictEqual(req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
+  t.assert.strictEqual(req.method, 'GET')
+  t.assert.strictEqual(req.url, '[Redacted]')
 })
 
-test('child can remove parent redact by array', async ({ equal }) => {
+test('child can remove parent redact by array', async (t) => {
   const stream = sink()
   const instance = pino({ redact: ['req.method', '*.headers.cookie'] }, stream)
   instance.child({
@@ -823,11 +823,11 @@ test('child can remove parent redact by array', async ({ equal }) => {
     redact: []
   }).info('message completed')
   const { req } = await once(stream, 'data')
-  equal(req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
-  equal(req.method, 'GET')
+  t.assert.strictEqual(req.headers.cookie, 'SESSID=298zf09hf012fh2; csrftoken=u32t4o3tb3gg43; _gat=1;')
+  t.assert.strictEqual(req.method, 'GET')
 })
 
-test('redact safe stringify', async ({ equal }) => {
+test('redact safe stringify', async (t) => {
   const stream = sink()
   const instance = pino({ redact: { paths: ['that.secret'] } }, stream)
 
@@ -841,7 +841,7 @@ test('redact safe stringify', async ({ equal }) => {
     }
   })
   const { that, other } = await once(stream, 'data')
-  equal(that.secret, '[Redacted]')
-  equal(that.myBigInt, 123)
-  equal(other.mySecondBigInt, 222)
+  t.assert.strictEqual(that.secret, '[Redacted]')
+  t.assert.strictEqual(that.myBigInt, 123)
+  t.assert.strictEqual(other.mySecondBigInt, 222)
 })


### PR DESCRIPTION
This PR moves redact.test.js to node test