### PR TITLE
Add tracing channels

### DIFF
--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const diagChan = require('node:diagnostics_channel')
+
+module.exports = {
+  asJsonChan: diagChan.tracingChannel('pino_asJson')
+}

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -24,6 +24,7 @@ const {
   nestedKeyStrSym,
   msgPrefixSym
 } = require('./symbols')
+const { asJsonChan } = require('./diagnostics')
 const { isMainThread } = require('worker_threads')
 const transport = require('./transport')
 
@@ -104,6 +105,7 @@ function asString (str) {
 }
 
 function asJson (obj, msg, num, time) {
+  asJsonChan.start.publish({ arguments })
   const stringify = this[stringifySym]
   const stringifySafe = this[stringifySafeSym]
   const stringifiers = this[stringifiersSym]
@@ -189,13 +191,16 @@ function asJson (obj, msg, num, time) {
     }
   }
 
+  let finalized = ''
   if (this[nestedKeySym] && propStr) {
     // place all the obj properties under the specified key
     // the nested key is already formatted from the constructor
-    return data + this[nestedKeyStrSym] + propStr.slice(1) + '}' + msgStr + end
+    finalized = data + this[nestedKeyStrSym] + propStr.slice(1) + '}' + msgStr + end
   } else {
-    return data + propStr + msgStr + end
+    finalized = data + propStr + msgStr + end
   }
+  asJsonChan.end.publish({ arguments, line: finalized })
+  return finalized
 }
 
 function asChindings (instance, bindings) {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
   "homepage": "https://getpino.io",
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.1",
+    "@matteo.collina/tspl": "^0.2.0",
     "@types/flush-write-stream": "^1.0.0",
     "@types/node": "^24.0.8",
     "@types/tap": "^15.0.6",

--- a/pino.js
+++ b/pino.js
@@ -223,6 +223,8 @@ module.exports.destination = (dest = process.stdout.fd) => {
 module.exports.transport = require('./lib/transport')
 module.exports.multistream = require('./lib/multistream')
 
+module.exports.diagnosticsChannels = require('./lib/diagnostics')
+
 module.exports.levels = mappings()
 module.exports.stdSerializers = serializers
 module.exports.stdTimeFunctions = Object.assign({}, time)

--- a/test/diagnostics.test.js
+++ b/test/diagnostics.test.js
@@ -1,0 +1,57 @@
+'use strict'
+
+const test = require('node:test')
+const os = require('node:os')
+const { Writable } = require('node:stream')
+const tspl = require('@matteo.collina/tspl')
+const pino = require('../pino')
+
+const hostname = os.hostname()
+const { pid } = process
+
+test.beforeEach(ctx => {
+  ctx.pino = {
+    ts: 1757512800000, // 2025-09-10T10:00:00.000-05:00
+    now: Date.now
+  }
+
+  Date.now = () => ctx.pino.ts
+})
+
+test.afterEach(ctx => {
+  Date.now = ctx.pino.now
+})
+
+test('asJson emits events', async (t) => {
+  const plan = tspl(t, { plan: 3 })
+  const dest = new Writable({
+    objectMode: true,
+    write (data, enc, cb) {
+      cb()
+    }
+  })
+  const expectedArguments = [
+    {},
+    'testing',
+    30,
+    `,"time":${t.pino.ts}`
+  ]
+
+  pino.diagnosticsChannels.asJsonChan.subscribe({
+    start (event) {
+      plan.deepStrictEqual(Array.from(event.arguments ?? []), expectedArguments)
+    },
+
+    end (event) {
+      plan.deepStrictEqual(Array.from(event.arguments ?? []), expectedArguments)
+      plan.equal(
+        event.line,
+        `{"level":30,"time":${t.pino.ts},"pid":${pid},"hostname":"${hostname}","msg":"testing"}\n`
+      )
+    }
+  })
+
+  const logger = pino({}, dest)
+  logger.info('testing')
+  await plan
+})


### PR DESCRIPTION
This PR adds a tracing channel for the `asJson` function. APM tools can utilize this channel for their tracing needs. At New Relic, this is the only channel we need. Other vendors may like a bit more, so I'm tagging them here to get their input.

I'm opening this in draft mode while the feedback is collected. Once we have "yeah, this is good" from enough people, I will add documentation and convert the PR to ready.

attn: @AbhiPrasad @bengl @bizob2828 @timfish