### PR TITLE
Fix pipeline transport worker options

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -176,6 +176,43 @@ function buildStream (filename, workerData, workerOpts, sync, name) {
   return stream
 }
 
+function setupTransportWorkerOptions (dest, workerOpts) {
+  const { worker, ...transportOptions } = dest
+
+  if (!worker) {
+    return { dest: transportOptions, workerOpts }
+  }
+
+  const { workerData, transferList, ...streamWorkerOpts } = worker
+
+  if (workerData !== undefined) {
+    transportOptions.options = {
+      ...transportOptions.options,
+      workerData
+    }
+  }
+
+  for (const key of Object.keys(streamWorkerOpts)) {
+    if (workerOpts[key] === undefined) {
+      workerOpts = {
+        ...workerOpts,
+        [key]: streamWorkerOpts[key]
+      }
+    }
+  }
+
+  if (transferList) {
+    workerOpts = {
+      ...workerOpts,
+      transferList: workerOpts.transferList
+        ? workerOpts.transferList.concat(transferList)
+        : transferList
+    }
+  }
+
+  return { dest: transportOptions, workerOpts }
+}
+
 function autoEnd (stream) {
   stream.ref()
   stream.flushSync()
@@ -191,6 +228,7 @@ function flush (stream) {
 
 function transport (fullOptions) {
   const { pipeline, targets, levels, dedupe, worker = {}, caller = getCallers(), sync = false } = fullOptions
+  let workerOpts = { ...worker }
 
   const options = {
     ...fullOptions.options
@@ -218,17 +256,23 @@ function transport (fullOptions) {
   if (targets) {
     target = bundlerOverrides['pino-worker'] || join(__dirname, 'worker.js')
     options.targets = targets.filter(dest => dest.target).map((dest) => {
+      const transport = setupTransportWorkerOptions(dest, workerOpts)
+      workerOpts = transport.workerOpts
+
       return {
-        ...dest,
-        target: fixTarget(dest.target)
+        ...transport.dest,
+        target: fixTarget(transport.dest.target)
       }
     })
     options.pipelines = targets.filter(dest => dest.pipeline).map((dest) => {
       return dest.pipeline.map((t) => {
+        const transport = setupTransportWorkerOptions(t, workerOpts)
+        workerOpts = transport.workerOpts
+
         return {
-          ...t,
+          ...transport.dest,
           level: dest.level, // duplicate the pipeline `level` property defined in the upper level
-          target: fixTarget(t.target)
+          target: fixTarget(transport.dest.target)
         }
       })
     })
@@ -237,9 +281,12 @@ function transport (fullOptions) {
   } else if (pipeline) {
     target = bundlerOverrides['pino-worker'] || join(__dirname, 'worker.js')
     options.pipelines = [pipeline.map((dest) => {
+      const transport = setupTransportWorkerOptions(dest, workerOpts)
+      workerOpts = transport.workerOpts
+
       return {
-        ...dest,
-        target: fixTarget(dest.target)
+        ...transport.dest,
+        target: fixTarget(transport.dest.target)
       }
     })]
   }
@@ -255,7 +302,7 @@ function transport (fullOptions) {
   options.pinoWillSendConfig = true
 
   const name = (targets || pipeline) ? 'pino.transport' : target
-  const stream = buildStream(fixTarget(target), options, worker, sync, name)
+  const stream = buildStream(fixTarget(target), options, workerOpts, sync, name)
   if (usesMultistream) {
     stream[transportUsesMultistreamSym] = true
   }

--- a/test/fixtures/transport-pipeline-worker-options.js
+++ b/test/fixtures/transport-pipeline-worker-options.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const build = require('pino-abstract-transport')
+const { pipeline, Transform } = require('node:stream')
+
+module.exports = (options) => {
+  const { port, value } = options.workerData
+  port.postMessage({ value })
+  port.close()
+
+  return build(function (source) {
+    const stream = new Transform({
+      autoDestroy: true,
+      objectMode: true,
+      transform (chunk, enc, cb) {
+        this.push(JSON.stringify(chunk))
+        cb()
+      }
+    })
+    pipeline(source, stream, () => {})
+    return stream
+  }, {
+    enablePipelining: true
+  })
+}

--- a/test/transport/pipeline.test.js
+++ b/test/transport/pipeline.test.js
@@ -3,8 +3,10 @@
 const test = require('node:test')
 const assert = require('node:assert')
 const os = require('node:os')
+const { once } = require('node:events')
 const { join } = require('node:path')
 const { readFile } = require('node:fs').promises
+const { MessageChannel } = require('node:worker_threads')
 
 const { watchFileCreated, file } = require('../helper')
 const pino = require('../../')
@@ -35,6 +37,45 @@ test('pino.transport with a pipeline', async (t) => {
     level: DEFAULT_LEVELS.info,
     msg: 'hello',
     service: 'pino' // this property was added by the transform
+  })
+})
+
+test('pino.transport with a pipeline passes worker options', async (t) => {
+  const destination = file()
+  const { port1, port2 } = new MessageChannel()
+  const message = once(port2, 'message')
+  t.after(() => port2.close())
+
+  const transport = pino.transport({
+    pipeline: [{
+      target: join(__dirname, '..', 'fixtures', 'transport-pipeline-worker-options.js'),
+      worker: {
+        workerData: {
+          port: port1,
+          value: 'worker options'
+        },
+        transferList: [port1]
+      }
+    }, {
+      target: join(__dirname, '..', 'fixtures', 'to-file-transport.js'),
+      options: { destination }
+    }]
+  })
+  t.after(transport.end.bind(transport))
+  const instance = pino(transport)
+  instance.info('hello')
+
+  const [workerData] = await message
+  assert.deepEqual(workerData, { value: 'worker options' })
+
+  await watchFileCreated(destination)
+  const result = JSON.parse(await readFile(destination))
+  delete result.time
+  assert.deepEqual(result, {
+    pid,
+    hostname,
+    level: DEFAULT_LEVELS.info,
+    msg: 'hello'
   })
 })
 


### PR DESCRIPTION
Fixes #1856.

This updates pipeline transport setup so worker options defined on individual pipeline transport entries are not serialized directly into the pino worker configuration. Instead, `workerData` is forwarded to that transport's options and nested `transferList` entries are carried up to the actual worker thread options.

That lets transports in a pipeline receive worker data containing transferable values such as `MessagePort` without triggering `Object that needs transfer was found in message but not listed in transferList`.

Validation:
- `npx borp --timeout 60000 test/transport/pipeline.test.js`
- `node --test test/transport/pipeline.test.js`
- `npm run lint`