### PR TITLE
Defense-in-depth: require own-property `transport` to skip prototype-pollution gadget

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -334,7 +334,7 @@ function createArgsNormalizer (defaultOptions) {
     } else if (opts instanceof SonicBoom || opts.writable || opts._writableState) {
       stream = opts
       opts = {}
-    } else if (opts.transport) {
+    } else if (Object.hasOwn(opts, 'transport') && opts.transport) {
       if (opts.transport instanceof SonicBoom || opts.transport.writable || opts.transport._writableState) {
         throw Error('option.transport do not allow stream, please pass to option directly. e.g. pino(transport)')
       }

--- a/test/fixtures/transport-pp-gadget-sentinel.mjs
+++ b/test/fixtures/transport-pp-gadget-sentinel.mjs
@@ -1,0 +1,28 @@
+// Attacker fixture for the prototype-pollution defense-in-depth test.
+//
+// If this module is ever imported by thread-stream's worker, the
+// top-level side effect below creates a sentinel file at the path
+// supplied via PINO_PP_TEST_SENTINEL. The defense in lib/tools.js
+// must prevent the worker from being spawned in the first place
+// when `transport` is inherited from Object.prototype, so this
+// module must never be imported.
+//
+// The default export returns a working no-op writable so that if the
+// worker IS spawned (defense regression), the worker doesn't crash —
+// the test then asserts on the sentinel file's existence rather than
+// on noisy worker-error propagation.
+import { writeFileSync } from 'node:fs'
+import { Writable } from 'node:stream'
+
+if (process.env.PINO_PP_TEST_SENTINEL) {
+  writeFileSync(process.env.PINO_PP_TEST_SENTINEL, 'attacker-module-loaded')
+}
+
+export default async function run () {
+  return new Writable({
+    autoDestroy: true,
+    write (chunk, enc, cb) {
+      cb()
+    }
+  })
+}

--- a/test/transport/protect-from-prototype-pollution.test.js
+++ b/test/transport/protect-from-prototype-pollution.test.js
@@ -1,0 +1,91 @@
+'use strict'
+
+// Regression for the defense-in-depth in lib/tools.js — the
+// `else if` that loads a transport now requires `transport` to be
+// the caller's own property, not inherited from Object.prototype.
+//
+// Threat model anchor: pino doesn't promise PP-safety in general,
+// but if Object.prototype.transport is polluted upstream, the
+// gadget would otherwise reach `thread-stream` -> dynamic import()
+// of an attacker-controlled module path. The own-property check
+// closes that read site without altering behaviour for normal
+// callers.
+
+const test = require('node:test')
+const assert = require('node:assert')
+const { existsSync, readFileSync } = require('node:fs')
+const { join } = require('node:path')
+const { setTimeout: sleep } = require('node:timers/promises')
+
+const { file, watchFileCreated } = require('../helper')
+const pino = require('../../')
+
+const ATTACKER_FIXTURE = join(__dirname, '..', 'fixtures', 'transport-pp-gadget-sentinel.mjs')
+
+function withPollutedTransport (target, fn) {
+  // Defensive: never overwrite an existing inherited descriptor; if
+  // another test in the same process has already set it (which it
+  // shouldn't), fail loudly rather than silently masking the issue.
+  assert.equal(Object.hasOwn(Object.prototype, 'transport'), false,
+    'Object.prototype.transport already polluted before test start')
+  Object.prototype.transport = { target } // eslint-disable-line no-extend-native
+  try {
+    return fn()
+  } finally {
+    delete Object.prototype.transport
+  }
+}
+
+test('pino() ignores inherited Object.prototype.transport (gadget closed)', async () => {
+  const sentinel = file()
+  process.env.PINO_PP_TEST_SENTINEL = sentinel
+
+  try {
+    withPollutedTransport(ATTACKER_FIXTURE, () => {
+      // No own `transport` here. With the defense, this MUST take the
+      // default branch and return a plain stdout-backed logger.
+      const instance = pino()
+      // Sanity: instance should still be a usable logger.
+      assert.equal(typeof instance.info, 'function')
+    })
+
+    // Worker spawn + ESM resolve typically completes within ~50ms;
+    // give a generous window then assert the side effect never fired.
+    await sleep(300)
+    assert.equal(existsSync(sentinel), false,
+      'attacker module was imported via the prototype-polluted transport gadget')
+  } finally {
+    delete process.env.PINO_PP_TEST_SENTINEL
+  }
+})
+
+test('pino({transport: {target}}) still spawns the worker for own-property transport', async () => {
+  // Same prototype-polluted state, but the caller supplies their own
+  // `transport` -- the defense must not break this path.
+  const destination = file()
+  const legitFixture = join(__dirname, '..', 'fixtures', 'to-file-transport.mjs')
+
+  await new Promise((resolve, reject) => {
+    let instance
+    try {
+      withPollutedTransport(ATTACKER_FIXTURE, () => {
+        instance = pino({
+          transport: {
+            target: legitFixture,
+            options: { destination }
+          }
+        })
+        instance.info('hello-from-own-property-transport')
+      })
+    } catch (err) {
+      reject(err)
+      return
+    }
+    // Flush the legit transport then check it received the line.
+    watchFileCreated(destination).then(resolve, reject)
+  })
+
+  const written = readFileSync(destination, 'utf8')
+  assert.match(written, /hello-from-own-property-transport/,
+    'own-property transport did not receive the log line')
+})


### PR DESCRIPTION

## What

One-line change at `lib/tools.js:337` — gate the `opts.transport` branch on `Object.hasOwn(opts, 'transport')`. When `opts` doesn't have its own `transport` key, skip the transport-loading branch instead of reading the value through the prototype chain.

## Why

Per your reply on GHSA-7f85-5jq4-96m8, pino's threat model assumes no active prototype pollution on the process. That's fair — Node itself doesn't harden against PP, so libraries can't promise to either. This PR isn't asking pino to make that guarantee; it's accepting the existing threat model and adding a single own-property check at the place that triggers a dynamic `import()` via `thread-stream`.

The change costs one method call per `pino()` invocation (Object.hasOwn is V8-fast-path) and removes the one read site where a polluted `Object.prototype.transport` value would reach an import path.

## What it does NOT do

- Doesn't claim to make pino "PP-safe". Any of the other dozen `opts.*` reads in this function still inherit from the prototype.
- Doesn't change behavior for any normal caller — if you pass `pino({transport:...})`, `opts.transport` is an own-property and `hasOwn` returns true.
- Doesn't add a dependency or a sanitization layer.

## Test coverage

Verified locally against `pino@main` (`0a10b332`):

- **`npm test`** — 531 tests, **527 pass, 0 fail**. One flaky retry on `thread-stream async flush should call the passed callback`; runner counted it 0-fail. Unrelated to the transport-read site.
- **Gadget closed** — with `Object.prototype.transport = {target:'./evil.mjs'}` polluted, calling `pino()` no longer spawns the worker → no attacker module loaded → no sentinel file created. (PoC from GHSA-7f85-5jq4-96m8 reproduced under the patched source.)
- **Normal usage preserved** — `pino({transport: {target: <legit>}})` still spawns the worker and reaches the user-supplied transport module. Own-property `transport` passes `hasOwn`, branch fires as before.
- **Coverage** — `tools.js` lines: 97.65% pre-patch and post-patch; the patched line (337) sits in the already-covered region.

Happy to add an explicit regression test for the polluted-prototype case if you'd like — `test/transport/transport.test.js` would be the natural home. Drop the PoC in a `tap.test('pino() ignores inherited Object.prototype.transport', ...)` block.

## Why this read site specifically

Of the 5 reads of `opts.transport` in `normalizeArgs`, this is the one that flows into `transport({...opts.transport, ...})` which calls `new ThreadStream({worker: target})` and ends up at `worker_threads.Worker` + dynamic `import()`. The other reads (`opts && opts.transport` truthy check at L330, `instanceof SonicBoom` at L338, `.targets`/`.writable`/`._writableState` checks) either throw an error on the polluted shape or short-circuit harmlessly. Hardening just the dangerous one keeps the patch minimal.