### PR TITLE
Avoid setLevel in child when possible

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -147,8 +147,10 @@ function child (bindings, options) {
   }
 
   instance[chindingsSym] = asChindings(instance, bindings)
-  const childLevel = options.level || this.level
-  instance[setLevelSym](childLevel)
+  if ((options.level !== undefined && options.level !== this.level) || options.hasOwnProperty('customLevels')) {
+    const childLevel = options.level || this.level
+    instance[setLevelSym](childLevel)
+  }
   this.onChild(instance)
   return instance
 }


### PR DESCRIPTION
```
➜  pino git:(avoid-set-level) node benchmarks/child-creation.bench.js
benchBunyanCreation*10000: 179.387ms
benchBoleCreation*10000: 110.908ms
benchPinoCreation*10000: 95.213ms
benchPinoMinLengthCreation*10000: 145.782ms
benchPinoNodeStreamCreation*10000: 106.669ms
benchPinoCreationWithOption*10000: 97.398ms
benchBunyanCreation*10000: 171.922ms
benchBoleCreation*10000: 107.137ms
benchPinoCreation*10000: 89.508ms
benchPinoMinLengthCreation*10000: 142.082ms
benchPinoNodeStreamCreation*10000: 105.554ms
benchPinoCreationWithOption*10000: 87.491ms
➜  pino git:(avoid-set-level) git checkout main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
➜  pino git:(main) node benchmarks/child-creation.bench.js
benchBunyanCreation*10000: 183.198ms
benchBoleCreation*10000: 111.747ms
benchPinoCreation*10000: 95.134ms
benchPinoMinLengthCreation*10000: 145.248ms
benchPinoNodeStreamCreation*10000: 121.929ms
benchPinoCreationWithOption*10000: 117.167ms
benchBunyanCreation*10000: 188.406ms
benchBoleCreation*10000: 109.969ms
benchPinoCreation*10000: 99.403ms
benchPinoMinLengthCreation*10000: 145.222ms
benchPinoNodeStreamCreation*10000: 106.462ms
benchPinoCreationWithOption*10000: 101.245ms
```