### PR TITLE
test: move to describe

### DIFF
--- a/test/browser-is-level-enabled.test.js
+++ b/test/browser-is-level-enabled.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('node:test')
+const { describe, test } = require('node:test')
 const pino = require('../browser')
 
 const customLevels = {
@@ -12,42 +12,42 @@ const customLevels = {
   fatal: 60
 }
 
-test('Default levels suite', async t => {
-  await t.test('can check if current level enabled', async (t) => {
+describe('Default levels suite', () => {
+  test('can check if current level enabled', async (t) => {
     const log = pino({ level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('can check if current level enabled when as object', async (t) => {
+  test('can check if current level enabled when as object', async (t) => {
     const log = pino({ asObject: true, level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('can check if level enabled after level set', async (t) => {
+  test('can check if level enabled after level set', async (t) => {
     const log = pino()
     t.assert.strictEqual(false, log.isLevelEnabled('debug'))
     log.level = 'debug'
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('can check if higher level enabled', async (t) => {
+  test('can check if higher level enabled', async (t) => {
     const log = pino({ level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
   })
 
-  await t.test('can check if lower level is disabled', async (t) => {
+  test('can check if lower level is disabled', async (t) => {
     const log = pino({ level: 'error' })
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  await t.test('ASC: can check if child has current level enabled', async (t) => {
+  test('ASC: can check if child has current level enabled', async (t) => {
     const log = pino().child({}, { level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  await t.test('can check if custom level is enabled', async (t) => {
+  test('can check if custom level is enabled', async (t) => {
     const log = pino({
       customLevels: { foo: 35 },
       level: 'debug'
@@ -58,37 +58,37 @@ test('Default levels suite', async t => {
   })
 })
 
-test('Custom levels suite', async t => {
-  await t.test('can check if current level enabled', async (t) => {
+describe('Custom levels suite', () => {
+  test('can check if current level enabled', async (t) => {
     const log = pino({ level: 'debug', customLevels })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('can check if level enabled after level set', async (t) => {
+  test('can check if level enabled after level set', async (t) => {
     const log = pino({ customLevels })
     t.assert.strictEqual(false, log.isLevelEnabled('debug'))
     log.level = 'debug'
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('can check if higher level enabled', async (t) => {
+  test('can check if higher level enabled', async (t) => {
     const log = pino({ level: 'debug', customLevels })
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
   })
 
-  await t.test('can check if lower level is disabled', async (t) => {
+  test('can check if lower level is disabled', async (t) => {
     const log = pino({ level: 'error', customLevels })
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  await t.test('can check if child has current level enabled', async (t) => {
+  test('can check if child has current level enabled', async (t) => {
     const log = pino().child({ customLevels }, { level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  await t.test('can check if custom level is enabled', async (t) => {
+  test('can check if custom level is enabled', async (t) => {
     const log = pino({
       customLevels: { foo: 35, ...customLevels },
       level: 'debug'

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const { test } = require('node:test')
+const { describe, test } = require('node:test')
 const match = require('@jsumners/assert-match')
 const { sink, once } = require('./helper')
 const pino = require('../')
 
-test('log method hook', async t => {
-  await t.test('gets invoked', async t => {
+describe('log method hook', () => {
+  test('gets invoked', async t => {
     t.plan(8)
 
     const stream = sink()
@@ -32,7 +32,7 @@ test('log method hook', async t => {
     match(await o, { msg: 'a-b-c' }, t)
   })
 
-  await t.test('fatal method invokes hook', async t => {
+  test('fatal method invokes hook', async t => {
     t.plan(2)
 
     const stream = sink()
@@ -50,7 +50,7 @@ test('log method hook', async t => {
     match(await o, { msg: 'a' }, t)
   })
 
-  await t.test('children get the hook', async t => {
+  test('children get the hook', async t => {
     t.plan(4)
 
     const stream = sink()
@@ -74,7 +74,7 @@ test('log method hook', async t => {
     match(await o, { msg: 'c-d' }, t)
   })
 
-  await t.test('get log level', async t => {
+  test('get log level', async t => {
     t.plan(3)
 
     const stream = sink()
@@ -95,8 +95,8 @@ test('log method hook', async t => {
   })
 })
 
-test('streamWrite hook', async t => {
-  await t.test('gets invoked', async t => {
+describe('streamWrite hook', () => {
+  test('gets invoked', async t => {
     t.plan(1)
 
     const stream = sink()

--- a/test/is-level-enabled.test.js
+++ b/test/is-level-enabled.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('node:test')
+const { describe, test } = require('node:test')
 const pino = require('../')
 
 const descLevels = {
@@ -21,37 +21,37 @@ const ascLevels = {
   fatal: 60
 }
 
-test('Default levels suite', async (t) => {
-  await t.test('can check if current level enabled', async (t) => {
+describe('Default levels suite', () => {
+  test('can check if current level enabled', async (t) => {
     const log = pino({ level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('can check if level enabled after level set', async (t) => {
+  test('can check if level enabled after level set', async (t) => {
     const log = pino()
     t.assert.strictEqual(false, log.isLevelEnabled('debug'))
     log.level = 'debug'
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('can check if higher level enabled', async (t) => {
+  test('can check if higher level enabled', async (t) => {
     const log = pino({ level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
   })
 
-  await t.test('can check if lower level is disabled', async (t) => {
+  test('can check if lower level is disabled', async (t) => {
     const log = pino({ level: 'error' })
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  await t.test('ASC: can check if child has current level enabled', async (t) => {
+  test('ASC: can check if child has current level enabled', async (t) => {
     const log = pino().child({}, { level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  await t.test('can check if custom level is enabled', async (t) => {
+  test('can check if custom level is enabled', async (t) => {
     const log = pino({
       customLevels: { foo: 35 },
       level: 'debug'
@@ -62,40 +62,40 @@ test('Default levels suite', async (t) => {
   })
 })
 
-test('Ascending levels suite', async (t) => {
+describe('Ascending levels suite', () => {
   const customLevels = ascLevels
   const levelComparison = 'ASC'
 
-  await t.test('can check if current level enabled', async (t) => {
+  test('can check if current level enabled', async (t) => {
     const log = pino({ level: 'debug', levelComparison, customLevels, useOnlyCustomLevels: true })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('can check if level enabled after level set', async (t) => {
+  test('can check if level enabled after level set', async (t) => {
     const log = pino({ levelComparison, customLevels, useOnlyCustomLevels: true })
     t.assert.strictEqual(false, log.isLevelEnabled('debug'))
     log.level = 'debug'
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('can check if higher level enabled', async (t) => {
+  test('can check if higher level enabled', async (t) => {
     const log = pino({ level: 'debug', levelComparison, customLevels, useOnlyCustomLevels: true })
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
   })
 
-  await t.test('can check if lower level is disabled', async (t) => {
+  test('can check if lower level is disabled', async (t) => {
     const log = pino({ level: 'error', customLevels, useOnlyCustomLevels: true })
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  await t.test('can check if child has current level enabled', async (t) => {
+  test('can check if child has current level enabled', async (t) => {
     const log = pino().child({ levelComparison, customLevels, useOnlyCustomLevels: true }, { level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  await t.test('can check if custom level is enabled', async (t) => {
+  test('can check if custom level is enabled', async (t) => {
     const log = pino({
       levelComparison,
       useOnlyCustomLevels: true,
@@ -108,40 +108,40 @@ test('Ascending levels suite', async (t) => {
   })
 })
 
-test('Descending levels suite', async (t) => {
+describe('Descending levels suite', () => {
   const customLevels = descLevels
   const levelComparison = 'DESC'
 
-  await t.test('can check if current level enabled', async (t) => {
+  test('can check if current level enabled', async (t) => {
     const log = pino({ level: 'debug', levelComparison, customLevels, useOnlyCustomLevels: true })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('can check if level enabled after level set', async (t) => {
+  test('can check if level enabled after level set', async (t) => {
     const log = pino({ levelComparison, customLevels, useOnlyCustomLevels: true })
     t.assert.strictEqual(false, log.isLevelEnabled('debug'))
     log.level = 'debug'
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('can check if higher level enabled', async (t) => {
+  test('can check if higher level enabled', async (t) => {
     const log = pino({ level: 'debug', levelComparison, customLevels, useOnlyCustomLevels: true })
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
   })
 
-  await t.test('can check if lower level is disabled', async (t) => {
+  test('can check if lower level is disabled', async (t) => {
     const log = pino({ level: 'error', levelComparison, customLevels, useOnlyCustomLevels: true })
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  await t.test('can check if child has current level enabled', async (t) => {
+  test('can check if child has current level enabled', async (t) => {
     const log = pino({ levelComparison, customLevels, useOnlyCustomLevels: true }).child({}, { level: 'debug' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
     t.assert.strictEqual(true, log.isLevelEnabled('error'))
     t.assert.strictEqual(false, log.isLevelEnabled('trace'))
   })
 
-  await t.test('can check if custom level is enabled', async (t) => {
+  test('can check if custom level is enabled', async (t) => {
     const log = pino({
       levelComparison,
       customLevels: { foo: 35, ...customLevels },
@@ -154,23 +154,23 @@ test('Descending levels suite', async (t) => {
   })
 })
 
-test('Custom levels comparison', async (t) => {
-  await t.test('Custom comparison returns true cause level is enabled', async (t) => {
+describe('Custom levels comparison', () => {
+  test('Custom comparison returns true cause level is enabled', async (t) => {
     const log = pino({ level: 'error', levelComparison: () => true })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('Custom comparison returns false cause level is disabled', async (t) => {
+  test('Custom comparison returns false cause level is disabled', async (t) => {
     const log = pino({ level: 'error', levelComparison: () => false })
     t.assert.strictEqual(false, log.isLevelEnabled('debug'))
   })
 
-  await t.test('Custom comparison returns true cause child level is enabled', async (t) => {
+  test('Custom comparison returns true cause child level is enabled', async (t) => {
     const log = pino({ levelComparison: () => true }).child({ level: 'error' })
     t.assert.strictEqual(true, log.isLevelEnabled('debug'))
   })
 
-  await t.test('Custom comparison returns false cause child level is disabled', async (t) => {
+  test('Custom comparison returns false cause child level is disabled', async (t) => {
     const log = pino({ levelComparison: () => false }).child({ level: 'error' })
     t.assert.strictEqual(false, log.isLevelEnabled('debug'))
   })

--- a/test/levels.test.js
+++ b/test/levels.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('node:test')
+const { describe, test } = require('node:test')
 const { sink, once, check } = require('./helper')
 const pino = require('../')
 
@@ -533,7 +533,7 @@ test('changing level from info to silent and back to info in child logger', asyn
   check(t.assert.strictEqual, result, expected.level, expected.msg)
 })
 
-test('changing level respects level comparison set to', async (t) => {
+describe('changing level respects level comparison set to', () => {
   const ascLevels = {
     debug: 1,
     info: 2,
@@ -551,7 +551,7 @@ test('changing level respects level comparison set to', async (t) => {
     msg: 'hello world'
   }
 
-  await t.test('ASC in parent logger', async (t) => {
+  test('ASC in parent logger', async (t) => {
     const customLevels = ascLevels
     const levelComparison = 'ASC'
 
@@ -569,7 +569,7 @@ test('changing level respects level comparison set to', async (t) => {
     check(t.assert.strictEqual, result, expected.level, expected.msg)
   })
 
-  await t.test('DESC in parent logger', async (t) => {
+  test('DESC in parent logger', async (t) => {
     const customLevels = descLevels
     const levelComparison = 'DESC'
 
@@ -587,7 +587,7 @@ test('changing level respects level comparison set to', async (t) => {
     check(t.assert.strictEqual, result, expected.level, expected.msg)
   })
 
-  await t.test('custom function in parent logger', async (t) => {
+  test('custom function in parent logger', async (t) => {
     const customLevels = {
       info: 2,
       debug: 345,
@@ -612,7 +612,7 @@ test('changing level respects level comparison set to', async (t) => {
     check(t.assert.strictEqual, result, expected.level, expected.msg)
   })
 
-  await t.test('ASC in child logger', async (t) => {
+  test('ASC in child logger', async (t) => {
     const customLevels = ascLevels
     const levelComparison = 'ASC'
 
@@ -630,7 +630,7 @@ test('changing level respects level comparison set to', async (t) => {
     check(t.assert.strictEqual, result, expected.level, expected.msg)
   })
 
-  await t.test('DESC in parent logger', async (t) => {
+  test('DESC in parent logger', async (t) => {
     const customLevels = descLevels
     const levelComparison = 'DESC'
 
@@ -648,7 +648,7 @@ test('changing level respects level comparison set to', async (t) => {
     check(t.assert.strictEqual, result, expected.level, expected.msg)
   })
 
-  await t.test('custom function in child logger', async (t) => {
+  test('custom function in child logger', async (t) => {
     const customLevels = {
       info: 2,
       debug: 345,


### PR DESCRIPTION
This PR move group test to describe.

@jsumners This one is to align Pino with the `describe` thread of this [PR](https://github.com/pinojs/pino-pretty/pull/569#discussion_r2083445857)