### PR TITLE
docs(ecosystem): add eslint-plugin-pino to ecosystem page

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -74,6 +74,7 @@ according to a given format string.
 + [`cloud-pine`](https://github.com/metcoder95/cloud-pine): transport that provides abstraction and compatibility with [`@google-cloud/logging`](https://www.npmjs.com/package/@google-cloud/logging).
 + [`cls-proxify`](https://github.com/keenondrums/cls-proxify): integration of pino and [CLS](https://github.com/jeff-lewis/cls-hooked). Useful for creating dynamically configured child loggers (e.g. with added trace ID) for each request.
 + [`crawlee-pino`](https://github.com/imyelo/crawlee-pino): use Pino to log within Crawlee
++ [`eslint-plugin-pino`](https://github.com/orzarchi/eslint-plugin-pino): linting rules for pino usage, primarly for preventing missing context in logs due to incorrect argument order.
 + [`pino-colada`](https://github.com/lrlna/pino-colada): cute ndjson formatter for pino.
 + [`pino-dev`](https://github.com/dnjstrom/pino-dev): simple prettifier for pino with built-in support for common ecosystem packages.
 + [`pino-fluentd`](https://github.com/davidedantonio/pino-fluentd): send Pino logs to Elasticsearch,
@@ -83,4 +84,3 @@ MongoDB, and many [others](https://www.fluentd.org/dataoutputs) via Fluentd.
 prettifier inspired by the [logrus](https://github.com/sirupsen/logrus) logger.
 + [`pino-rotating-file`](https://github.com/homeaway/pino-rotating-file): a hapi-pino log transport for splitting logs into separate, automatically rotating files.
 + [`pino-tiny`](https://github.com/holmok/pino-tiny): a tiny (and extensible?) little log formatter for pino.
-+ [`eslint-plugin-pino`](https://github.com/orzarchi/eslint-plugin-pino): linting rules for pino usage, primarly for preventing missing context in logs due to incorrect argument order.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -83,3 +83,4 @@ MongoDB, and many [others](https://www.fluentd.org/dataoutputs) via Fluentd.
 prettifier inspired by the [logrus](https://github.com/sirupsen/logrus) logger.
 + [`pino-rotating-file`](https://github.com/homeaway/pino-rotating-file): a hapi-pino log transport for splitting logs into separate, automatically rotating files.
 + [`pino-tiny`](https://github.com/holmok/pino-tiny): a tiny (and extensible?) little log formatter for pino.
++ [`eslint-plugin-pino`](https://github.com/orzarchi/eslint-plugin-pino): linting rules for pino usage, primarly for preventing missing context in logs due to incorrect argument order.


### PR DESCRIPTION
Adding (my) new eslint plugin for pino users that catches this common error of passing in arguments to pino methods in the wrong order:

```javascript
// right
logger.info( { importantContext: 2 }, "very useful log message") // perfect log record

// wrong
logger.info("very useful log message", { importantContext: 2 }) // whoops, context is thrown away
```