### PR TITLE
fix: add named `default` export

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,7 @@ module.exports = defineConfig([
   {
     files: ['test/types/**/*'],
     rules: {
+      'no-unused-expressions': 'off',
       '@typescript-eslint/no-unused-expressions': 'off',
       '@typescript-eslint/no-unused-vars': 'off',
       'n/handle-callback-err': 'off'

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -854,36 +854,7 @@ declare namespace pino {
       opts?: MultiStreamOptions
     ): MultiStreamRes<TLevel>
 
-    /// Nested version of default export for TypeScript/Babel compatibility
-
-    /**
-     * @param [optionsOrStream]: an options object or a writable stream where the logs will be written. It can also receive some log-line metadata, if the
-     * relative protocol is enabled. Default: process.stdout
-     * @returns a new logger instance.
-     */
-    function pino<CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean> (optionsOrStream?: LoggerOptions<CustomLevels, UseOnlyCustomLevels> | DestinationStream): Logger<CustomLevels, UseOnlyCustomLevels>
-
-    /**
-     * @param [options]: an options object
-     * @param [stream]: a writable stream where the logs will be written. It can also receive some log-line metadata, if the
-     * relative protocol is enabled. Default: process.stdout
-     * @returns a new logger instance.
-     */
-    function pino<CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean> (options: LoggerOptions<CustomLevels, UseOnlyCustomLevels>, stream?: DestinationStream | undefined): Logger<CustomLevels, UseOnlyCustomLevels>
-
-    /**
-     * Attach selected static members to the nested callable export, so that
-     * `const { pino } = require('pino')` exposes them (e.g. `pino.stdTimeFunctions`).
-     */
-    namespace pino {
-      const stdTimeFunctions: {
-        epochTime: TimeFn;
-        unixTime: TimeFn;
-        nullTime: TimeFn;
-        isoTime: TimeFn;
-        isoTimeNano: TimeFn;
-      }
-    }
+    export { pino as default, pino }
 }
 
 /// Callable default export

--- a/test/types/pino-import.tst.cts
+++ b/test/types/pino-import.tst.cts
@@ -1,30 +1,34 @@
 import { expect } from 'tstyche'
 
 import * as pinoStar from '../../pino.js'
-import { type default as P, default as pino, pino as pinoNamed } from '../../pino.js'
+import pinoDefault, { default as pino, pino as pinoNamed } from '../../pino.js'
 import pinoCjsImport = require ('../../pino.js')
 const pinoCjs = require('../../pino.js')
 const { P: pinoCjsNamed } = require('pino')
 
 const log = pino()
-expect(log.info).type.toBe<P.LogFn>()
-expect(log.error).type.toBe<P.LogFn>()
+expect(log.info).type.toBe<pino.LogFn>()
+expect(log.error).type.toBe<pino.LogFn>()
 
+expect(pinoDefault()).type.toBe<pino.Logger>()
 expect(pinoNamed()).type.toBe<pino.Logger>()
-expect(pinoNamed()).type.toBe<P.Logger>()
 expect(pinoStar.default()).type.toBe<pino.Logger>()
 expect(pinoStar.pino()).type.toBe<pino.Logger>()
-// expect(pinoCjsImport.default()).type.toBe<pino.Logger>()
+expect(pinoCjsImport()).type.toBe<pino.Logger>()
+expect(pinoCjsImport.default()).type.toBe<pino.Logger>()
 expect(pinoCjsImport.pino()).type.toBe<pino.Logger>()
 expect(pinoCjsNamed()).type.toBe<any>()
 expect(pinoCjs()).type.toBe<any>()
-expect(pinoNamed.stdTimeFunctions.isoTimeNano).type.toBe<P.TimeFn>()
-expect(pinoNamed.stdTimeFunctions.isoTimeNano()).type.toBe<string>()
 
-const levelChangeEventListener: P.LevelChangeEventListener = (
-    lvl: P.LevelWithSilent | string,
+expect(pinoDefault.stdTimeFunctions.isoTimeNano()).type.toBe<string>()
+expect(pinoNamed.stdTimeFunctions.isoTimeNano()).type.toBe<string>()
+expect(pinoStar.stdTimeFunctions.isoTimeNano()).type.toBe<string>()
+expect(pinoCjsImport.stdTimeFunctions.isoTimeNano()).type.toBe<string>()
+
+const levelChangeEventListener: pino.LevelChangeEventListener = (
+    lvl: pino.LevelWithSilent | string,
     val: number,
-    prevLvl: P.LevelWithSilent | string,
+    prevLvl: pino.LevelWithSilent | string,
     prevVal: number,
 ) => {}
-expect(levelChangeEventListener).type.toBe<P.LevelChangeEventListener>()
+expect(levelChangeEventListener).type.toBe<pino.LevelChangeEventListener>()

--- a/test/types/pino-import.tst.cts
+++ b/test/types/pino-import.tst.cts
@@ -3,8 +3,6 @@ import { expect } from 'tstyche'
 import * as pinoStar from '../../pino.js'
 import pinoDefault, { default as pino, pino as pinoNamed } from '../../pino.js'
 import pinoCjsImport = require ('../../pino.js')
-const pinoCjs = require('../../pino.js')
-const { P: pinoCjsNamed } = require('pino')
 
 const log = pino()
 expect(log.info).type.toBe<pino.LogFn>()
@@ -17,8 +15,6 @@ expect(pinoStar.pino()).type.toBe<pino.Logger>()
 expect(pinoCjsImport()).type.toBe<pino.Logger>()
 expect(pinoCjsImport.default()).type.toBe<pino.Logger>()
 expect(pinoCjsImport.pino()).type.toBe<pino.Logger>()
-expect(pinoCjsNamed()).type.toBe<any>()
-expect(pinoCjs()).type.toBe<any>()
 
 expect(pinoDefault.stdTimeFunctions.isoTimeNano()).type.toBe<string>()
 expect(pinoNamed.stdTimeFunctions.isoTimeNano()).type.toBe<string>()

--- a/test/types/pino-import.tst.js
+++ b/test/types/pino-import.tst.js
@@ -1,0 +1,73 @@
+// @ts-check
+
+const {
+  pino,
+  destination,
+  levels,
+  multistream,
+  stdSerializers,
+  stdTimeFunctions,
+  transport,
+  version
+} = require('../../pino.js')
+const { default: pinoDefault } = require('../../pino.js')
+const pinoCjs = require('../../pino.js')
+
+const log = pino()
+log.info('test')
+log.error('test')
+
+const logDefault = pinoDefault()
+logDefault.info('test')
+logDefault.error('test')
+
+const logCjs = pinoCjs()
+logCjs.info('test')
+logCjs.error('test')
+
+destination()
+pino.destination()
+pinoDefault.destination()
+pinoCjs.destination()
+
+levels
+pino.levels
+pinoDefault.levels
+pinoCjs.levels
+
+multistream(process.stdout)
+pino.multistream(process.stdout)
+pinoDefault.multistream(process.stdout)
+pinoCjs.multistream(process.stdout)
+
+stdSerializers.err(new Error())
+pino.stdSerializers.err(new Error())
+pinoDefault.stdSerializers.err(new Error())
+pinoCjs.stdSerializers.err(new Error())
+
+stdTimeFunctions.epochTime()
+pino.stdTimeFunctions.epochTime()
+pinoDefault.stdTimeFunctions.epochTime()
+pinoCjs.stdTimeFunctions.epochTime()
+
+transport({
+  target: '#pino/pretty',
+  options: { some: 'options for', the: 'transport' }
+})
+pino.transport({
+  target: '#pino/pretty',
+  options: { some: 'options for', the: 'transport' }
+})
+pinoDefault.transport({
+  target: '#pino/pretty',
+  options: { some: 'options for', the: 'transport' }
+})
+pinoCjs.transport({
+  target: '#pino/pretty',
+  options: { some: 'options for', the: 'transport' }
+})
+
+version
+pino.version
+pinoDefault.version
+pinoCjs.version

--- a/test/types/tsconfig.json
+++ b/test/types/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "fastify-tsconfig",
   "compilerOptions": {
+    "checkJs": true,
     "noEmit": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
Close #2152, because I believe all cases should be covered.

This is a continuation of #2223 and #2258.

Instead of duplicating function declarations inside of the namespace (see #2258 for explanation), one can do:

```diff
  namespace pino {
    export type Level = "fatal" | "error" | "warn" | "info" | "debug" | "trace";
-   declare function pino(msg: string);
+   export { pino as default, pino }
  }
  declare function pino(msg: string);
  export = pino;
```

This allows removing duplicate code and enable the disabled `pinoCjsImport.default()` test. The rest of tests are passing. I added few more.

By the way, `fastify` is using similar [approach](https://github.com/fastify/fastify/blob/b06a196b694c0c7aed53976cd77456f1ad7d4c9f/fastify.d.ts#L205-L208). Also a detailed [explanation](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/MissingExportEquals.md) can be found at `arethetypeswrong`.