### PR TITLE
test: add regression test for issue #2313

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "quick-format-unescaped": "^4.0.3",
     "real-require": "^0.2.0",
     "safe-stable-stringify": "^2.3.1",
-    "slow-redact": "github:pinojs/slow-redact#fix-censor-undefined-paths",
+    "slow-redact": "^0.3.1",
     "sonic-boom": "^4.0.1",
     "thread-stream": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "quick-format-unescaped": "^4.0.3",
     "real-require": "^0.2.0",
     "safe-stable-stringify": "^2.3.1",
-    "slow-redact": "^0.3.0",
+    "slow-redact": "github:pinojs/slow-redact#fix-censor-undefined-paths",
     "sonic-boom": "^4.0.1",
     "thread-stream": "^3.0.0"
   },


### PR DESCRIPTION
## Summary

Adds a regression test for https://github.com/pinojs/pino/issues/2313

The test verifies that the censor function is not called for non-existent nested paths when using redaction. This was a regression introduced in v9.12 where the censor function started being called with `undefined` values if the parent key existed but the nested path didn't.

## Changes

- Added comprehensive test case covering multiple scenarios:
  - Parent exists but nested path doesn't (`req.authorization` when only `req.id` exists)
  - Deeply nested path doesn't exist (`a.b.c` when only `a.d` exists)
  - Multiple missing paths
  - Verification that censor IS called when path actually exists

## Status

The test **passes** with the fix from https://github.com/pinojs/slow-redact/pull/17 which adds path existence checking before calling the censor function.

This PR temporarily includes `slow-redact` from the PR branch to demonstrate the fix. Once slow-redact#17 is merged and published, the dependency should be updated to the published version.

## Testing

```bash
npm run borp test/redact.test.js
```

The test validates all four scenarios described in the original issue.

Refs: #2313
Refs: pinojs/slow-redact#17