### PR TITLE
remove unused parsedChindingsSym symbol

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -9,7 +9,6 @@ const {
   setLevelSym,
   getLevelSym,
   chindingsSym,
-  parsedChindingsSym,
   mixinSym,
   asJsonSym,
   writeSym,
@@ -168,7 +167,6 @@ function bindings () {
 function setBindings (newBindings) {
   const chindings = asChindings(this, newBindings)
   this[chindingsSym] = chindings
-  delete this[parsedChindingsSym]
 }
 
 /**

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -768,7 +768,6 @@ declare namespace pino {
         readonly mixinSym: unique symbol;
         readonly lsCacheSym: unique symbol;
         readonly chindingsSym: unique symbol;
-        readonly parsedChindingsSym: unique symbol;
         readonly asJsonSym: unique symbol;
         readonly writeSym: unique symbol;
         readonly serializersSym: unique symbol;


### PR DESCRIPTION
## Summary
- Remove unused `parsedChindingsSym` symbol import from `lib/proto.js`
- Remove unused reference to `parsedChindingsSym` in `setBindings` function
- Remove `parsedChindingsSym` from TypeScript definitions

## Details
The `parsedChindingsSym` symbol was imported and referenced but never actually defined in the symbols module or used meaningfully. It was only being deleted from objects where it didn't exist, making it dead code.

## Test plan
- [x] Linting passes
- [x] TypeScript compilation and type tests pass
- [x] All existing functionality unchanged