### PR TITLE
fix: handle read-only prepareStackTrace

### DIFF
--- a/lib/caller.js
+++ b/lib/caller.js
@@ -16,9 +16,18 @@ module.exports = function getCallers () {
   }
 
   const originalPrepare = Error.prepareStackTrace
-  Error.prepareStackTrace = noOpPrepareStackTrace
-  const stack = new Error().stack
-  Error.prepareStackTrace = originalPrepare
+  let stack
+
+  try {
+    Error.prepareStackTrace = noOpPrepareStackTrace
+    stack = new Error().stack
+  } catch {
+    return undefined
+  } finally {
+    try {
+      Error.prepareStackTrace = originalPrepare
+    } catch {}
+  }
 
   if (!Array.isArray(stack)) {
     return undefined

--- a/test/caller.test.js
+++ b/test/caller.test.js
@@ -2,6 +2,7 @@
 
 const test = require('node:test')
 const assert = require('node:assert')
+const util = require('node:util')
 const loop = require('./fixtures/caller-loop.js')
 
 test('returns a callstack of absolute paths', () => {
@@ -17,4 +18,34 @@ test('returns a callstack of absolute paths', () => {
   assert.match(callers[5], /^[/\\]fixtures[/\\]caller-loop\.js$/)
   assert.match(callers[6], /^[/\\]fixtures[/\\]caller-loop\.js$/)
   assert.match(callers[7], /^[/\\]caller\.test\.js$/)
+})
+
+test('does not throw when prepareStackTrace is read-only', () => {
+  const originalGetCallSite = util.getCallSite
+  const originalGetCallSites = util.getCallSites
+  const originalPrepareStackTrace = Object.getOwnPropertyDescriptor(Error, 'prepareStackTrace')
+  const callerPath = require.resolve('../lib/caller.js')
+
+  util.getCallSite = undefined
+  util.getCallSites = undefined
+  Object.defineProperty(Error, 'prepareStackTrace', {
+    value: undefined,
+    writable: false,
+    configurable: true
+  })
+  delete require.cache[callerPath]
+
+  try {
+    const getCallers = require('../lib/caller.js')
+    assert.equal(getCallers(), undefined)
+  } finally {
+    util.getCallSite = originalGetCallSite
+    util.getCallSites = originalGetCallSites
+    if (originalPrepareStackTrace) {
+      Object.defineProperty(Error, 'prepareStackTrace', originalPrepareStackTrace)
+    } else {
+      delete Error.prepareStackTrace
+    }
+    delete require.cache[callerPath]
+  }
 })


### PR DESCRIPTION
Fixes #2071.

## Summary
- keep using `util.getCallSites()` / `util.getCallSite()` when available
- make the legacy `Error.prepareStackTrace` fallback return `undefined` instead of throwing when `prepareStackTrace` is read-only
- add a regression test that simulates the fallback path without `util.getCallSites()` and a read-only `Error.prepareStackTrace`

## Validation
- `npm run lint`
- `node --test test/caller.test.js`
- `npx borp --timeout 60000 test/caller.test.js`
- `node --frozen-intrinsics -e "require('./pino')(); console.log('ok')"`

`npm test` starts successfully through lint, then fails on this Windows shell in `npm run transpile` because `test/fixtures/ts/transpile.cjs` shells out to `mv`, which is not available in Windows CMD/PowerShell.