### PR TITLE
fix: honor per-target level filter on single-element `targets` array

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -233,7 +233,10 @@ function transport (fullOptions) {
       })
     })
 
-    usesMultistream = options.targets.length + options.pipelines.length > 1
+    const targetsHaveLevel = options.targets.some(t => t.level != null)
+    const pipelinesHaveLevel = options.pipelines.some(p => p.some(t => t.level != null))
+    usesMultistream = options.targets.length + options.pipelines.length > 1 ||
+      targetsHaveLevel || pipelinesHaveLevel
   } else if (pipeline) {
     target = bundlerOverrides['pino-worker'] || join(__dirname, 'worker.js')
     options.pipelines = [pipeline.map((dest) => {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -123,7 +123,10 @@ module.exports = async function ({ targets, pipelines, levels, dedupe }) {
   // OR
   //
   // pino.transport({ pipeline: ... })
-  if (targetStreams.length === 1) {
+  //
+  // When a `level` is set on the single target/pipeline, fall through to the
+  // multistream path so the per-target level filter is honored (#1996).
+  if (targetStreams.length === 1 && targetStreams[0].level == null) {
     return targetStreams[0].stream
   } else {
     return build(process, {

--- a/test/transport/core.test.js
+++ b/test/transport/core.test.js
@@ -267,6 +267,59 @@ test('pino.transport with two files and dedupe', async (t) => {
   })
 })
 
+test('pino.transport with single target in targets array honors level filter (#1996)', async (t) => {
+  const destination = file()
+  const transport = pino.transport({
+    targets: [{
+      level: 'error',
+      target: join(__dirname, '..', 'fixtures', 'to-file-transport.js'),
+      options: { destination }
+    }]
+  })
+  t.after(transport.end.bind(transport))
+  const instance = pino({ level: 'debug' }, transport)
+  instance.debug('debug-msg')
+  instance.info('info-msg')
+  instance.warn('warn-msg')
+  instance.error('error-msg')
+  await watchForWrite(destination, 'error-msg')
+  const lines = (await readFile(destination, 'utf8')).trim().split('\n').filter(Boolean)
+  assert.equal(lines.length, 1, 'only error should be written to destination')
+  const result = JSON.parse(lines[0])
+  delete result.time
+  assert.deepEqual(result, {
+    pid,
+    hostname,
+    level: 50,
+    msg: 'error-msg'
+  })
+})
+
+test('pino.transport with single target in targets array without level keeps logger.level gating', async (t) => {
+  const destination = file()
+  const transport = pino.transport({
+    targets: [{
+      target: join(__dirname, '..', 'fixtures', 'to-file-transport.js'),
+      options: { destination }
+    }]
+  })
+  t.after(transport.end.bind(transport))
+  const instance = pino({ level: 'debug' }, transport)
+  instance.debug('debug-msg')
+  instance.info('info-msg')
+  await watchForWrite(destination, 'info-msg')
+  const lines = (await readFile(destination, 'utf8')).trim().split('\n').filter(Boolean)
+  assert.equal(lines.length, 2, 'both debug and info reach the single target when no per-target level is set')
+  const first = JSON.parse(lines[0])
+  delete first.time
+  assert.deepEqual(first, {
+    pid,
+    hostname,
+    level: 20,
+    msg: 'debug-msg'
+  })
+})
+
 test('pino.transport with an array including a pino-pretty destination', async (t) => {
   const dest1 = file()
   const dest2 = file()


### PR DESCRIPTION
## Summary

- Fixes #1996 — the per-target `level` filter was silently ignored when `pino.transport({ targets: [...] })` contained a single element.
- The single-target shortcut in `lib/worker.js` returned the raw stream directly, bypassing `pino.multistream` (which is the only place that consults `targets[i].level`).
- Now, when `level` is set on the single target/pipeline, we fall through to the multistream path that already enforces per-target filtering. When `level` is *not* set, behavior is unchanged.

## Root cause

`lib/worker.js:126`:

```js
if (targetStreams.length === 1) {
  return targetStreams[0].stream
}
```

The level captured at line 85 (`level: t.level`) was collected and then discarded for the one-element case. So `targets: [{ level: 'error', target: '...' }]` emitted info/warn/debug logs anyway — the exact symptom reported in #1996.

## Fix

`lib/worker.js`:

```js
if (targetStreams.length === 1 && targetStreams[0].level == null) {
  return targetStreams[0].stream
}
```

`lib/transport.js` — extend `usesMultistream` so `transportUsesMultistreamSym` is set whenever per-target filtering will run in the worker. This keeps the existing `formatters.level` warning (`pino.js:169`) consistent: if filtering happens, the numeric `level` invariant must hold.

## Scope

Intentionally minimal — fixes the case where `level` is set (the #1996 reproducer) without altering the no-level case. The remaining asymmetry (single target with no level inherits `logger.level` instead of defaulting to `info` like multistream does) is a separate semver-major decision and is left for a follow-up.

## Test plan

- [x] New TDD test reproducing #1996 verbatim (`targets: [{ level: 'error', ... }]` → only error reaches destination)
- [x] New regression guard for the no-level case (single target with no per-target level keeps `logger.level` gating)
- [x] `test/transport/core.test.js` (38 tests) — all pass
- [x] `test/transport/{pipeline,targets,sync-true,sync-false,crash,uses-pino-config}.test.js` — all pass
- [x] `test/transport-stream.test.js`, `test/multistream.test.js` — all pass
- [x] `test/levels.test.js`, `test/is-level-enabled.test.js` — all pass
- [x] `npm run lint` — clean

Closes #1996