### PR TITLE
fix(types): add missing remove() and lastId to MultiStreamRes

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -301,8 +301,10 @@ declare namespace pino {
     export interface MultiStreamRes<TOriginLevel = Level> {
       write: (data: any) => void,
       add: <TLevel = Level>(dest: StreamEntry<TLevel> | DestinationStream) => MultiStreamRes<TOriginLevel & TLevel>,
+      remove: (id: number) => MultiStreamRes<TOriginLevel>,
       flushSync: () => void,
       minLevel: number,
+      lastId: number,
       streams: StreamEntry<TOriginLevel>[],
       clone<const TLevel = Level>(level: TLevel): MultiStreamRes<TLevel>,
     }

--- a/test/types/pino-multistream.tst.ts
+++ b/test/types/pino-multistream.tst.ts
@@ -45,5 +45,9 @@ expect(multistream(streams)).type.toBe<
 expect(multistream(streams).clone('error')).type.toBe<
   pino.MultiStreamRes<'error'>
 >()
+expect(multistream(streams).remove(0)).type.toBe<
+  pino.MultiStreamRes<'error' | 'fatal'>
+>()
+expect(multistream(process.stdout).lastId).type.toBe<number>()
 
 expect(multistream(process.stdout)).type.toBe<pino.MultiStreamRes>()


### PR DESCRIPTION
## What

`MultiStreamRes` — the object returned by `pino.multistream()` — is missing two members from its TypeScript declaration: `remove(id)` and `lastId`.

## Why

Both are real, public, documented members of the returned object:

- **Runtime** (`lib/multistream.js`): the returned object includes `remove` and `lastId: 0`, stream IDs are assigned via `++res.lastId`, and `remove(id)` removes a stream by its assigned ID.
- **Docs** (`docs/api.md`): the `MultiStreamRes` "Properties" section documents both `lastId` and `remove(id)`.

But the `MultiStreamRes` interface in `pino.d.ts` only declared `write`, `add`, `flushSync`, `minLevel`, `streams`, and `clone`. As a result, TypeScript users calling `multistream(...).remove(id)` or reading `.lastId` get `error TS2339: Property does not exist on type 'MultiStreamRes<...>'`, despite both being documented, shipped public API.

## Changes

- Add `remove: (id: number) => MultiStreamRes<TOriginLevel>` and `lastId: number` to the `MultiStreamRes` interface in `pino.d.ts`.
- Add tstyche assertions in `test/types/pino-multistream.tst.ts` covering `.remove(0)` and `.lastId`.

Type-only change — no runtime behavior change. `npm run test-types` (tsc + tstyche + ts-node + attw) and `npm run lint` pass locally.
