### PR TITLE
Fix typo in bench-long-string script name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bench-object": "node benchmarks/utils/runbench object",
     "bench-deep-object": "node benchmarks/utils/runbench deep-object",
     "bench-multi-arg": "node benchmarks/utils/runbench multi-arg",
-    "bench-longs-tring": "node benchmarks/utils/runbench long-string",
+    "bench-long-string": "node benchmarks/utils/runbench long-string",
     "bench-child": "node benchmarks/utils/runbench child",
     "bench-child-child": "node benchmarks/utils/runbench child-child",
     "bench-child-creation": "node benchmarks/utils/runbench child-creation",


### PR DESCRIPTION
## Description

Corrects a typo in the npm script name for the long-string benchmark in `package.json`.

## Changes

- Fixed `"bench-longs-tring"` → `"bench-long-string"` in package.json scripts section

## Testing

- ✅ All existing tests pass
- ✅ Fixed benchmark script now runs successfully: `npm run bench-long-string`
- ✅ Linting passes
- ✅ No breaking changes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A for this change)
- [x] I have made corresponding changes to the documentation (N/A for this change)  
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (N/A - script name fix)
- [x] New and existing unit tests pass locally with my changes