### PR TITLE
Add support for `Pear` and `Bare` runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Pino works on [Bare](https://github.com/holepunchto/bare) with the [`pino-bare`]
 
 ### Pear
 
-Pino works on [Pear](https://docs.pears.com), which is built on [Bare](https://github.com/holepunchto/bare), with the [`pino-bare`](https://github.com/pinojs/pino-bare) compatability module.
+Pino works on [Pear](https://docs.pears.com), which is built on [Bare](https://github.com/holepunchto/bare), with the [`pino-bare`](https://github.com/pinojs/pino-bare) compatibility module.
 
 
 ## Install


### PR DESCRIPTION
Hello, this PR adds out-of-box support for [Bare](https://github.com/holepunchto/bare) JavaScript runtime and therefore [Pear](https://github.com/holepunchto/pear) runtime also.

A [subpath import](https://nodejs.org/docs/latest/api/packages.html#subpath-imports) field was added in the `package.json`; it is a map that covers every built-in Node.js module that is used internally by Pino and happens to not be provided by default by `Bare`. A intuitive case is the global variable `process` which requires an extra step to be available.

`{ with: { imports: './package.json' } }` is a feature from `Bare` module resolution that dynamically applies the declared `subpath imports`. When executing Pino in Node.js, the `{ with: { imports: './package.json' } }` is ignored by the Node.js module resolution, resulting in no performance impacts.

A unit test was added to ensure that the basic usage works as intended in `Bare`. I would like to follow the pattern and use `tap` as the other test files do, but for that, it will be needed some additional work to add `Bare` portability to `tap` and its dependencies as well. So I used the already `Bare`-friendly test framework [Brittle](https://github.com/holepunchto/brittle) for this particular case.

Open to suggestions and thanks!