### PR TITLE
fix: ensuring the file has the correct context before evaluating it

### DIFF
--- a/test/transport/uses-pino-config.test.js
+++ b/test/transport/uses-pino-config.test.js
@@ -7,7 +7,7 @@ const { join } = require('node:path')
 const { readFile } = require('node:fs').promises
 const writeStream = require('flush-write-stream')
 
-const { watchFileCreated, file } = require('../helper')
+const { watchFileCreated, watchForWrite, file } = require('../helper')
 const pino = require('../../')
 
 const { pid } = process
@@ -46,6 +46,7 @@ test('transport uses pino config', async (t) => {
   instance.custom('foo')
   instance.error(error)
   await watchFileCreated(destination)
+  await watchForWrite(destination, '"body":"foo"')
   const result = parseLogs(await readFile(destination))
 
   assert.deepEqual(result, [{
@@ -83,6 +84,7 @@ test('transport uses pino config without customizations', async (t) => {
   instance.info('baz')
   instance.error(error)
   await watchFileCreated(destination)
+  await watchForWrite(destination, '"body":"qux"')
   const result = parseLogs(await readFile(destination))
 
   assert.deepEqual(result, [{
@@ -132,6 +134,7 @@ test('transport uses pino config with multistream', async (t) => {
   instance.custom('fizz')
   instance.error(error)
   await watchFileCreated(destination)
+  await watchForWrite(destination, '"body":"buzz"')
   const result = parseLogs(await readFile(destination))
 
   assert.deepEqual(result, [{


### PR DESCRIPTION
## Summary
This PR, uses the `watchForWrite` function, to ensure that before running the `assert.deepEqual` the `pino.transport` had enough time to properly write the content. Despite the `await watchFileCreated(destination)` function is being used, it does not ensure that the content has been filled.

## Error reproduce
```
git clone https://github.com/pinojs/pino.git
cd ./pino

docker run --rm -it \                                                              
  --cpus="0.15" \
  -v "$PWD:/opt/app-root/src:ro" \
  -w /opt/app-root/src \
  node:24-bookworm \
  sh -c 'for i in $(seq 1 100); do node --test test/transport/uses-pino-config.test.js || exit 1; done'
```

It should produce the following error

```
✖ failing tests:

test at test/transport/uses-pino-config.test.js:69:1
✖ transport uses pino config without customizations (115.904224ms)
  AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:
  
  [
    {
      attributes: {
        hostname: '53d6c978610b',
        pid: 492
      },
      body: 'baz',
      severityText: 'info'
    }
  ]
  
  should loosely deep-equal
  
  [
    {
      attributes: {
        hostname: '53d6c978610b',
        pid: 492
      },
      body: 'baz',
      severityText: 'info'
    },
    {
      attributes: {
        hostname: '53d6c978610b',
        pid: 492
      },
      body: 'qux',
      error: {
        message: 'qux',
        stack: 'Error: qux\n' +
          '    at TestContext.<anonymous> (/opt/app-root/src/test/transport/uses-pino-config.test.js:82:17)\n' +
          '    at Test.runInAsyncScope (node:async_hooks:214:14)\n' +
          '    at Test.run (node:internal/test_ru...
      at TestContext.<anonymous> (/opt/app-root/src/test/transport/uses-pino-config.test.js:88:10)
      at async Test.run (node:internal/test_runner/test:1113:7)
      at async Test.processPendingSubtests (node:internal/test_runner/test:788:7) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: [ { severityText: 'info', body: 'baz', attributes: [Object] } ],
    expected: [ { severityText: 'info', body: 'baz', attributes: [Object] }, { severityText: 'error', body: 'qux', attributes: [Object], error: [Object] } ],
    operator: 'deepEqual',
    diff: 'simple'
  }
```

By applying this PR, the error does not occur