### PR TITLE
perf: optimize .child

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -91,6 +91,10 @@ function child (bindings, options) {
   const formatters = this[formattersSym]
   const instance = Object.create(this)
 
+  // If an `options` object was not supplied, we can improve
+  // the performance of child creation by skipping
+  // the checks for set options and simply return
+  // a baseline instance.
   if (options == null) {
     if (instance[formattersSym].bindings !== resetChildingsFormatter) {
       instance[formattersSym] = buildFormatters(

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -43,7 +43,8 @@ const {
   asChindings,
   asJson,
   buildFormatters,
-  stringify
+  stringify,
+  noop
 } = require('./tools')
 const {
   version
@@ -86,10 +87,27 @@ function child (bindings, options) {
   if (!bindings) {
     throw Error('missing bindings for child Pino')
   }
-  options = options || {} // default options to empty object
   const serializers = this[serializersSym]
   const formatters = this[formattersSym]
   const instance = Object.create(this)
+
+  if (options == null) {
+    if (instance[formattersSym].bindings !== resetChildingsFormatter) {
+      instance[formattersSym] = buildFormatters(
+        formatters.level,
+        resetChildingsFormatter,
+        formatters.log
+      )
+    }
+
+    instance[chindingsSym] = asChindings(instance, bindings)
+
+    if (this.onChild !== noop) {
+      this.onChild(instance)
+    }
+
+    return instance
+  }
 
   if (options.hasOwnProperty('serializers') === true) {
     instance[serializersSym] = Object.create(null)
@@ -222,8 +240,6 @@ function write (_obj, msg, num) {
   }
   stream.write(streamWriteHook ? streamWriteHook(s) : s)
 }
-
-function noop () {}
 
 function flush (cb) {
   if (cb != null && typeof cb !== 'function') {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -257,10 +257,10 @@ function asChindings (instance, bindings) {
 
   for (const key in bindings) {
     value = bindings[key]
-    const valid = key !== 'level' &&
+    const valid = (key.length < 5 || (key !== 'level' &&
       key !== 'serializers' &&
       key !== 'formatters' &&
-      key !== 'customLevels' &&
+      key !== 'customLevels')) &&
       bindings.hasOwnProperty(key) &&
       value !== undefined
     if (valid === true) {


### PR DESCRIPTION
```bash
benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
pino child creation          174.95 ns/iter  87.23 ns █                    
                       (63.07 ns … 5.76 µs)   3.60 µs █                    
                    ( 53.17  b …   8.62 kb) 261.17  b █▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

pino2 child creation         257.64 ns/iter 330.37 ns █                    
                       (67.99 ns … 7.37 µs)   4.49 µs █▂                   
                    ( 22.38  b …   5.82 kb) 266.57  b ██▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁

```
```js
// bench.mjs

import { bench, run } from 'mitata'

import pino from './pino.js'
import pino2 from 'pino'

let logger = pino().child({ b: 'property' })
const children = []

bench('pino child creation', function () {
  children.push(logger.child({ a: 'property' }))
})

let logger2 = pino().child({ b: 'property' })
const children2 = []

bench('pino2 child creation', function () {
  children2.push(logger2.child({ a: 'property' }))
})

await run()

children[Math.random() * children.length | 0].info({ hello: 'world' })
```