### PR TITLE
chore: add .npmignore to exclude unnecessary files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+*.png
+.github/
+docsify/
+.nyc_output/
+coverage/


### PR DESCRIPTION
## Summary

Adds `.npmignore` file to exclude development and CI-related files from npm packages:
- `.github/` directory
- `docsify/` directory  
- `.nyc_output/` directory (test coverage)
- `coverage/` directory
- `*.png` files

## Impact

Reduces package size from **1.6 MB** to **141.3 kB** (91% reduction).

## Test Plan

- [x] Verified with `npm pack --dry-run` 
- [x] All tests pass