### PR TITLE
test: move repl.test.js to node test

### DIFF
--- a/test/transport/repl.test.js
+++ b/test/transport/repl.test.js
@@ -1,14 +1,14 @@
 'use strict'
 
-const { doesNotThrow, test } = require('tap')
+const { test } = require('node:test')
 const proxyquire = require('proxyquire')
 
-test('pino.transport resolves targets in REPL', async ({ same }) => {
+test('pino.transport resolves targets in REPL', async (t) => {
   // Arrange
   const transport = proxyquire('../../lib/transport', {
     './caller': () => ['node:repl']
   })
 
   // Act / Assert
-  doesNotThrow(() => transport({ target: 'pino-pretty' }))
+  t.assert.doesNotThrow(() => transport({ target: 'pino-pretty' }))
 })


### PR DESCRIPTION
This PR moves `repl.test.js` to node test