### PR TITLE
chore: remove benchmark as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "@types/tap": "^15.0.6",
     "@yao-pkg/pkg": "6.3.0",
     "airtap": "5.0.0",
-    "benchmark": "^2.1.4",
     "bole": "^5.0.5",
     "bunyan": "^1.8.14",
     "debug": "^4.3.4",


### PR DESCRIPTION
We use fastbench and not benchmark as benchmark engine