### PR TITLE
test: move pkg/index.js to node test

### DIFF
--- a/test/pkg/index.js
+++ b/test/pkg/index.js
@@ -4,7 +4,7 @@ const os = require('node:os')
 const { join } = require('node:path')
 const { readFile } = require('node:fs').promises
 const { watchFileCreated, file } = require('../helper')
-const { test } = require('node:test')
+const assert = require('node:assert/strict')
 const pino = require('../../pino')
 
 const { pid } = process
@@ -14,7 +14,7 @@ const hostname = os.hostname()
  * This file is packaged using pkg in order to test if transport-stream.js works in that context
  */
 
-test('pino.transport with worker destination overridden by bundler and mjs transport', async (t) => {
+async function runTest () {
   globalThis.__bundlerPathsOverrides = {
     'pino-worker': join(__dirname, '..', '..', 'lib/worker.js')
   }
@@ -28,19 +28,23 @@ test('pino.transport with worker destination overridden by bundler and mjs trans
       }
     ]
   })
+  try {
+    const instance = pino(transport)
+    instance.info('hello')
+    await watchFileCreated(destination)
+    const result = JSON.parse(await readFile(destination))
+    delete result.time
+    assert.deepStrictEqual(result, {
+      pid,
+      hostname,
+      level: 30,
+      msg: 'hello'
+    })
 
-  t.after(transport.end.bind(transport))
-  const instance = pino(transport)
-  instance.info('hello')
-  await watchFileCreated(destination)
-  const result = JSON.parse(await readFile(destination))
-  delete result.time
-  t.assert.deepStrictEqual(result, {
-    pid,
-    hostname,
-    level: 30,
-    msg: 'hello'
-  })
+    globalThis.__bundlerPathsOverrides = undefined
+  } finally {
+    transport.end()
+  }
+}
 
-  globalThis.__bundlerPathsOverrides = undefined
-})
+runTest()

--- a/test/pkg/index.js
+++ b/test/pkg/index.js
@@ -4,7 +4,7 @@ const os = require('node:os')
 const { join } = require('node:path')
 const { readFile } = require('node:fs').promises
 const { watchFileCreated, file } = require('../helper')
-const { test } = require('tap')
+const { test } = require('node:test')
 const pino = require('../../pino')
 
 const { pid } = process
@@ -14,7 +14,7 @@ const hostname = os.hostname()
  * This file is packaged using pkg in order to test if transport-stream.js works in that context
  */
 
-test('pino.transport with worker destination overridden by bundler and mjs transport', async ({ same, teardown }) => {
+test('pino.transport with worker destination overridden by bundler and mjs transport', async (t) => {
   globalThis.__bundlerPathsOverrides = {
     'pino-worker': join(__dirname, '..', '..', 'lib/worker.js')
   }
@@ -29,13 +29,13 @@ test('pino.transport with worker destination overridden by bundler and mjs trans
     ]
   })
 
-  teardown(transport.end.bind(transport))
+  t.after(transport.end.bind(transport))
   const instance = pino(transport)
   instance.info('hello')
   await watchFileCreated(destination)
   const result = JSON.parse(await readFile(destination))
   delete result.time
-  same(result, {
+  t.assert.deepStrictEqual(result, {
     pid,
     hostname,
     level: 30,

--- a/test/pkg/pkg.config.json
+++ b/test/pkg/pkg.config.json
@@ -7,8 +7,6 @@
             "../../node_modules/pino-abstract-transport/index.js"
         ],
         "targets": [
-            "node16",
-            "node18",
             "node20",
             "node22"
         ],

--- a/test/pkg/pkg.config.json
+++ b/test/pkg/pkg.config.json
@@ -7,10 +7,8 @@
             "../../node_modules/pino-abstract-transport/index.js"
         ],
         "targets": [
-            "node14",
-            "node16",
-            "node18",
-            "node20"
+            "node20",
+            "node22"
         ],
         "outputPath": "test/pkg"
     }

--- a/test/pkg/pkg.config.json
+++ b/test/pkg/pkg.config.json
@@ -7,6 +7,8 @@
             "../../node_modules/pino-abstract-transport/index.js"
         ],
         "targets": [
+            "node16",
+            "node18",
             "node20",
             "node22"
         ],


### PR DESCRIPTION
This PR moves `pkg/index.js` to node test