### PR TITLE
feat(types): add LogFnFields

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -37,6 +37,9 @@
   * [DestinationStream](#destinationstream)
 * [Types](#types)
   * [Level](#level-1)
+* [TypeScript](#typescript)
+  * [Module Augmentation](#module-augmentation)
+  * [LogFnFields Interface](#logfnfields-interface)
 
 <a id="export"></a>
 ## `pino([options], [destination]) => logger`
@@ -1497,3 +1500,79 @@ Exposes the Pino package version. Also available on the logger instance.
 ### `Level`
 
   * Values: `"fatal"` | `"error"` | `"warn"` | `"info"` | `"debug"` | `"trace"`
+
+## TypeScript
+
+### Module Augmentation
+
+Pino supports TypeScript module augmentation to extend its type definitions. This allows you to customize the logging behavior to fit your application's specific requirements.
+
+#### `LogFnFields` Interface
+
+The `LogFnFields` interface can be augmented to control what fields are allowed in logging method objects. This is particularly useful for:
+
+- Preventing certain fields from being logged (for security or compliance reasons)
+- Enforcing specific field types across your application
+- Enforcing consistent structured logging
+
+##### Banning Fields
+
+You can ban specific fields from being passed to logging methods by setting them to `never`. This can be useful to prevent users from unintentionally overriding fields set in the logger's `base` option.
+
+```typescript
+declare module "pino" {
+  interface LogFnFields {
+    service?: never;
+    version?: never;
+  }
+}
+
+
+// These will now cause TypeScript errors
+logger.info({ service: 'other-api', message: 'success' })   // ❌
+logger.info({ message: 'success' })     // ✅
+```
+
+##### Enforcing Field Types
+
+You can also enforce specific types for certain fields:
+
+```typescript
+declare module "pino" {
+  interface LogFnFields {
+    userId?: string;
+    requestId?: string;
+    timestamp?: number;
+  }
+}
+
+// These will cause TypeScript errors
+logger.info({ userId: 123 })           // ❌ Error: userId must be string
+logger.info({ requestId: null })       // ❌ Error: requestId must be string
+
+// This works fine
+logger.info({ userId: 'user123' })     // ✅ Works fine
+```
+
+##### Enforcing Structured Logging
+
+Required fields (non-optional) enforce consistent structured logging by requiring specific fields in all log objects:
+
+```typescript
+declare module "pino" {
+  interface LogFnFields {
+    userId: string
+  }
+}
+
+logger.info({ userId: 'user123' }) // ✅ Works fine
+logger.info({}) // ❌ Property 'userId' is missing in type '{}'
+```
+
+**Note**: Required fields will cause TypeScript errors when logging certain types like `Error` objects that don't contain the required properties:
+
+```typescript
+logger.error(new Error('test')) // ❌ Property 'userId' is missing in type 'Error'
+```
+
+This ensures that all log entries include required context fields, promoting consistent logging practices.

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -344,8 +344,10 @@ declare namespace pino {
             : ParseLogFnArgs<Rest, Acc>
         : Acc;
 
+    interface LogFnFields {}
+
     interface LogFn {
-        <T, TMsg extends string = string>(obj: T, msg?: T extends string ? never: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
+        <T, TMsg extends string = string>(obj: T extends object ? T & LogFnFields : T, msg?: T extends string ? never: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
         <_, TMsg extends string = string>(msg: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
     }
 

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -527,3 +527,15 @@ expectError(loggerWithCustomLevelOnly.error('test'));
 expectError(loggerWithCustomLevelOnly.warn('test'));
 expectError(loggerWithCustomLevelOnly.debug('test'));
 expectError(loggerWithCustomLevelOnly.trace('test'));
+
+// Module extension
+declare module "../../" {
+    interface LogFnFields {
+        bannedField?: never;
+        typeCheckedField?: string
+    }
+}
+
+info({typeCheckedField: 'bar'})
+expectError(info({bannedField: 'bar'}))
+expectError(info({typeCheckedField: 123}))


### PR DESCRIPTION
Hello, we recently went down a little bit of a rabbit hole with wanting to enforce some typing on the logging function.

This feature adds the ability for us to add some global types to the logger functions.

This came about because we had some internal configuration where we wanted to add some typing to.

We have the ability to set our `retention` days by adding it to our log

eg.

```ts
logger.info({ logOptions: { retention: 90 }, err }, 'Something failed');
```

But we wanted `logOptions` to be properly typed without relying on users setting an overload everytime.

eg.

```ts
logger.info<LoggerOptions>({ logOptions: { retention: 90 }, err }, 'Something failed');
```

So I came up with introducing a module type augmentation which would allow us to set a single module augmentation:

```ts
declare module "pino" {
  interface LogFnFields {
    logOptions?: {
      retention: 30 | 60 | 90
    },
    logoptions?: never,
  }
}
```
