### PR TITLE
docs: link hono integration to homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For using Pino with a web framework see:
 * [Pino with Koa](docs/web.md#koa)
 * [Pino with Node core `http`](docs/web.md#http)
 * [Pino with Nest](docs/web.md#nest)
-
+* [Pino with Hono](docs/web.md#hono)
 
 <a name="essentials"></a>
 ## Essentials

--- a/docs/web.md
+++ b/docs/web.md
@@ -270,7 +270,7 @@ Execute `npx --yes listhen -w --open ./server.mjs`.
 See the [pino-http README](https://npm.im/pino-http) for more info.
 
 
-<a id="h3"></a>
+<a id="hono"></a>
 ## Pino with Hono
 
 ```sh


### PR DESCRIPTION
# Docs: Link Hono integration to homepage
Links to the [Hono integration](https://getpino.io/#/docs/web?id=pino-with-hono) from the [homepage](https://getpino.io/#/)

# Changes
- Add link to Hono integration in `README.md`
- Fix ID of Hono integration section in `docs/web.md`

# Type of Change
Documentation update

# Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas (N/A - documentation change)
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective (N/A - documentation change)
- [X] New and existing unit tests pass locally with my changes