### PR TITLE
docs: add Deno to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Using YARN:
 $ yarn add pino
 ```
 
+Using Deno:
+```
+$ deno install pino
+```
+
 If you would like to install pino v6, refer to https://github.com/pinojs/pino/tree/v6.x.
 
 ## Usage


### PR DESCRIPTION
👋 Bartek from the Deno team here.

The install instructions list npm and yarn, but not Deno. Since Deno is a drop-in replacement for npm these days, I'd like to add a Deno line so Deno users have a copy-pasteable command, in parity with the others:

```sh
deno install pino
```

(As of Deno 2.8 there's no `npm:` prefix needed, it's the same command shape as `npm install pino`.)

Totally fine to close this if you'd rather keep the list short, no hard feelings. Happy to adjust wording, placement, or move it to a docs site instead.

_Disclosure: I work on Deno, so I have an interest here. The goal is parity with the package managers you already list, not promotion. This PR was prepared with AI assistance under human supervision: I review every change myself and personally respond to any comments or review feedback._
