### PR TITLE
docs: warn against untrusted top-level log keys

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,16 @@ non-externally provided input.
 Pino assumes all objects being logged, `logger.info(obj, message)`, are json-serializable.
 Use the `serializers` and `redact` features to sanitize them.
 
+Pino also assumes that applications control the top-level keys of logged objects
+and child logger bindings. Do not pass externally supplied objects directly as
+`logger.info(untrustedObject)` or `logger.child(untrustedObject)`. Top-level
+keys are written at the root of the log line and can conflict with Pino fields
+such as `level`, `time`, or `msg`, as well as application or security fields.
+If untrusted data must be logged, place it under an application-controlled key,
+for example `logger.info({ untrusted })` or `logger.child({ untrusted })`, and
+apply appropriate serialization and redaction. As a matter of good security
+hygiene, prefer not to log untrusted data at all unless it is necessary.
+
 Pino is not hardened against external prototype pollution attacks, but we
 will accept a vulnerability if Pino can be misused to cause a prototype pollution.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -724,6 +724,25 @@ logger.info({MIX: {IN: true}})
 // {"level":30,"time":1531254555820,"pid":55956,"hostname":"x","MIX":{"IN":true}}
 ```
 
+Do not pass an externally supplied object directly as the `mergingObject`.
+Top-level keys are written at the root of the log line and can conflict with
+Pino fields such as `level`, `time`, or `msg`, as well as application or
+security fields. If untrusted data must be logged, place it under an
+application-controlled key:
+
+```js
+// Avoid: user-controlled keys become top-level log fields
+logger.info(untrustedObject)
+
+// Prefer: user-controlled keys are contained under a trusted namespace
+logger.info({ untrusted: untrustedObject })
+```
+
+As a matter of good security hygiene, prefer not to log untrusted data at all
+unless it is necessary. When it is necessary, sanitize and redact it first.
+The same top-level key guidance applies to [`logger.child()` bindings](#logger-child-bindings)
+and [`logger.setBindings()`](#logger-set-bindings).
+
 If the object is of type Error, it is wrapped in an object containing a property err (`{ err: mergingObject }`).
 This allows for a unified error handling flow.
 
@@ -926,6 +945,24 @@ child.info('child!')
 
 The `bindings` object may contain any key except for reserved configuration keys `level` and `serializers`.
 
+Do not pass externally supplied objects directly as child bindings. Binding keys
+are top-level log fields emitted on every log line from the child logger, so
+user-controlled keys can conflict with Pino fields such as `level`, `time`, or
+`msg`, as well as application or security fields. If untrusted data must be
+included in child bindings, place it under an application-controlled key:
+
+```js
+// Avoid: user-controlled keys become top-level fields on every child log line
+const child = logger.child(untrustedObject)
+
+// Prefer: user-controlled keys are contained under a trusted namespace
+const child = logger.child({ untrusted: untrustedObject })
+```
+
+As a matter of good security hygiene, prefer not to log untrusted data at all
+unless it is necessary. When it is necessary, sanitize and redact it first.
+See also [`mergingObject`](#mergingobject) and [`logger.setBindings()`](#logger-set-bindings).
+
 ##### `bindings.serializers` (Object) - DEPRECATED
 
 Use `options.serializers` instead.
@@ -1022,6 +1059,11 @@ Adds to the bindings of this logger instance.
 
 **Note:** Does not overwrite bindings. Can potentially result in duplicate keys in
 log lines.
+
+Do not pass externally supplied objects directly as bindings. Binding keys are
+top-level log fields and can conflict with Pino fields or application fields.
+If untrusted data must be added, place it under an application-controlled key,
+for example `logger.setBindings({ untrusted })`, and sanitize or redact it first.
 
 * See [`bindings` parameter in `logger.child`](#logger-child-bindings)
 

--- a/docs/child-loggers.md
+++ b/docs/child-loggers.md
@@ -20,6 +20,26 @@ module.exports = {
 }
 ```
 
+Child logger bindings are top-level fields on every log line emitted by the
+child logger. Do not create child loggers from externally supplied objects or
+user-controlled binding names, because those keys can conflict with Pino fields
+such as `level`, `time`, or `msg`, as well as application or security fields.
+If untrusted data must be associated with logs, place it under an
+application-controlled key:
+
+```js
+// Avoid: user-controlled keys become top-level fields on every child log line
+const child = logger.child(untrustedObject)
+
+// Prefer: user-controlled keys are contained under a trusted namespace
+const child = logger.child({ untrusted: untrustedObject })
+```
+
+As a matter of good security hygiene, prefer not to log untrusted data at all
+unless it is necessary. When it is necessary, sanitize and redact it first.
+See also [`logger.child()` in the API documentation](/docs/api.md#child) and
+[`mergingObject`](/docs/api.md#mergingobject).
+
 ## Cost of child logging
 
 Child logger creation is fast:
@@ -88,7 +108,8 @@ behavior.
 
 There may be cases where this edge case becomes problematic if a JSON parser with alternative behavior
 is used to process the logs. It's recommended to be conscious of namespace conflicts with child loggers,
-in light of an expected log processing approach.
+in light of an expected log processing approach. This is especially important for untrusted data: do not
+allow externally supplied objects or user-controlled key names to become child logger bindings.
 
 One of Pino's performance tricks is to avoid building objects and stringifying
 them, so we're building strings instead. This is why duplicate keys between

--- a/docs/help.md
+++ b/docs/help.md
@@ -147,11 +147,19 @@ const logger = pino({
 <a id="dupe-keys"></a>
 ## How Pino handles duplicate keys
 
-Duplicate keys are possibly when a child logger logs an object with a key that
-collides with a key in the child loggers bindings.
+Duplicate keys are possible when a logged object contains a top-level key that
+collides with a Pino field or a key in the child logger's bindings, or when child
+logger bindings collide with parent bindings.
+
+For untrusted data, avoid passing externally supplied objects directly to logging
+methods or child logger bindings. User-controlled top-level keys can conflict
+with Pino fields such as `level`, `time`, or `msg`, as well as application or
+security fields. If untrusted data must be logged, place it under an
+application-controlled key, such as `logger.info({ untrusted })`, and prefer not
+to log untrusted data at all unless necessary.
 
 See the [child logger duplicate keys caveat](/docs/child-loggers.md#duplicate-keys-caveat)
-for information on this is handled.
+and [`logger.child()` bindings](/docs/api.md#logger-child-bindings) for more information.
 
 <a id="level-string"></a>
 ## Log levels as labels instead of numbers


### PR DESCRIPTION
## Summary

- document that untrusted top-level log object keys can conflict with Pino, application, and security fields
- recommend wrapping untrusted data under an application-controlled key, including for `logger.child()` bindings
- cross-link duplicate key and child logger guidance

## Validation

- `npm run lint -- --quiet`
