### PR TITLE
Add files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "commonjs",
   "types": "pino.d.ts",
   "browser": "./browser.js",
+  "files": ["*.js", "*.d.ts", "lib"],
   "scripts": {
     "docs": "docsify serve",
     "browser-test": "airtap --local 8080 test/browser*test.js",


### PR DESCRIPTION
This removes the `test`, `doc`, `benchmark`, and other files from the NPM package. This results in >85% reduction in number of files and compressed size.

<details><summary>Before</summary>

```
$ npm pack
npm notice
npm notice 📦  pino@9.11.0
npm notice Tarball Contents
npm notice 36B .eslintignore
npm notice 92B .eslintrc
npm notice 274B .github/dependabot.yml
npm notice 1.4kB .github/workflows/bench.yml
npm notice 2.3kB .github/workflows/ci.yml
npm notice 801B .github/workflows/lock-threads.yml
npm notice 1.5kB .github/workflows/publish-release.yml
npm notice 553B .github/workflows/target-main.yml
npm notice 0B .nojekyll
npm notice 2B .prettierignore
npm notice 99B .taprc.yaml
npm notice 10B CNAME
npm notice 1.5kB CONTRIBUTING.md
npm notice 1.2kB LICENSE
npm notice 4.9kB README.md
npm notice 2.5kB SECURITY.md
npm notice 2.2kB benchmarks/basic.bench.js
npm notice 1.5kB benchmarks/child-child.bench.js
npm notice 1.9kB benchmarks/child-creation.bench.js
npm notice 1.6kB benchmarks/child.bench.js
npm notice 2.1kB benchmarks/deep-object.bench.js
npm notice 1.0kB benchmarks/formatters.bench.js
npm notice 1.6kB benchmarks/internal/custom-levels.js
npm notice 1.9kB benchmarks/internal/just-pino-heavy.bench.js
npm notice 5.0kB benchmarks/internal/just-pino.bench.js
npm notice 2.0kB benchmarks/internal/parent-vs-child.bench.js
npm notice 2.7kB benchmarks/internal/redact.bench.js
npm notice 1.8kB benchmarks/long-string.bench.js
npm notice 5.4kB benchmarks/multi-arg.bench.js
npm notice 2.4kB benchmarks/multistream.js
npm notice 2.0kB benchmarks/object.bench.js
npm notice 722B benchmarks/utils/generate-benchmark-doc.js
npm notice 3.8kB benchmarks/utils/runbench.js
npm notice 1.5kB benchmarks/utils/wrap-log-level.js
npm notice 170B bin.js
npm notice 14.4kB browser.js
npm notice 751B build/sync-version.js
npm notice 49.9kB docs/api.md
npm notice 1.5kB docs/asynchronous.md
npm notice 1.1kB docs/benchmarks.md
npm notice 7.7kB docs/browser.md
npm notice 1.8kB docs/bundling.md
npm notice 2.8kB docs/child-loggers.md
npm notice 839B docs/diagnostics.md
npm notice 5.5kB docs/ecosystem.md
npm notice 11.9kB docs/help.md
npm notice 2.9kB docs/lts.md
npm notice 939B docs/pretty.md
npm notice 4.3kB docs/redaction.md
npm notice 38.9kB docs/transports.md
npm notice 6.1kB docs/web.md
npm notice 1.2kB docsify/sidebar.md
npm notice 1.2kB examples/basic.js
npm notice 1.5kB examples/transport.js
npm notice 970B favicon-16x16.png
npm notice 1.5kB favicon-32x32.png
npm notice 15.1kB favicon.ico
npm notice 358B file.js
npm notice 821B inc-version.sh
npm notice 1.8kB index.html
npm notice 551B lib/caller.js
npm notice 375B lib/constants.js
npm notice 183B lib/deprecations.js
npm notice 6.7kB lib/levels.js
npm notice 53B lib/meta.js
npm notice 4.7kB lib/multistream.js
npm notice 6.9kB lib/proto.js
npm notice 3.3kB lib/redaction.js
npm notice 2.1kB lib/symbols.js
npm notice 1.4kB lib/time.js
npm notice 13.1kB lib/tools.js
npm notice 2.2kB lib/transport-stream.js
npm notice 4.0kB lib/transport.js
npm notice 9.0kB lib/worker.js
npm notice 4.3kB package.json
npm notice 42.0kB pino-banner.png
npm notice 51.6kB pino-logo-hire.png
npm notice 13.4kB pino-tree.png
npm notice 40.6kB pino.d.ts
npm notice 6.3kB pino.js
npm notice 14.5kB pretty-demo.png
npm notice 23.3kB test/basic.test.js
npm notice 1.6kB test/broken-pipe.test.js
npm notice 2.7kB test/browser-child.test.js
npm notice 1.7kB test/browser-disabled.test.js
npm notice 212B test/browser-early-console-freeze.test.js
npm notice 3.1kB test/browser-is-level-enabled.test.js
npm notice 4.5kB test/browser-levels.test.js
npm notice 8.5kB test/browser-serializers.test.js
npm notice 1.8kB test/browser-timestamp.test.js
npm notice 9.2kB test/browser-transmit.test.js
npm notice 16.1kB test/browser.test.js
npm notice 1.0kB test/complex-objects.test.js
npm notice 707B test/crlf.test.js
npm notice 6.0kB test/custom-levels.test.js
npm notice 3.0kB test/diagnostics.test.js
npm notice 8.8kB test/error.test.js
npm notice 1.1kB test/errorKey.test.js
npm notice 2.4kB test/escaping.test.js
npm notice 323B test/esm/esm.mjs
npm notice 1.1kB test/esm/index.test.js
npm notice 760B test/esm/named-exports.mjs
npm notice 2.0kB test/exit.test.js
npm notice 251B test/fixtures/broken-pipe/basic.js
npm notice 291B test/fixtures/broken-pipe/destination.js
npm notice 343B test/fixtures/broken-pipe/syncfalse.js
npm notice 319B test/fixtures/console-transport.js
npm notice 287B test/fixtures/crashing-transport.js
npm notice 305B test/fixtures/default-exit.js
npm notice 328B test/fixtures/destination-exit.js
npm notice 168B test/fixtures/eval/index.js
npm notice 48B test/fixtures/eval/node_modules/2-files.js
npm notice 45B test/fixtures/eval/node_modules/14-files.js
npm notice 82B test/fixtures/eval/node_modules/file1.js
npm notice 82B test/fixtures/eval/node_modules/file2.js
npm notice 82B test/fixtures/eval/node_modules/file3.js
npm notice 82B test/fixtures/eval/node_modules/file4.js
npm notice 82B test/fixtures/eval/node_modules/file5.js
npm notice 82B test/fixtures/eval/node_modules/file6.js
npm notice 82B test/fixtures/eval/node_modules/file7.js
npm notice 82B test/fixtures/eval/node_modules/file8.js
npm notice 85B test/fixtures/eval/node_modules/file9.js
npm notice 85B test/fixtures/eval/node_modules/file10.js
npm notice 85B test/fixtures/eval/node_modules/file11.js
npm notice 85B test/fixtures/eval/node_modules/file12.js
npm notice 85B test/fixtures/eval/node_modules/file13.js
npm notice 196B test/fixtures/eval/node_modules/file14.js
npm notice 170B test/fixtures/noop-transport.js
npm notice 358B test/fixtures/pretty/null-prototype.js
npm notice 368B test/fixtures/stdout-hack-protection.js
npm notice 333B test/fixtures/syncfalse-child.js
npm notice 386B test/fixtures/syncfalse-exit.js
npm notice 403B test/fixtures/syncfalse-flush-exit.js
npm notice 324B test/fixtures/syncfalse.js
npm notice 33B test/fixtures/syntax-error-esm.mjs
npm notice 479B test/fixtures/to-file-transport-with-transform.js
npm notice 289B test/fixtures/to-file-transport.js
npm notice 223B test/fixtures/to-file-transport.mjs
npm notice 275B test/fixtures/transport-exit-immediately-with-async-dest.js
npm notice 174B test/fixtures/transport-exit-immediately.js
npm notice 216B test/fixtures/transport-exit-on-ready.js
npm notice 221B test/fixtures/transport-main.js
npm notice 462B test/fixtures/transport-many-lines.js
npm notice 189B test/fixtures/transport-string-stdout.js
npm notice 535B test/fixtures/transport-transform.js
npm notice 820B test/fixtures/transport-uses-pino-config.js
npm notice 233B test/fixtures/transport-with-on-exit.js
npm notice 416B test/fixtures/transport-worker-data.js
npm notice 355B test/fixtures/transport-worker.js
npm notice 108B test/fixtures/transport-wrong-export-type.js
npm notice 238B test/fixtures/transport/index.js
npm notice 72B test/fixtures/transport/package.json
npm notice 505B test/fixtures/ts/to-file-transport-with-transform.ts
npm notice 346B test/fixtures/ts/to-file-transport.ts
npm notice 1.0kB test/fixtures/ts/transpile.cjs
npm notice 307B test/fixtures/ts/transport-exit-immediately-with-async-dest.ts
npm notice 159B test/fixtures/ts/transport-exit-immediately.ts
npm notice 201B test/fixtures/ts/transport-exit-on-ready.ts
npm notice 201B test/fixtures/ts/transport-main.ts
npm notice 174B test/fixtures/ts/transport-string-stdout.ts
npm notice 286B test/fixtures/ts/transport-worker.ts
npm notice 7.1kB test/formatters.test.js
npm notice 205B test/helper.d.ts
npm notice 3.4kB test/helper.js
npm notice 2.6kB test/hooks.test.js
npm notice 6.3kB test/http.test.js
npm notice 371B test/internals/version.test.js
npm notice 6.1kB test/is-level-enabled.test.js
npm notice 174B test/jest/basic.spec.js
npm notice 19.2kB test/levels.test.js
npm notice 2.7kB test/metadata.test.js
npm notice 1.2kB test/mixin-merge-strategy.test.js
npm notice 5.2kB test/mixin.test.js
npm notice 16.0kB test/multistream.test.js
npm notice 1.2kB test/pkg/index.js
npm notice 413B test/pkg/pkg.config.json
npm notice 2.4kB test/pkg/pkg.test.js
npm notice 24.2kB test/redact.test.js
npm notice 7.1kB test/serializers.test.js
npm notice 1.2kB test/stdout-protection.test.js
npm notice 4.4kB test/syncfalse.test.js
npm notice 1.1kB test/timestamp-nano.test.js
npm notice 3.9kB test/timestamp.test.js
npm notice 741B test/transport-stream.test.js
npm notice 1.3kB test/transport/big.test.js
npm notice 2.6kB test/transport/bundlers-support.test.js
npm notice 1.1kB test/transport/caller.test.js
npm notice 17.8kB test/transport/core.test.js
npm notice 6.6kB test/transport/core.test.ts
npm notice 3.2kB test/transport/core.transpiled.test.ts
npm notice 901B test/transport/crash.test.js
npm notice 5.4kB test/transport/module-link.test.js
npm notice 3.8kB test/transport/pipeline.test.js
npm notice 363B test/transport/repl.test.js
npm notice 1.9kB test/transport/syncfalse.test.js
npm notice 1.4kB test/transport/syncTrue.test.js
npm notice 999B test/transport/targets.test.js
npm notice 3.8kB test/transport/uses-pino-config.test.js
npm notice 946B test/types/pino-import.test-d.cts
npm notice 1.4kB test/types/pino-multistream.test-d.ts
npm notice 999B test/types/pino-top-export.test-d.ts
npm notice 3.2kB test/types/pino-transport.test-d.ts
npm notice 2.1kB test/types/pino-type-only.test-d.ts
npm notice 15.0kB test/types/pino.test-d.ts
npm notice 2.4kB test/types/pino.ts
npm notice 245B tsconfig.json
npm notice Tarball Details
npm notice name: pino
npm notice version: 9.11.0
npm notice filename: pino-9.11.0.tgz
npm notice package size: 244.2 kB
npm notice unpacked size: 770.4 kB
npm notice shasum: b83736286c569e5f8a8c322636c76ee89cc3e4e9
npm notice integrity: sha512-Um6uv+jCwBKVe[...]wEdq3QaT90gPw==
npm notice total files: 206
npm notice
pino-9.11.0.tgz

```

</details>

<details><summary>After</summary>

```
$ npm pack
npm notice
npm notice 📦  pino@9.11.0
npm notice Tarball Contents
npm notice 1.2kB LICENSE
npm notice 4.9kB README.md
npm notice 170B bin.js
npm notice 14.4kB browser.js
npm notice 358B file.js
npm notice 835B lib/caller.js
npm notice 375B lib/constants.js
npm notice 183B lib/deprecations.js
npm notice 6.7kB lib/levels.js
npm notice 53B lib/meta.js
npm notice 4.7kB lib/multistream.js
npm notice 6.9kB lib/proto.js
npm notice 3.3kB lib/redaction.js
npm notice 2.1kB lib/symbols.js
npm notice 1.4kB lib/time.js
npm notice 13.1kB lib/tools.js
npm notice 2.2kB lib/transport-stream.js
npm notice 4.0kB lib/transport.js
npm notice 9.0kB lib/worker.js
npm notice 4.3kB package.json
npm notice 40.6kB pino.d.ts
npm notice 6.3kB pino.js
npm notice Tarball Details
npm notice name: pino
npm notice version: 9.11.0
npm notice filename: pino-9.11.0.tgz
npm notice package size: 33.6 kB
npm notice unpacked size: 127.1 kB
npm notice shasum: 80b2c4315264269cdf693085bbea344c16a19fc1
npm notice integrity: sha512-IMiBYNmoSb8CS[...]iz2DUvbrFU3pQ==
npm notice total files: 22
npm notice
pino-9.11.0.tgz
```

</details> 
