### PR TITLE
test: move module-link.test.js to node test

### DIFF
--- a/test/transport/module-link.test.js
+++ b/test/transport/module-link.test.js
@@ -3,7 +3,7 @@
 const os = require('node:os')
 const { join } = require('node:path')
 const { readFile, symlink, unlink, mkdir, writeFile } = require('node:fs').promises
-const { test } = require('tap')
+const { test } = require('node:test')
 const { isWin, isYarnPnp, watchFileCreated, file } = require('../helper')
 const { once } = require('node:events')
 const execa = require('execa')
@@ -39,7 +39,7 @@ async function uninstallTransportModule () {
 }
 
 // TODO make this test pass on Windows
-test('pino.transport with package', { skip: isWin }, async ({ same, teardown }) => {
+test('pino.transport with package', { skip: isWin }, async (t) => {
   const destination = file()
 
   await installTransportModule()
@@ -49,7 +49,7 @@ test('pino.transport with package', { skip: isWin }, async ({ same, teardown }) 
     options: { destination }
   })
 
-  teardown(async () => {
+  t.after(async () => {
     await uninstallTransportModule()
     transport.end()
   })
@@ -58,7 +58,7 @@ test('pino.transport with package', { skip: isWin }, async ({ same, teardown }) 
   await watchFileCreated(destination)
   const result = JSON.parse(await readFile(destination))
   delete result.time
-  same(result, {
+  t.assert.deepStrictEqual(result, {
     pid,
     hostname,
     level: 30,
@@ -67,7 +67,7 @@ test('pino.transport with package', { skip: isWin }, async ({ same, teardown }) 
 })
 
 // TODO make this test pass on Windows
-test('pino.transport with package as a target', { skip: isWin }, async ({ same, teardown }) => {
+test('pino.transport with package as a target', { skip: isWin }, async (t) => {
   const destination = file()
 
   await installTransportModule()
@@ -78,7 +78,7 @@ test('pino.transport with package as a target', { skip: isWin }, async ({ same, 
       options: { destination }
     }]
   })
-  teardown(async () => {
+  t.after(async () => {
     await uninstallTransportModule()
     transport.end()
   })
@@ -87,7 +87,7 @@ test('pino.transport with package as a target', { skip: isWin }, async ({ same, 
   await watchFileCreated(destination)
   const result = JSON.parse(await readFile(destination))
   delete result.time
-  same(result, {
+  t.assert.deepStrictEqual(result, {
     pid,
     hostname,
     level: 30,
@@ -96,13 +96,13 @@ test('pino.transport with package as a target', { skip: isWin }, async ({ same, 
 })
 
 // TODO make this test pass on Windows
-test('pino({ transport })', { skip: isWin || isYarnPnp }, async ({ same, teardown }) => {
+test('pino({ transport })', { skip: isWin || isYarnPnp }, async (t) => {
   const folder = join(
     os.tmpdir(),
     '_' + Math.random().toString(36).substr(2, 9)
   )
 
-  teardown(() => {
+  t.after(() => {
     rimraf.sync(folder)
   })
 
@@ -139,7 +139,7 @@ test('pino({ transport })', { skip: isWin || isYarnPnp }, async ({ same, teardow
 
   const result = JSON.parse(await readFile(destination))
   delete result.time
-  same(result, {
+  t.assert.deepStrictEqual(result, {
     pid: child.pid,
     hostname,
     level: 30,
@@ -148,7 +148,7 @@ test('pino({ transport })', { skip: isWin || isYarnPnp }, async ({ same, teardow
 })
 
 // TODO make this test pass on Windows
-test('pino({ transport }) from a wrapped dependency', { skip: isWin || isYarnPnp }, async ({ same, teardown }) => {
+test('pino({ transport }) from a wrapped dependency', { skip: isWin || isYarnPnp }, async (t) => {
   const folder = join(
     os.tmpdir(),
     '_' + Math.random().toString(36).substr(2, 9)
@@ -164,7 +164,7 @@ test('pino({ transport }) from a wrapped dependency', { skip: isWin || isYarnPnp
   await mkdir(join(folder, 'node_modules'), { recursive: true })
   await mkdir(join(wrappedFolder, 'node_modules'), { recursive: true })
 
-  teardown(() => {
+  t.after(() => {
     rimraf.sync(wrappedFolder)
     rimraf.sync(folder)
   })
@@ -230,7 +230,7 @@ test('pino({ transport }) from a wrapped dependency', { skip: isWin || isYarnPnp
 
   const result = JSON.parse(await readFile(destination))
   delete result.time
-  same(result, {
+  t.assert.deepStrictEqual(result, {
     pid: child.pid,
     hostname,
     level: 30,


### PR DESCRIPTION
This PR moves `module-link.test.js` to node test