### PR TITLE
fix(types): compatibility when leveraging parameters

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -341,17 +341,8 @@ declare namespace pino {
         : Acc;
 
     export interface LogFn {
-        <TMsg extends string = string>(
-            msg: TMsg, 
-            ...args: ParseLogFnArgs<TMsg>
-        ): void;
-        <T, TMsg extends string = string>(
-            obj: T, 
-            msg?: T extends string ? never : TMsg, 
-            ...args: ParseLogFnArgs<TMsg> extends [any, ...any[]]
-                ? ParseLogFnArgs<TMsg>
-                : any[]
-        ): void;
+        <TMsg extends string = string>(msg: TMsg, ...args: ParseLogFnArgs<TMsg>): void;
+        <T, TMsg extends string = string>(obj: T, msg?: T extends string ? never : TMsg, ...args: ParseLogFnArgs<TMsg> extends [any, ...any[]] ? ParseLogFnArgs<TMsg> : any[]): void;
     }
 
     export interface LoggerOptions<CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean> {

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -340,9 +340,21 @@ declare namespace pino {
             : ParseLogFnArgs<Rest, Acc>
         : Acc;
 
+    type Args<TMsg extends string> = 
+    ParseLogFnArgs<TMsg> extends [any, ...any[]]
+        ? ParseLogFnArgs<TMsg>
+        : any[];
+
     export interface LogFn {
-        <T, TMsg extends string = string>(obj: T, msg?: T extends string ? never: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
-        <_, TMsg extends string = string>(msg: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
+        <T, TMsg extends string = string>(
+            obj: T, 
+            msg?: T extends string ? never : TMsg, 
+            ...args: Args<TMsg>
+        ): void;
+        <TMsg extends string = string>(
+            msg: TMsg, 
+            ...args: Args<TMsg>
+        ): void;
     }
 
     export interface LoggerOptions<CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean> {

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -340,20 +340,17 @@ declare namespace pino {
             : ParseLogFnArgs<Rest, Acc>
         : Acc;
 
-    type Args<TMsg extends string> = 
-    ParseLogFnArgs<TMsg> extends [any, ...any[]]
-        ? ParseLogFnArgs<TMsg>
-        : any[];
-
     export interface LogFn {
+        <TMsg extends string = string>(
+            msg: TMsg, 
+            ...args: ParseLogFnArgs<TMsg>
+        ): void;
         <T, TMsg extends string = string>(
             obj: T, 
             msg?: T extends string ? never : TMsg, 
-            ...args: Args<TMsg>
-        ): void;
-        <TMsg extends string = string>(
-            msg: TMsg, 
-            ...args: Args<TMsg>
+            ...args: ParseLogFnArgs<TMsg> extends [any, ...any[]]
+                ? ParseLogFnArgs<TMsg>
+                : any[]
         ): void;
     }
 

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -74,11 +74,11 @@ expectError(info({ a: 1, b: '2' }, 'hello world with %d', 2, 'extra' ));
 expectError(info({ a: 1, b: '2' }, 'hello world with %s', {}));
 
 // metadata after message
-// expectError(info('message', { a: 1, b: '2' }));
+expectError(info('message', { a: 1, b: '2' }));
 
 // multiple strings without placeholder
-// expectError(info('string1', 'string2'));
-// expectError(info('string1', 'string2', 'string3'));
+expectError(info('string1', 'string2'));
+expectError(info('string1', 'string2', 'string3'));
 
 setImmediate(info, "after setImmediate");
 error(new Error("an error"));
@@ -473,7 +473,7 @@ const bLogger = pino({
 
 // I should be able to properly extract parameters from the log fn type
 type LogParam = Parameters<LogFn>
-const _: LogParam = ['multiple', 'params', 'should', 'be', 'accepted']
+const _: LogParam = [{ multiple: 'params' }, 'params', 'should', 'be', 'accepted']
 
 expectType<Logger<'log'>>(pino({
   customLevels: {

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage, ServerResponse } from "http";
 import { Socket } from "net";
 import { expectError, expectType } from 'tsd';
-import pino, { LoggerOptions } from "../../";
+import pino, { LogFn, LoggerOptions } from "../../";
 import Logger = pino.Logger;
 
 const log = pino();
@@ -74,11 +74,11 @@ expectError(info({ a: 1, b: '2' }, 'hello world with %d', 2, 'extra' ));
 expectError(info({ a: 1, b: '2' }, 'hello world with %s', {}));
 
 // metadata after message
-expectError(info('message', { a: 1, b: '2' }));
+// expectError(info('message', { a: 1, b: '2' }));
 
 // multiple strings without placeholder
-expectError(info('string1', 'string2'));
-expectError(info('string1', 'string2', 'string3'));
+// expectError(info('string1', 'string2'));
+// expectError(info('string1', 'string2', 'string3'));
 
 setImmediate(info, "after setImmediate");
 error(new Error("an error"));
@@ -470,6 +470,10 @@ const bLogger = pino({
     },
   },
 });
+
+// I should be able to properly extract parameters from the log fn type
+type LogParam = Parameters<LogFn>
+const _: LogParam = ['multiple', 'params', 'should', 'be', 'accepted']
 
 expectType<Logger<'log'>>(pino({
   customLevels: {

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -474,7 +474,7 @@ const bLogger = pino({
 
 // Test that we can properly extract parameters from the log fn type
 type LogParam = Parameters<LogFn>
-const _: LogParam = [{ multiple: 'params' }, 'params', 'should', 'be', 'accepted']
+const _: LogParam = [{ multiple: 'params' }, 'should', 'be', 'accepted']
 
 const logger = mock.fn<LogFn>()
 logger.mock.calls[0].arguments[1]?.includes('I should be able to get params')


### PR DESCRIPTION
When using features like `logMethod`, there is no longer compatibility with the previous versions of `pino`:
```ts
logMethod?: (this: Logger, args: Parameters<LogFn>, method: LogFn, level: number) => void;
```
As you can see here, when we extract the `Parameters`, the type is wrong:
<img width="1090" height="228" alt="image" src="https://github.com/user-attachments/assets/774b0380-6705-4275-ad6f-7c820c48201b" />

While previously:
<img width="1054" height="221" alt="image" src="https://github.com/user-attachments/assets/f214be9e-00d6-4427-8278-4fddb7f12c4b" />

This PR should be considered more of a hotfix, since it will restore compatibility to its previous state, thereby avoiding issues like [this one](https://github.com/pinojs/pino/issues/2259). 👍🏼 

This is the current result, compared with previous versions:
<img width="1153" height="155" alt="image" src="https://github.com/user-attachments/assets/3d63d938-8dcb-4d64-ade1-3dcd6f7c3b80" />
