### PR TITLE
fix: use util.getCallSites when able to allow frozen intrinsics

### DIFF
--- a/lib/caller.js
+++ b/lib/caller.js
@@ -1,10 +1,20 @@
 'use strict'
 
+const util = require('node:util')
+
+// getCallSite requires Node >=22.9.0
+// getCallSite was renamed in Node 23.3.0 / 22.12.0
+const getCallSites = util.getCallSites ?? util.getCallSite
+
 function noOpPrepareStackTrace (_, stack) {
   return stack
 }
 
 module.exports = function getCallers () {
+  if (getCallSites) {
+    return getCallSites().slice(2).map(callSite => callSite.scriptName)
+  }
+
   const originalPrepare = Error.prepareStackTrace
   Error.prepareStackTrace = noOpPrepareStackTrace
   const stack = new Error().stack

--- a/test/caller.test.js
+++ b/test/caller.test.js
@@ -1,0 +1,21 @@
+const { test } = require('tap')
+const loop = require('./fixtures/caller-loop.js')
+
+test('caller', async ({ test, end }) => {
+  test('returns a callstack of absolute paths', async ({ equal }) => {
+    const callers = loop(7, true).map(fileName => fileName.substring(__dirname.length))
+
+    // default callstack size is 10, but the top 2 are dropped
+    equal(callers.length, 8)
+    equal(callers[0], '/fixtures/caller-loop.js')
+    equal(callers[1], '/fixtures/caller-loop.js')
+    equal(callers[2], '/fixtures/caller-loop.js')
+    equal(callers[3], '/fixtures/caller-loop.js')
+    equal(callers[4], '/fixtures/caller-loop.js')
+    equal(callers[5], '/fixtures/caller-loop.js')
+    equal(callers[6], '/fixtures/caller-loop.js')
+    equal(callers[7], '/caller.test.js')
+  })
+
+  end()
+})

--- a/test/fixtures/caller-loop.js
+++ b/test/fixtures/caller-loop.js
@@ -1,0 +1,6 @@
+const getCallers = require('../../lib/caller.js')
+
+module.exports = function loop (count, kind) {
+  if (count <= 0) return getCallers(kind)
+  return loop(count - 1, kind)
+}


### PR DESCRIPTION
Issue: https://github.com/pinojs/pino/issues/2071

The examples pass now with `--frozen-intrinsics`.