### PR TITLE
perf: use JSON.stringify in fast path for node v25+ 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, windows-latest, ubuntu-latest]
-        node-version: [20, 22, 24]
+        node-version: [20, 22, 24, 25]
         exclude:
           - os: windows-latest
             node-version: 22

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -27,8 +27,12 @@ const {
 } = require('./symbols')
 const { isMainThread } = require('worker_threads')
 const transport = require('./transport')
+const [nodeMajor] = process.versions.node.split('.').map(v => Number(v))
 
 const asJsonChan = diagChan.tracingChannel('pino_asJson')
+
+// JSON.stringify is faster in node 25+.
+const asString = nodeMajor >= 25 ? str => JSON.stringify(str) : _asString
 
 function noop () {
 }
@@ -81,7 +85,7 @@ function genLog (level, hook) {
 // everything below 32 needs JSON.stringify()
 // 34 and 92 happens all the time, so we
 // have a fast case for them
-function asString (str) {
+function _asString (str) {
   let result = ''
   let last = 0
   let found = false


### PR DESCRIPTION
Fixes: https://github.com/pinojs/pino/issues/2274#issuecomment-3445045578