### PR TITLE
fix: remove trailing comma in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "commonjs",
     "noEmit": true,
     "strict": true,
-    "esModuleInterop": true,
+    "esModuleInterop": true
   },
   "exclude": [
     "./test/types/*.test-d.ts",


### PR DESCRIPTION
# Fix: Remove trailing comma in tsconfig.json

Removes a trailing comma from the `esModuleInterop` property in tsconfig.json to ensure valid JSON syntax.

## Changes
- Fixed trailing comma after `"esModuleInterop": true,` → `"esModuleInterop": true` in tsconfig.json

## Testing
✅ All existing tests pass  
✅ TypeScript configuration is now syntactically correct  
✅ Linting passes  
✅ No breaking changes  

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature  
- [ ] Breaking change  
- [ ] Documentation update  

## Checklist
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [x] I have commented my code, particularly in hard-to-understand areas (N/A for this change)  
- [x] I have made corresponding changes to the documentation (N/A for this change)  
- [x] My changes generate no new warnings  
- [x] I have added tests that prove my fix is effective (N/A - syntax fix)  
- [x] New and existing unit tests pass locally with my changes  

---

This PR addresses a minor JSON syntax issue that ensures the tsconfig.json file follows proper JSON formatting standards by removing an unnecessary trailing comma. 