### PR TITLE
test: fix flaky transport config test

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -88,14 +88,18 @@ function watchForWrite (filename, testString) {
     const threshold = TIMEOUT / INTERVAL
     let counter = 0
     const interval = setInterval(() => {
-      if (readFileSync(filename).includes(testString)) {
+      const exists = existsSync(filename)
+      if (exists && readFileSync(filename).includes(testString)) {
         clearInterval(interval)
         resolve()
       } else if (counter <= threshold) {
         counter++
       } else {
         clearInterval(interval)
-        reject(new Error(`'${testString}' hasn't been written to ${filename} within ${TIMEOUT} ms.`))
+        reject(new Error(
+          `'${testString}' hasn't been written to ${filename} within ${TIMEOUT} ms. ` +
+          (exists ? 'File exists, but content is still incomplete.' : 'File not yet created.')
+        ))
       }
     }, INTERVAL)
   })

--- a/test/transport/uses-pino-config.test.js
+++ b/test/transport/uses-pino-config.test.js
@@ -7,7 +7,7 @@ const { join } = require('node:path')
 const { readFile } = require('node:fs').promises
 const writeStream = require('flush-write-stream')
 
-const { watchFileCreated, file } = require('../helper')
+const { watchForWrite, file } = require('../helper')
 const pino = require('../../')
 
 const { pid } = process
@@ -45,7 +45,7 @@ test('transport uses pino config', async (t) => {
   const error = new Error('bar')
   instance.custom('foo')
   instance.error(error)
-  await watchFileCreated(destination)
+  await watchForWrite(destination, '"body":"bar"')
   const result = parseLogs(await readFile(destination))
 
   assert.deepEqual(result, [{
@@ -82,7 +82,7 @@ test('transport uses pino config without customizations', async (t) => {
   const error = new Error('qux')
   instance.info('baz')
   instance.error(error)
-  await watchFileCreated(destination)
+  await watchForWrite(destination, '"body":"qux"')
   const result = parseLogs(await readFile(destination))
 
   assert.deepEqual(result, [{
@@ -131,7 +131,7 @@ test('transport uses pino config with multistream', async (t) => {
   const serializedError = serializeError(error)
   instance.custom('fizz')
   instance.error(error)
-  await watchFileCreated(destination)
+  await watchForWrite(destination, '"body":"buzz"')
   const result = parseLogs(await readFile(destination))
 
   assert.deepEqual(result, [{


### PR DESCRIPTION
Fixes #2433.

- wait for the final expected write in multi-write transport tests
- make `watchForWrite()` tolerate files that are not created yet
