### PR TITLE
docs: fix typo "compatability" → "compatibility" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Pino is built to run on [Node.js](http://nodejs.org).
 
 ### Bare
 
-Pino works on [Bare](https://github.com/holepunchto/bare) with the [`pino-bare`](https://github.com/pinojs/pino-bare) compatability module.
+Pino works on [Bare](https://github.com/holepunchto/bare) with the [`pino-bare`](https://github.com/pinojs/pino-bare) compatibility module.
 
 ### Pear
 


### PR DESCRIPTION
Single-word typo fix in the Bare/Pear Runtimes section of the README. No content change beyond the spelling correction.