### PR TITLE
fix(typescript): resolve TS2595 import error by updating config

### DIFF
--- a/test/transport/module-link.test.js
+++ b/test/transport/module-link.test.js
@@ -121,7 +121,7 @@ test('pino({ transport })', { skip: isWin || isYarnPnp }, async ({ same, teardow
   const toRun = join(folder, 'index.js')
 
   const toRunContent = `
-    const pino = require('pino')
+    const pino = require('pino').default
     const logger = pino({
       transport: {
         target: 'transport',
@@ -198,7 +198,7 @@ test('pino({ transport }) from a wrapped dependency', { skip: isWin || isYarnPnp
   const wrapped = join(wrappedFolder, 'index.js')
 
   const wrappedContent = `
-    const pino = require('pino')
+    const pino = require('pino').default
     const getCaller = require('get-caller-file')
 
     module.exports = function build () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,14 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "lib": [ "es2015", "dom" ],
+    "lib": ["es2015", "dom"],
     "module": "commonjs",
+    "moduleResolution": "node",
     "noEmit": true,
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true
   },
   "exclude": [
     "./test/types/*.test-d.ts",


### PR DESCRIPTION
 Description
Fixes TypeScript error TS2595 when importing Pino in TypeScript projects by:
1. Adding proper TypeScript configuration options in [tsconfig.json](cci:7://file:///Users/tawseefbhat/Desktop/code/pino/tsconfig.json:0:0-0:0)
2. Updating test files to use correct import syntax

Fixes #2255