### PR TITLE
test: move version.test.js to node test

### DIFF
--- a/test/internals/version.test.js
+++ b/test/internals/version.test.js
@@ -2,8 +2,7 @@
 
 const fs = require('node:fs')
 const path = require('node:path')
-const t = require('tap')
-const test = t.test
+const { test } = require('node:test')
 const pino = require('../..')()
 
 test('should be the same as package.json', t => {
@@ -11,5 +10,5 @@ test('should be the same as package.json', t => {
 
   const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json')).toString('utf8'))
 
-  t.equal(pino.version, json.version)
+  t.assert.strictEqual(pino.version, json.version)
 })


### PR DESCRIPTION
This PR moves `version.test.js` to node test