### PR TITLE
Fix missing asObjectBindingsOnly type from browser config

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -33,7 +33,7 @@ When `write` is set, `asObject` will always be `true`.
 const pino = require('pino')({browser: {asObjectBindingsOnly: true}})
 ```
 
-The `asObjectBindingsOnly` is similar to `asObject` but will keep the message
+The `asObjectBindingsOnly` option is similar to `asObject` but will keep the message
 and arguments unformatted. This allows to defer formatting the message to the
 actual call to `console` methods, where browsers then have richer formatting in
 their devtools than when pino will format the message to a string first.

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -34,9 +34,9 @@ const pino = require('pino')({browser: {asObjectBindingsOnly: true}})
 ```
 
 The `asObjectBindingsOnly` is similar to `asObject` but will keep the message
-and arguments unformatted, this allows to defer formatting the message to the
+and arguments unformatted. This allows to defer formatting the message to the
 actual call to `console` methods, where browsers then have richer formatting in
-their devtools then when pino will format the message to a string first.
+their devtools than when pino will format the message to a string first.
 
 ```js
 pino.info('hello %s', 'world') // creates and logs {level: 30, time: <ts>}, 'hello %s', 'world'

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -451,6 +451,16 @@ declare namespace pino {
              * pino.info('hi') // creates and logs {msg: 'hi', level: 30, time: <ts>}
              */
             asObject?: boolean;
+            /**
+             * The `asObjectBindingsOnly` option is similar to `asObject` but will keep the message and arguments
+             * unformatted. This allows to defer formatting the message to the actual call to console methods,
+             * where browsers then have richer formatting in their devtools than when pino will format the message to
+             * a string first.
+             *
+             * @example
+             * pino.info('hello %s', 'world') // creates and logs {level: 30, time: <ts>}, 'hello %s', 'world'
+             */
+            asObjectBindingsOnly?: boolean;
             formatters?: {
                 /**
                  * Changes the shape of the log level.

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -453,7 +453,7 @@ declare namespace pino {
             asObject?: boolean;
             /**
              * The `asObjectBindingsOnly` option is similar to `asObject` but will keep the message and arguments
-             * unformatted. This allows to defer formatting the message to the actual call to console methods,
+             * unformatted. This allows to defer formatting the message to the actual call to `console` methods,
              * where browsers then have richer formatting in their devtools than when pino will format the message to
              * a string first.
              *

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -160,6 +160,12 @@ pino({
     },
 });
 
+pino({
+  browser: {
+    asObjectBindingsOnly: true,
+  }
+});
+
 pino({}, undefined);
 
 pino({ base: null });


### PR DESCRIPTION
Fixes https://github.com/pinojs/pino/issues/2234

Updates the docs for grammatical readability. Then uses the same update in the docstring for the change. 