### PR TITLE
build(deps): update thread-stream to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "safe-stable-stringify": "^2.3.1",
     "@pinojs/redact": "^0.4.0",
     "sonic-boom": "^4.0.1",
-    "thread-stream": "^3.0.0"
+    "thread-stream": "^4.0.0"
   },
   "tsd": {
     "directory": "test/types"


### PR DESCRIPTION
## Summary
- Updates `thread-stream` from v3 to v4
- thread-stream v4 uses `Atomics.waitAsync` instead of `setTimeout` for improved performance
- Requires Node.js >=20 (aligns with pino's current test matrix)

## Changes
- Updated `thread-stream` dependency to `^4.0.0`
- Fixed a timing-sensitive test in `test/transport/sync-false.test.js` that assumed specific flush behavior which changed with the new async implementation

## Test plan
- [x] All existing tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)