### PR TITLE
chore(deps): remove `pre-commit`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "bin": {
     "pino": "./bin.js"
   },
-  "precommit": "test",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/pinojs/pino.git"
@@ -87,7 +86,6 @@
     "midnight-smoker": "1.1.1",
     "neostandard": "^0.13.0",
     "pino-pretty": "^13.0.0",
-    "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
     "pump": "^3.0.0",
     "rimraf": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "midnight-smoker": "1.1.1",
     "neostandard": "^0.13.0",
     "pino-pretty": "^13.0.0",
-    "pre-commit": "^1.2.2",
     "proxyquire": "^2.1.3",
     "pump": "^3.0.0",
     "rimraf": "^6.0.1",


### PR DESCRIPTION
Remove `pre-commit` because it is no longer actively maintained.