### PR TITLE
fix(types): Correct conditional type handling for generic log function arguments

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -346,9 +346,9 @@ declare namespace pino {
         // Simple case: When first argument is always a string message, use parsed arguments directly
         <TMsg extends string = string>(msg: TMsg, ...args: ParseLogFnArgs<TMsg>): void;
         // Complex case: When first argument can be any type - if it's a string, no message needed; otherwise require a message
-        <T, TMsg extends string = string>(obj: T extends object ? T & LogFnFields : T, msg?: T extends string ? never: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
+        <T, TMsg extends string = string>(obj: [T] extends [object] ? T & LogFnFields : T, msg?: T extends string ? never: TMsg, ...args: ParseLogFnArgs<TMsg> | []): void;
         // Complex case with type safety: Same as above but ensures ParseLogFnArgs is a valid tuple before using it
-        <T, TMsg extends string = string>(obj: T extends object ? T & LogFnFields : T, msg?: T extends string ? never : TMsg, ...args: ParseLogFnArgs<TMsg> extends [unknown, ...unknown[]] ? ParseLogFnArgs<TMsg> : unknown[]): void;
+        <T, TMsg extends string = string>(obj: [T] extends [object] ? T & LogFnFields : T, msg?: T extends string ? never : TMsg, ...args: ParseLogFnArgs<TMsg> extends [unknown, ...unknown[]] ? ParseLogFnArgs<TMsg> : unknown[]): void;
     }
 
     export interface LoggerOptions<CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean> {

--- a/test/types/pino.test-d.ts
+++ b/test/types/pino.test-d.ts
@@ -594,3 +594,6 @@ declare module "../../" {
 info({typeCheckedField: 'bar'})
 expectError(info({bannedField: 'bar'}))
 expectError(info({typeCheckedField: 123}))
+const someGenericFunction = <T extends string | number | symbol = never>(arg: Record<T, unknown>) => {
+    info(arg)
+}


### PR DESCRIPTION
Resolves https://github.com/pinojs/pino/issues/2328

Allow generics to passthrough