### PR TITLE
chore: upgrade typescript to v6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "through2": "^4.0.0",
     "ts-node": "^10.9.1",
     "tstyche": "^6.0.2",
-    "typescript": "~5.9.2",
+    "typescript": "~6.0.2",
     "winston": "^3.7.2"
   },
   "dependencies": {

--- a/test/fixtures/ts/transpile.cjs
+++ b/test/fixtures/ts/transpile.cjs
@@ -7,7 +7,7 @@ const existsSync = fs.existsSync
 const stat = fs.promises.stat
 
 // Hardcoded parameters
-const esVersions = ['es5', 'es6', 'es2017', 'esnext']
+const esVersions = ['es6', 'es2017', 'esnext']
 const filesToTranspile = ['to-file-transport.ts']
 
 async function transpile () {
@@ -23,8 +23,8 @@ async function transpile () {
       const shouldTranspile = !existsSync(targetFileName) || (await stat(targetFileName)).mtimeMs < sourceStat.mtimeMs
 
       if (shouldTranspile) {
-        await execa('tsc', ['--target', esVersion, '--module', 'commonjs', sourceFileName])
-        await execa('mv', [intermediateFileName, targetFileName])
+        await execa('tsc', [ '--ignoreConfig', '--types', 'node', '--target', esVersion, '--module', 'commonjs', sourceFileName ])
+        await execa('mv', [ intermediateFileName, targetFileName ])
       }
     }
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "lib": [ "es2015", "dom" ],
-    "module": "commonjs",
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "node16",
+    "moduleResolution": "node16",
     "noEmit": true,
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node"]
   },
   "exclude": [
     "./test/types/**/*.tst.*",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,10 @@
     "moduleResolution": "node16",
     "noEmit": true,
     "strict": true,
-    "esModuleInterop": true,
     "types": ["node"]
   },
   "exclude": [
-    "./test/types/**/*.tst.*",
+    "./test/types/**/*",
     "./*.d.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "types": ["node"]
   },
   "exclude": [
-    "./test/types/**/*",
     "./*.d.ts"
   ]
 }


### PR DESCRIPTION
Proposal:

- Upgrade typescript v6.0.2 🔥

Changes made:

- Bump `typescript`dependency  from `~5.9.2` to `~6.0.2`
- Update `tsconfig.json`:
  - `target`: `es6` → `es2022`
  - `lib`: `["es2015", "dom"]` → `["es2022"]`
  - `module`: `commonjs` → `node16`
  - `moduleResolution`: `node16` 
  - `types`: `["node"]`
- Update `transpile.cjs`

This PR should resolve this PR: https://github.com/pinojs/pino/pull/2417