### PR TITLE
fix: handle read-only Error.prepareStackTrace safely

### DIFF
--- a/lib/caller.js
+++ b/lib/caller.js
@@ -16,9 +16,20 @@ module.exports = function getCallers () {
   }
 
   const originalPrepare = Error.prepareStackTrace
-  Error.prepareStackTrace = noOpPrepareStackTrace
-  const stack = new Error().stack
-  Error.prepareStackTrace = originalPrepare
+  let stack
+
+  try {
+    Error.prepareStackTrace = noOpPrepareStackTrace
+    stack = new Error().stack
+  } catch (err) {
+    return undefined
+  } finally {
+    try {
+      Error.prepareStackTrace = originalPrepare
+    } catch (err) {
+      // Ignore cases where prepareStackTrace is not writable.
+    }
+  }
 
   if (!Array.isArray(stack)) {
     return undefined

--- a/test/caller.test.js
+++ b/test/caller.test.js
@@ -3,6 +3,7 @@
 const test = require('node:test')
 const assert = require('node:assert')
 const loop = require('./fixtures/caller-loop.js')
+const proxyquire = require('proxyquire')
 
 test('returns a callstack of absolute paths', () => {
   const callers = loop(7).map(fileName => fileName.substring(__dirname.length))
@@ -17,4 +18,34 @@ test('returns a callstack of absolute paths', () => {
   assert.match(callers[5], /^[/\\]fixtures[/\\]caller-loop\.js$/)
   assert.match(callers[6], /^[/\\]fixtures[/\\]caller-loop\.js$/)
   assert.match(callers[7], /^[/\\]caller\.test\.js$/)
+})
+
+test('returns undefined when Error.prepareStackTrace is read-only', () => {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(Error, 'prepareStackTrace')
+
+  try {
+    assert.ok(originalDescriptor)
+    Object.defineProperty(Error, 'prepareStackTrace', {
+      ...originalDescriptor,
+      writable: false
+    })
+  } catch (err) {
+    throw new Error(`failed to lock prepareStackTrace for regression test: ${err.message}`)
+  }
+
+  const getCallers = proxyquire('../lib/caller', {
+    'node:util': {
+      getCallSites: undefined,
+      getCallSite: undefined
+    }
+  })
+
+  try {
+    const callers = getCallers()
+    assert.equal(callers, undefined)
+  } finally {
+    if (originalDescriptor) {
+      Object.defineProperty(Error, 'prepareStackTrace', originalDescriptor)
+    }
+  }
 })


### PR DESCRIPTION
## Summary\n\n- Guard Error.prepareStackTrace assignment in lib/caller.js so environments with read-only accessors do not throw.\n- Restore Error.prepareStackTrace in a inally block and keep undefined fallback behavior when the legacy stack path cannot be used.\n- Add regression coverage in 	est/caller.test.js for the read-only prepareStackTrace case using proxyquire.\n\n## Validation\n\n- 
px eslint lib/caller.js test/caller.test.js\n- 
ode --test test/caller.test.js\n- 
pm run test (note: fails on Windows locally because 	est/fixtures/ts/transpile.cjs invokes mv, unavailable on this environment)