### PR TITLE
fix(logfn): use unknown type

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -342,7 +342,7 @@ declare namespace pino {
 
     export interface LogFn {
         <TMsg extends string = string>(msg: TMsg, ...args: ParseLogFnArgs<TMsg>): void;
-        <T, TMsg extends string = string>(obj: T, msg?: T extends string ? never : TMsg, ...args: ParseLogFnArgs<TMsg> extends [any, ...any[]] ? ParseLogFnArgs<TMsg> : any[]): void;
+        <T, TMsg extends string = string>(obj: T, msg?: T extends string ? never : TMsg, ...args: ParseLogFnArgs<TMsg> extends [unknown, ...unknown[]] ? ParseLogFnArgs<TMsg> : unknown[]): void;
     }
 
     export interface LoggerOptions<CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean> {

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -474,7 +474,12 @@ const bLogger = pino({
 
 // Test that we can properly extract parameters from the log fn type
 type LogParam = Parameters<LogFn>
-const _: LogParam = [{ multiple: 'params' }, 'should', 'be', 'accepted']
+const [param1, param2, param3, param4]: LogParam = [{ multiple: 'params' }, 'should', 'be', 'accepted']
+
+expectType<unknown>(param1)
+expectType<string>(param2)
+expectType<unknown>(param3)
+expectType<unknown>(param4)
 
 const logger = mock.fn<LogFn>()
 logger.mock.calls[0].arguments[1]?.includes('I should be able to get params')


### PR DESCRIPTION
Prefer `unknown` over `any` on previous [hotfix](https://github.com/pinojs/pino/commit/47ac3805b2663e3b68f6f57fecfd745b2b05474c)