### PR TITLE
test: move targets.test.js to node test

### DIFF
--- a/test/transport/targets.test.js
+++ b/test/transport/targets.test.js
@@ -1,18 +1,18 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { join } = require('node:path')
 const proxyquire = require('proxyquire')
 const Writable = require('node:stream').Writable
 const pino = require('../../pino')
 
-test('file-target mocked', async function ({ equal, same, plan, pass }) {
-  plan(1)
+test('file-target mocked', async (t) => {
+  t.plan(1)
   let ret
   const fileTarget = proxyquire('../../file', {
     './pino': {
       destination (opts) {
-        same(opts, { dest: 1, sync: false })
+        t.assert.deepStrictEqual(opts, { dest: 1, sync: false })
 
         ret = new Writable()
         ret.fd = opts.dest
@@ -29,16 +29,17 @@ test('file-target mocked', async function ({ equal, same, plan, pass }) {
   await fileTarget()
 })
 
-test('pino.transport with syntax error', ({ same, teardown, plan }) => {
-  plan(1)
+test('pino.transport with syntax error', (t, end) => {
+  t.plan(1)
   const transport = pino.transport({
     targets: [{
       target: join(__dirname, '..', 'fixtures', 'syntax-error-esm.mjs')
     }]
   })
-  teardown(transport.end.bind(transport))
+  t.after(transport.end.bind(transport))
 
   transport.on('error', (err) => {
-    same(err, new SyntaxError('Unexpected end of input'))
+    t.assert.deepStrictEqual(err, new SyntaxError('Unexpected end of input'))
+    end()
   })
 })


### PR DESCRIPTION
This PR moves `targets.test.js` to node test