### PR TITLE
fix: allow object type in %s placeholder

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -326,7 +326,7 @@ declare namespace pino {
     type PlaceholderTypeMapping<T extends PlaceholderSpecifier> = T extends 'd'
         ? number
         : T extends 's'
-            ? string | number | boolean | bigint | null | undefined | symbol | object
+            ? unknown
             : T extends 'j' | 'o' | 'O'
             ? object
             : never;

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -326,7 +326,7 @@ declare namespace pino {
     type PlaceholderTypeMapping<T extends PlaceholderSpecifier> = T extends 'd'
         ? number
         : T extends 's'
-            ? string | number | boolean | bigint | null | undefined | symbol
+            ? string | number | boolean | bigint | null | undefined | symbol | object
             : T extends 'j' | 'o' | 'O'
             ? object
             : never;

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -71,8 +71,9 @@ info({ a: 1, b: '2' }, 'hello world with %s', 'extra data');
 // Extra message after placeholder
 expectError(info({ a: 1, b: '2' }, 'hello world with %d', 2, 'extra' ));
 
-// metadata with messages type errors
-expectError(info({ a: 1, b: '2' }, 'hello world with %s', {}));
+// metadata with messages type passes, because of custom toString method
+// We can't detect if the object has a custom toString method that returns a string
+info({ a: 1, b: '2' }, 'hello world with %s', {});
 
 // metadata after message
 expectError(info('message', { a: 1, b: '2' }));


### PR DESCRIPTION
Allows objects in %s placeholder type mapping.

Fixes #2266 