### PR TITLE
fix: escape child binding keys

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -258,7 +258,7 @@ function asChindings (instance, bindings) {
       value = serializers[key] ? serializers[key](value) : value
       value = (stringifiers[key] || wildcardStringifier || stringify)(value, stringifySafe)
       if (value === undefined) continue
-      data += ',"' + key + '":' + value
+      data += ',' + asString(key) + ':' + value
     }
   }
   return data

--- a/test/escaping.test.js
+++ b/test/escaping.test.js
@@ -36,6 +36,23 @@ testEscape('\\r', '\r')
 testEscape('\\t', '\t')
 testEscape('\\b', '\b')
 
+test('correctly escape child binding keys', async () => {
+  const stream = sink()
+  const key = 'x"}\n{"level":60,"msg":"forged"}\n{"swallow'
+  const instance = pino(stream).child({ [key]: true })
+
+  instance.info('hello')
+  const result = await once(stream, 'data')
+  delete result.time
+  assert.deepEqual(result, {
+    pid,
+    hostname,
+    level: 30,
+    msg: 'hello',
+    [key]: true
+  })
+})
+
 const toEscape = [
   '\u0000', // NUL  Null character
   '\u0001', // SOH  Start of Heading


### PR DESCRIPTION
## Summary

- serialize child and base binding keys with the existing JSON string encoder
- preserve quotes, backslashes, and control characters without breaking NDJSON framing
- add a regression test for a crafted child binding key containing quotes and newlines

## Tests

- `npm test`
- `node --test test/escaping.test.js`
- `git diff --check`
