### PR TITLE
fix: gracefully handle missing diagChannel.tracingChannel on Node < 18.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
-        node-version: [18, 20, 22]
+        node-version: [18, '18.18', 20, 22]
         exclude:
           - os: windows-latest
             node-version: 22

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -28,7 +28,19 @@ const {
 const { isMainThread } = require('worker_threads')
 const transport = require('./transport')
 
-const asJsonChan = diagChan.tracingChannel('pino_asJson')
+let asJsonChan
+// Node >= 18.19 supports diagnostics_channel.tracingChannel
+if (typeof diagChan.tracingChannel === 'function') {
+  asJsonChan = diagChan.tracingChannel('pino_asJson')
+} else {
+  // Older Node 18.x (e.g. 18.18), provided a no-op fallback
+  asJsonChan = {
+    hasSubscribers: false,
+    traceSync (fn, store, thisArg, ...args) {
+      return fn.call(thisArg, ...args)
+    }
+  }
+}
 
 function noop () {
 }

--- a/test/diagnostics.test.js
+++ b/test/diagnostics.test.js
@@ -13,6 +13,9 @@ const { pid } = process
 const AS_JSON_START = 'tracing:pino_asJson:start'
 const AS_JSON_END = 'tracing:pino_asJson:end'
 
+// Skip tests if diagnostics_channel.tracingChannel is not available (Node < 18.19)
+const skip = typeof diagChan.tracingChannel !== 'function'
+
 test.beforeEach(ctx => {
   ctx.pino = {
     ts: 1757512800000, // 2025-09-10T10:00:00.000-05:00
@@ -33,7 +36,7 @@ test.afterEach(ctx => {
   Date.now = ctx.pino.now
 })
 
-test('asJson emits events', async (t) => {
+test('asJson emits events', { skip }, async (t) => {
   const plan = tspl(t, { plan: 8 })
   const { dest } = t.pino
   const logger = pino({}, dest)
@@ -74,7 +77,7 @@ test('asJson emits events', async (t) => {
   }
 })
 
-test('asJson context is not lost', async (t) => {
+test('asJson context is not lost', { skip }, async (t) => {
   const plan = tspl(t, { plan: 2 })
   const { dest } = t.pino
   const logger = pino({}, dest)


### PR DESCRIPTION
This PR fixes a compatibility issue when running Pino on Node.js 18.x versions earlier than **18.19**, where `diagnostics_channel.tracingChannel` is not available.

### Problem

In Node 18.18 and earlier, `diagChannel.tracingChannel` does not exist. This caused Pino’s `asJson` tracing logic to throw an error at runtime.

### Solution

* Added **feature detection** for `diagChannel.tracingChannel`.
* When unavailable, provide a minimal no-op fallback:

  * `hasSubscribers: false`
  * `traceSync()` simply calls the provided function
* Ensures `asJson` works normally, even without tracing support.


### Notes

* Added inline comments to clarify that `tracingChannel` is available starting with Node 18.19+.
* Kept the fallback implementation minimal to avoid performance impact.

### Reference

This issue was added in the latest Pino release, https://github.com/pinojs/pino/pull/2281 and diagnostics_channel.tracingChannel was introduced in Node.js starting from v18.19 (see [Node.js docs](https://nodejs.org/api/diagnostics_channel.html#diagnostics_channeltracingchannelnameorchannels)).

closes https://github.com/pinojs/pino/issues/2289