### PR TITLE
feat: introduce `logger.msgPrefix` getter

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,6 +22,7 @@
   * [logger\[Symbol.for('pino.serializers')\]](#serializers)
   * [Event: 'level-change'](#level-change)
   * [logger.version](#version)
+  * [logger.msgPrefix](#msgPrefix)
 * [Statics](#statics)
   * [pino.destination()](#pino-destination)
   * [pino.transport()](#pino-transport)
@@ -943,6 +944,7 @@ const child = logger.child({foo: 'bar'}, {level: 'debug'})
 child.debug('debug!') // will log as the `level` property set the level to debug
 ```
 
+<a id="options-msgPrefix"></a>
 ##### `options.msgPrefix` (String)
 
 Default: `undefined`
@@ -1173,6 +1175,13 @@ logger.level = 'trace' // trigger event using actual value change, notice consol
 Exposes the Pino package version. Also available on the exported `pino` function.
 
 * See [`pino.version`](#pino-version)
+
+<a id="msgPrefix"></a>
+### `logger.msgPrefix` (String|Undefined)
+
+Exposes the cumulative `msgPrefix` of the logger.
+
+* See [`options.msgPrefix`](#options-msgPrefix)
 
 ## Statics
 

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -65,6 +65,7 @@ const prototype = {
   set level (lvl) { this[setLevelSym](lvl) },
   get levelVal () { return this[levelValSym] },
   set levelVal (n) { throw Error('levelVal is read-only') },
+  get msgPrefix () { return this[msgPrefixSym] },
   [lsCacheSym]: initialLsCache,
   [writeSym]: write,
   [asJsonSym]: asJson,

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -219,6 +219,13 @@ declare namespace pino {
          * Noop function.
          */
         silent: pino.LogFn;
+
+        /**
+         * Get `msgPrefix` of the logger instance.
+         *
+         * See {@link https://github.com/pinojs/pino/blob/main/docs/api.md#msgprefix-string}.
+         */
+        get msgPrefix(): string | undefined;
     }
 
     type Bindings = Record<string, any>;

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -807,6 +807,7 @@ test('logger message should have the prefix message that defined in the logger c
   const logger = pino({
     msgPrefix: 'My name is Bond '
   }, stream)
+  equal(logger.msgPrefix, 'My name is Bond ')
   logger.info('James Bond')
   const { msg } = await once(stream, 'data')
   equal(msg, 'My name is Bond James Bond')
@@ -848,6 +849,7 @@ test('child message should append parent prefix to current prefix that defined i
   }, stream)
   const child = instance.child({}, { msgPrefix: 'James ' })
   child.info('Bond')
+  equal(child.msgPrefix, 'My name is Bond James ')
   const { msg } = await once(stream, 'data')
   equal(msg, 'My name is Bond James Bond')
 })

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -300,7 +300,8 @@ const customBaseLogger: CustomBaseLogger = {
   debug() {},
   trace() {},
   silent() {},
-  child() { return this }
+  child() { return this },
+  msgPrefix: 'prefix',
 }
 
 // custom levels


### PR DESCRIPTION
When creating a logger or a child logger API allows providing `msgPrefix` string that gets appended to every formatted log line. However, there is no way to get this string from existing logger instance which makes it inaccessible from within the `hooks.logMethod`.

This commit adds the getter method and types for `logger.msgPrefix`.

cc @mcollina 