### PR TITLE
docs: use @hono/structured-logger for Pino with Hono

### DIFF
--- a/docs/web.md
+++ b/docs/web.md
@@ -274,28 +274,25 @@ See the [pino-http README](https://npm.im/pino-http) for more info.
 ## Pino with Hono
 
 ```sh
-npm install pino pino-http hono
+npm install pino @hono/structured-logger hono
 ```
 
 ```js
 import { serve } from '@hono/node-server';
 import { Hono } from 'hono';
 import { requestId } from 'hono/request-id';
-import { pinoHttp } from 'pino-http';
+import { structuredLogger } from '@hono/structured-logger';
+import pino from 'pino';
+
+const rootLogger = pino();
 
 const app = new Hono();
 app.use(requestId());
-app.use(async (c, next) => {
-  // pass hono's request-id to pino-http
-  c.env.incoming.id = c.var.requestId;
-
-  // map express style middleware to hono
-  await new Promise((resolve) => pinoHttp()(c.env.incoming, c.env.outgoing, () => resolve()));
-
-  c.set('logger', c.env.incoming.log);
-
-  await next();
-});
+app.use(
+  structuredLogger({
+    createLogger: (c) => rootLogger.child({ requestId: c.var.requestId }),
+  })
+);
 
 app.get('/', (c) => {
   c.var.logger.info('something');
@@ -306,4 +303,4 @@ app.get('/', (c) => {
 serve(app);
 ```
 
-See the [pino-http README](https://npm.im/pino-http) for more info.
+See the [@hono/structured-logger README](https://github.com/honojs/middleware/blob/main/packages/structured-logger/README.md) for more info.


### PR DESCRIPTION
## What

Replaces the `pino-http` example in the **Pino with Hono** section of `docs/web.md` with the newly released [`@hono/structured-logger`](https://github.com/honojs/middleware/blob/main/packages/structured-logger/README.md) middleware.

## Why

The current snippet wires `pino-http` (an Express-style middleware) into Hono by:

- reaching into `@hono/node-server` internals (`c.env.incoming` / `c.env.outgoing`),
- manually forwarding `hono/request-id` into the request object,
- wrapping the call in a `new Promise` to bridge the Express `(req, res, next)` signature.

`@hono/structured-logger` is a first-class Hono middleware with pino as one of its documented integrations. The recipe becomes:

- shorter and easier to read,
- no longer coupled to `@hono/node-server` internals,
- portable across every runtime Hono supports (Node, Bun, Deno, Workers, Lambda, Edge),
- still request-scoped via `rootLogger.child({ requestId })`.

## Scope

Docs-only. No code changes, no dep changes in the repo itself.