### PR TITLE
chore: remove outdated Node 14 conditional in CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,7 @@ jobs:
         run: npm run test-ci
 
       - name: Run smoke test
-        if: >
-          matrix.os != 'windows-latest' &&
-          matrix.node-version > 14
+        if: matrix.os != 'windows-latest'
         run: npm run test:smoke
 
   automerge:


### PR DESCRIPTION
The CI matrix already dropped Node 14 and 16 (running 20+ only), but the smoke test step still had a stale \matrix.node-version > 14\ condition. Since all current versions satisfy this, it's redundant -- cleaned it up.

Closes #1749