### PR TITLE
Enhance logger function typing

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -338,7 +338,7 @@ declare namespace pino {
         : Acc;
 
     interface LogFn {
-        <T, TMsg extends string = string>(obj: Exclude<T, string>, msg?: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
+        <T, TMsg extends string = string>(obj: T, msg?: T extends string ? never: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
         <_, TMsg extends string = string>(msg: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
     }
 

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -330,7 +330,7 @@ declare namespace pino {
 
     type ParseLogFnArgs<
         T,
-        Acc extends any[] = [],
+        Acc extends unknown[] = [],
     > = T extends `${infer _}%${infer Placeholder}${infer Rest}`
         ? Placeholder extends PlaceholderSpecifier
             ? ParseLogFnArgs<Rest, [...Acc, PlaceholderTypeMapping<Placeholder>]>

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -338,8 +338,8 @@ declare namespace pino {
         : Acc;
 
     interface LogFn {
-        <T extends unknown, TMsg extends string = string>(obj: Exclude<T, string>, msg?: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
-        <_ extends unknown, TMsg extends string = string>(msg: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
+        <T, TMsg extends string = string>(obj: Exclude<T, string>, msg?: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
+        <_, TMsg extends string = string>(msg: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
     }
 
     interface LoggerOptions<CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean> {

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -338,8 +338,8 @@ declare namespace pino {
         : Acc;
 
     interface LogFn {
-        <T extends unknown, TMsg extends string = string>(obj: Exclude<T, string>, msg?: TMsg, ...args: ParseLogFnArgs<TMsg>): void;
-        <_ extends unknown, TMsg extends string = string>(msg: TMsg, ...args: ParseLogFnArgs<TMsg>): void;
+        <T extends unknown, TMsg extends string = string>(obj: Exclude<T, string>, msg?: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
+        <_ extends unknown, TMsg extends string = string>(msg: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
     }
 
     interface LoggerOptions<CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean> {

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -319,8 +319,8 @@ declare namespace pino {
         labels: { [level: number]: string };
     }
 
-    type FormatSpecifier = 'd' | 's' | 'j' | 'o' | 'O';
-    type TypeMapping<T extends FormatSpecifier> = T extends 'd'
+    type PlaceholderSpecifier = 'd' | 's' | 'j' | 'o' | 'O';
+    type PlaceholderTypeMapping<T extends PlaceholderSpecifier> = T extends 'd'
         ? number
         : T extends 's'
             ? string
@@ -328,19 +328,18 @@ declare namespace pino {
             ? object
             : never;
 
-    type ParseArgs<
+    type ParseLogFnArgs<
         T,
         Acc extends any[] = [],
-    > = T extends `${infer _}%${infer Format}${infer Rest}`
-        ? Format extends FormatSpecifier
-            ? ParseArgs<Rest, [...Acc, TypeMapping<Format>]>
-            : ParseArgs<Rest, Acc>
+    > = T extends `${infer _}%${infer Placeholder}${infer Rest}`
+        ? Placeholder extends PlaceholderSpecifier
+            ? ParseLogFnArgs<Rest, [...Acc, PlaceholderTypeMapping<Placeholder>]>
+            : ParseLogFnArgs<Rest, Acc>
         : Acc;
 
     interface LogFn {
-        /* tslint:disable:no-unnecessary-generics */
-        <T extends unknown, TMsg extends string = string>(obj: Exclude<T, string>, msg?: TMsg, ...args: ParseArgs<TMsg>): void;
-        <T extends unknown, TMsg extends string = string>(msg: TMsg, ...args: ParseArgs<TMsg>): void;
+        <T extends unknown, TMsg extends string = string>(obj: Exclude<T, string>, msg?: TMsg, ...args: ParseLogFnArgs<TMsg>): void;
+        <_ extends unknown, TMsg extends string = string>(msg: TMsg, ...args: ParseLogFnArgs<TMsg>): void;
     }
 
     interface LoggerOptions<CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean> {

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -44,7 +44,6 @@ expectError(info('The object is %j', 'not a JSON'));
 expectError(info('The object is %O', 'not an object'));
 expectError(info('The answer is %d and the question is %s with %o', 42, { incorrect: 'order' }, 'unknown'));
 
-
 // object types with messages
 info({ obj: 42 }, "hello world");
 info({ obj: 42, b: 2 }, "hello world");
@@ -53,6 +52,9 @@ info({ a: 1, b: '2' }, 'hello world with %s', 'extra data');
 
 // metadata with messages type errors
 expectError(info({ a: 1, b: '2' }, 'hello world with %s', 123));
+
+// metadata after message
+expectError(info('message', { a: 1, b: '2' }));
 
 // multiple strings without template
 expectError(info('string1', 'string2', 'string3'));

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -35,6 +35,8 @@ info('The json is %j', { a: 1, b: '2' });
 info('The object is %O', { a: 1, b: '2' });
 info('The answer is %d and the question is %s with %o', 42, 'unknown', { correct: 'order' });
 info('Missing placeholder is fine %s');
+declare const errorOrString: string | Error;
+info(errorOrString)
 
 // placeholder messages type errors
 expectError(info('Hello %s', 123));

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -10,10 +10,53 @@ const error = log.error;
 
 info("hello world");
 error("this is at error level");
-info("the answer is %d", 42);
+
+// primative types
+info('simple string');
+info(true)
+info(42);
+info(3.14);
+info(null);
+info(undefined);
+
+// object types
+info({ a: 1, b: '2' });
+info(new Error());
+info(new Date());
+info([])
+info(new Map());
+info(new Set());
+
+// template messages
+info('Hello %s', 'world');
+info('The answer is %d', 42);
+info('The object is %o', { a: 1, b: '2' });
+info('The json is %j', { a: 1, b: '2' });
+info('The object is %O', { a: 1, b: '2' });
+info('The answer is %d and the question is %s with %o', 42, 'unknown', { correct: 'order' });
+
+// template messages type errors
+expectError(info('Hello %s', 123));
+expectError(info('Hello %s', false));
+expectError(info('The answer is %d', 'not a number'));
+expectError(info('The object is %o', 'not an object'));
+expectError(info('The object is %j', 'not a JSON'));
+expectError(info('The object is %O', 'not an object'));
+expectError(info('The answer is %d and the question is %s with %o', 42, { incorrect: 'order' }, 'unknown'));
+
+
+// object types with messages
 info({ obj: 42 }, "hello world");
 info({ obj: 42, b: 2 }, "hello world");
 info({ obj: { aa: "bbb" } }, "another");
+info({ a: 1, b: '2' }, 'hello world with %s', 'extra data');
+
+// metadata with messages type errors
+expectError(info({ a: 1, b: '2' }, 'hello world with %s', 123));
+
+// multiple strings without template
+expectError(info('string1', 'string2', 'string3'));
+
 setImmediate(info, "after setImmediate");
 error(new Error("an error"));
 

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -27,16 +27,16 @@ info([])
 info(new Map());
 info(new Set());
 
-// template messages
+// placeholder messages
 info('Hello %s', 'world');
 info('The answer is %d', 42);
 info('The object is %o', { a: 1, b: '2' });
 info('The json is %j', { a: 1, b: '2' });
 info('The object is %O', { a: 1, b: '2' });
 info('The answer is %d and the question is %s with %o', 42, 'unknown', { correct: 'order' });
-info('Missing template is fine %s');
+info('Missing placeholder is fine %s');
 
-// template messages type errors
+// placeholder messages type errors
 expectError(info('Hello %s', 123));
 expectError(info('Hello %s', false));
 expectError(info('The answer is %d', 'not a number'));
@@ -44,7 +44,7 @@ expectError(info('The object is %o', 'not an object'));
 expectError(info('The object is %j', 'not a JSON'));
 expectError(info('The object is %O', 'not an object'));
 expectError(info('The answer is %d and the question is %s with %o', 42, { incorrect: 'order' }, 'unknown'));
-expectError(info('Extra message %s', 'after template', 'not allowed'));
+expectError(info('Extra message %s', 'after placeholder', 'not allowed'));
 
 // object types with messages
 info({ obj: 42 }, "hello world");
@@ -52,7 +52,7 @@ info({ obj: 42, b: 2 }, "hello world");
 info({ obj: { aa: "bbb" } }, "another");
 info({ a: 1, b: '2' }, 'hello world with %s', 'extra data');
 
-// Extra message after template
+// Extra message after placeholder
 expectError(info({ a: 1, b: '2' }, 'hello world with %d', 2, 'extra' ));
 
 // metadata with messages type errors
@@ -61,7 +61,7 @@ expectError(info({ a: 1, b: '2' }, 'hello world with %s', 123));
 // metadata after message
 expectError(info('message', { a: 1, b: '2' }));
 
-// multiple strings without template
+// multiple strings without placeholder
 expectError(info('string1', 'string2'));
 expectError(info('string1', 'string2', 'string3'));
 

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -34,6 +34,7 @@ info('The object is %o', { a: 1, b: '2' });
 info('The json is %j', { a: 1, b: '2' });
 info('The object is %O', { a: 1, b: '2' });
 info('The answer is %d and the question is %s with %o', 42, 'unknown', { correct: 'order' });
+info('Missing template is fine %s');
 
 // template messages type errors
 expectError(info('Hello %s', 123));
@@ -43,12 +44,16 @@ expectError(info('The object is %o', 'not an object'));
 expectError(info('The object is %j', 'not a JSON'));
 expectError(info('The object is %O', 'not an object'));
 expectError(info('The answer is %d and the question is %s with %o', 42, { incorrect: 'order' }, 'unknown'));
+expectError(info('Extra message %s', 'after template', 'not allowed'));
 
 // object types with messages
 info({ obj: 42 }, "hello world");
 info({ obj: 42, b: 2 }, "hello world");
 info({ obj: { aa: "bbb" } }, "another");
 info({ a: 1, b: '2' }, 'hello world with %s', 'extra data');
+
+// Extra message after template
+expectError(info({ a: 1, b: '2' }, 'hello world with %d', 2, 'extra' ));
 
 // metadata with messages type errors
 expectError(info({ a: 1, b: '2' }, 'hello world with %s', 123));
@@ -57,6 +62,7 @@ expectError(info({ a: 1, b: '2' }, 'hello world with %s', 123));
 expectError(info('message', { a: 1, b: '2' }));
 
 // multiple strings without template
+expectError(info('string1', 'string2'));
 expectError(info('string1', 'string2', 'string3'));
 
 setImmediate(info, "after setImmediate");


### PR DESCRIPTION
An even bigger upgrade to https://github.com/pinojs/pino/pull/1995

This prevents metadata objects from being provided after a message and also guarantees type safety when you are using string templates.