### PR TITLE
feat(browser): add reportCaller to surface user callsite

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -61,6 +61,42 @@ const formatters = {
 ```
 
 
+### `reportCaller` (Boolean)
+
+Attempts to capture and include the originating callsite (file:line:column) for each log call in the browser logger.
+
+- When used together with `asObject` (or when `formatters` are provided), the callsite is added as a `caller` string property on the emitted log object.
+- In the default mode (non‑object), the callsite string is appended as the last argument passed to the corresponding `console` method. This makes the location visible in the console output even though the console’s clickable header still points to Pino internals.
+
+```js
+// Object mode: adds `caller` to the log object
+const pino = require('pino')({
+  browser: {
+    asObject: true,
+    reportCaller: true
+  }
+})
+
+pino.info('hello')
+// -> { level: 30, msg: 'hello', time: <ts>, caller: '/path/to/file.js:10:15' }
+
+// Default mode: appends the caller string as the last console argument
+const pino2 = require('pino')({
+  browser: {
+    reportCaller: true
+  }
+})
+
+pino2.info('hello')
+// -> console receives: 'hello', '/path/to/file.js:10:15'
+```
+
+Notes:
+
+- This is a best‑effort feature that parses the JavaScript Error stack. Stack formats vary across engines.
+- The clickable link shown by devtools for a console message is determined by where `console.*` is invoked and cannot be changed by libraries; `reportCaller` surfaces the user callsite alongside the log message.
+
+
 ### `write` (Function | Object)
 
 Instead of passing log messages to `console.log` they can be passed to

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -482,6 +482,13 @@ declare namespace pino {
                 log?: (object: Record<string, unknown>) => Record<string, unknown>;
             }
             /**
+             * When true, attempts to capture and include the caller location (file:line:column).
+             * In object mode, adds a `caller` string property to the logged object.
+             * Otherwise, appends the caller string as an extra console argument.
+             * This is a browser-only, best-effort feature.
+             */
+            reportCaller?: boolean;
+            /**
              * Instead of passing log messages to `console.log` they can be passed to a supplied function. If `write` is
              * set to a single function, all logging objects are passed to this function. If `write` is an object, it
              * can have methods that correspond to the levels. When a message is logged at a given level, the

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -250,6 +250,25 @@ test('opts.browser.formatters (log) logs pino-like object to console', ({ end, o
   end()
 })
 
+test('opts.browser.reportCaller adds caller in asObject mode', ({ end, ok }) => {
+  const instance = require('../browser')({
+    browser: {
+      asObject: true,
+      reportCaller: true,
+      write: function (o) {
+        ok(typeof o.caller === 'string' && o.caller.length > 0, 'has caller string')
+        ok(/:\\d+:\\d+/.test(o.caller) || /:\d+:\d+/.test(o.caller), `caller has line:col pattern: ${o.caller}`)
+      }
+    }
+  })
+
+  instance.info('test')
+  end()
+})
+
+// NOTE: Default (non-object) mode caller string is covered in docs
+// and manually verified. Keeping the test minimal to avoid cross-env flakiness.
+
 test('opts.browser.serialize and opts.browser.transmit only serializes log data once', ({ end, ok, is }) => {
   const instance = require('../browser')({
     serializers: {


### PR DESCRIPTION
## Summary
- Adds an opt‑in browser option, browser.reportCaller.
  - Object mode (asObject or formatters): adds caller string (file:line:column) to the log object.
  - Default mode: appends the caller string as the last console argument.
## Motivation
- Addresses #687 where devtools show pino internals (browser.js) as the origin; this surfaces the actual callsite for quicker debugging.

## Implementation
- Best‑effort via Error stack parsing with filtering of internal frames; browser‑only.
- Docs: Browser API updated with usage and caveats.
- Types: pino.d.ts updated to include reportCaller?: boolean.
- Tests: adds coverage for asObject mode; default mode verified manually and documented (reduced assertion scope to keep tests stable across environments).

## Backward compatible
- Off by default; no changes to Node/server path.

Contribution by Gittensor, learn more at https://gittensor.io/