### PR TITLE
fix(browser): serialize err.cause in errWithCause

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -39,7 +39,7 @@ const stdSerializers = {
   req: mock,
   res: mock,
   err: asErrValue,
-  errWithCause: asErrValue
+  errWithCause: asErrValueWithCause
 }
 function levelToValue (level, logger) {
   return level === 'silent'
@@ -509,6 +509,31 @@ function asErrValue (err) {
       obj[key] = err[key]
     }
   }
+  return obj
+}
+
+function asErrValueWithCause (err, seen) {
+  const obj = asErrValue(err)
+  if (!seen) {
+    seen = new Map()
+  } else if (seen.has(err)) {
+    return obj
+  }
+
+  seen.set(err, obj)
+  if (err.cause) {
+    const cause = err.cause
+    if (typeof cause === 'object' && cause !== null) {
+      if (cause.name) {
+        obj.cause = asErrValueWithCause(cause, seen)
+      } else {
+        obj.cause = cause
+      }
+    } else {
+      obj.cause = cause
+    }
+  }
+
   return obj
 }
 

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -118,6 +118,17 @@ test('exposes err stdSerializer', ({ end, ok }) => {
   end()
 })
 
+test('exposes errWithCause stdSerializer', ({ end, is }) => {
+  const err = new Error('outer')
+  err.cause = new Error('inner')
+  const serialized = pino.stdSerializers.errWithCause(err)
+  is(serialized.type, 'Error')
+  is(serialized.msg, 'outer')
+  is(serialized.cause.type, 'Error')
+  is(serialized.cause.msg, 'inner')
+  end()
+})
+
 consoleMethodTest('error')
 consoleMethodTest('fatal', 'error')
 consoleMethodTest('warn')


### PR DESCRIPTION
## Summary
- Update browser std serializer for errWithCause to recursively serialize Error.cause while avoiding cycles.
- Add regression test to assert serialized cause type/message are preserved.`n## Validation
- node test/browser.test.js
- npx eslint browser.js test/browser.test.js