### PR TITLE
test: move big.test.js to node test

### DIFF
--- a/test/transport/big.test.js
+++ b/test/transport/big.test.js
@@ -32,9 +32,6 @@ test('eight million lines', { skip }, async (t) => {
   let count = 0
   await pipeline(createReadStream(destination), split(), new Writable({
     write (chunk, enc, cb) {
-      if (count % (toWrite / 10) === 0) {
-        t.diagnostic(`read ${count}`)
-      }
       count++
       cb()
     }

--- a/test/transport/big.test.js
+++ b/test/transport/big.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { join } = require('node:path')
 const { createReadStream } = require('node:fs')
 const { promisify } = require('node:util')
@@ -15,7 +15,7 @@ const sleep = promisify(setTimeout)
 
 const skip = process.env.CI || process.env.CITGM
 
-test('eight million lines', { skip }, async ({ equal, comment }) => {
+test('eight million lines', { skip }, async (t) => {
   const destination = file()
   await execa(process.argv[0], [join(__dirname, '..', 'fixtures', 'transport-many-lines.js'), destination])
 
@@ -33,11 +33,11 @@ test('eight million lines', { skip }, async ({ equal, comment }) => {
   await pipeline(createReadStream(destination), split(), new Writable({
     write (chunk, enc, cb) {
       if (count % (toWrite / 10) === 0) {
-        comment(`read ${count}`)
+        t.diagnostic(`read ${count}`)
       }
       count++
       cb()
     }
   }))
-  equal(count, toWrite)
+  t.assert.strictEqual(count, toWrite)
 })


### PR DESCRIPTION
This PR moves `big.test.js` to node test