### PR TITLE
fix: log objects with an own __proto__ key instead of crashing

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -166,13 +166,13 @@ function _asJson (obj, msg, num, time) {
   for (const key in obj) {
     value = obj[key]
     if (Object.prototype.hasOwnProperty.call(obj, key) && value !== undefined) {
-      if (serializers[key]) {
+      if (typeof serializers[key] === 'function') {
         value = serializers[key](value)
       } else if (key === errorKey && serializers.err) {
         value = serializers.err(value)
       }
 
-      const stringifier = stringifiers[key] || wildcardStringifier
+      const stringifier = typeof stringifiers[key] === 'function' ? stringifiers[key] : wildcardStringifier
 
       switch (typeof value) {
         case 'undefined':
@@ -201,8 +201,8 @@ function _asJson (obj, msg, num, time) {
 
   let msgStr = ''
   if (msg !== undefined) {
-    value = serializers[messageKey] ? serializers[messageKey](msg) : msg
-    const stringifier = stringifiers[messageKey] || wildcardStringifier
+    value = typeof serializers[messageKey] === 'function' ? serializers[messageKey](msg) : msg
+    const stringifier = typeof stringifiers[messageKey] === 'function' ? stringifiers[messageKey] : wildcardStringifier
 
     switch (typeof value) {
       case 'function':
@@ -255,8 +255,9 @@ function asChindings (instance, bindings) {
       bindings.hasOwnProperty(key) &&
       value !== undefined
     if (valid === true) {
-      value = serializers[key] ? serializers[key](value) : value
-      value = (stringifiers[key] || wildcardStringifier || stringify)(value, stringifySafe)
+      value = typeof serializers[key] === 'function' ? serializers[key](value) : value
+      const stringifier = typeof stringifiers[key] === 'function' ? stringifiers[key] : (wildcardStringifier || stringify)
+      value = stringifier(value, stringifySafe)
       if (value === undefined) continue
       data += ',"' + key + '":' + value
     }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -349,7 +349,7 @@ function createArgsNormalizer (defaultOptions) {
       stream = transport({ caller, ...opts.transport, levels: customLevels })
     }
     opts = Object.assign({}, defaultOptions, opts)
-    opts.serializers = Object.assign({}, defaultOptions.serializers, opts.serializers)
+    opts.serializers = Object.assign(Object.create(null), defaultOptions.serializers, opts.serializers)
     opts.formatters = Object.assign({}, defaultOptions.formatters, opts.formatters)
 
     if (opts.prettyPrint) {

--- a/pino.js
+++ b/pino.js
@@ -131,7 +131,9 @@ function pino (...args) {
   const stringifyFn = stringify.bind({
     [stringifySafeSym]: stringifySafe
   })
-  const stringifiers = redact ? redaction(redact, stringifyFn) : {}
+  const stringifiers = redact
+    ? Object.assign(Object.create(null), redaction(redact, stringifyFn))
+    : Object.create(null)
   const formatOpts = redact
     ? { stringify: stringifiers[redactFmtSym] }
     : { stringify: stringifyFn }

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -884,3 +884,34 @@ test('grandchild message should inherent parent prefix', async () => {
   const { msg } = await once(stream, 'data')
   assert.equal(msg, 'My name is Bond James Bond')
 })
+
+test('logs an object with an own enumerable __proto__ key', async () => {
+  const stream = sink()
+  const instance = pino(stream)
+  // JSON.parse produces an own enumerable __proto__ key from any untrusted JSON
+  const obj = JSON.parse('{"__proto__":{"x":1},"user":"bob"}')
+  instance.info(obj, 'incoming request')
+  const result = await once(stream, 'data')
+  check(assert.equal.bind(assert), result, 30, 'incoming request')
+  assert.equal(result.user, 'bob')
+})
+
+test('logs a redacted object with an own enumerable __proto__ key', async () => {
+  const stream = sink()
+  const instance = pino({ redact: ['user'] }, stream)
+  const obj = JSON.parse('{"__proto__":{"x":1},"user":"bob"}')
+  instance.info(obj, 'incoming request')
+  const result = await once(stream, 'data')
+  check(assert.equal.bind(assert), result, 30, 'incoming request')
+  assert.equal(result.user, '[Redacted]')
+})
+
+test('logs child bindings with an own enumerable __proto__ key', async () => {
+  const stream = sink()
+  const bindings = JSON.parse('{"__proto__":{"x":1},"reqId":"abc"}')
+  const instance = pino(stream).child(bindings)
+  instance.info('incoming request')
+  const result = await once(stream, 'data')
+  check(assert.equal.bind(assert), result, 30, 'incoming request')
+  assert.equal(result.reqId, 'abc')
+})

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -884,3 +884,69 @@ test('grandchild message should inherent parent prefix', async () => {
   const { msg } = await once(stream, 'data')
   assert.equal(msg, 'My name is Bond James Bond')
 })
+
+test('logs an object with an own enumerable __proto__ key', async () => {
+  const stream = sink()
+  const instance = pino(stream)
+  // JSON.parse produces an own enumerable __proto__ key from any untrusted JSON
+  const obj = JSON.parse('{"__proto__":{"x":1},"user":"bob"}')
+  instance.info(obj, 'incoming request')
+  const result = await once(stream, 'data')
+  check(assert.equal.bind(assert), result, 30, 'incoming request')
+  assert.equal(result.user, 'bob')
+})
+
+test('logs a redacted object with an own enumerable __proto__ key', async () => {
+  const stream = sink()
+  const instance = pino({ redact: ['user'] }, stream)
+  const obj = JSON.parse('{"__proto__":{"x":1},"user":"bob"}')
+  instance.info(obj, 'incoming request')
+  const result = await once(stream, 'data')
+  check(assert.equal.bind(assert), result, 30, 'incoming request')
+  assert.equal(result.user, '[Redacted]')
+})
+
+test('logs child bindings with an own enumerable __proto__ key', async () => {
+  const stream = sink()
+  const bindings = JSON.parse('{"__proto__":{"x":1},"reqId":"abc"}')
+  const instance = pino(stream).child(bindings)
+  instance.info('incoming request')
+  const result = await once(stream, 'data')
+  check(assert.equal.bind(assert), result, 30, 'incoming request')
+  assert.equal(result.reqId, 'abc')
+})
+
+test('logs an object with keys named after Object.prototype members', async () => {
+  const stream = sink()
+  const instance = pino(stream)
+  const obj = {
+    toString: 'a',
+    constructor: 'b',
+    valueOf: 'c',
+    hasOwnProperty: 'd',
+    propertyIsEnumerable: 'e',
+    toLocaleString: 'f',
+    isPrototypeOf: 'g'
+  }
+  instance.info(obj, 'incoming request')
+  const result = await once(stream, 'data')
+  check(assert.equal.bind(assert), result, 30, 'incoming request')
+  assert.equal(result.toString, 'a')
+  assert.equal(result.constructor, 'b')
+  assert.equal(result.valueOf, 'c')
+  assert.equal(result.hasOwnProperty, 'd')
+  assert.equal(result.propertyIsEnumerable, 'e')
+  assert.equal(result.toLocaleString, 'f')
+  assert.equal(result.isPrototypeOf, 'g')
+})
+
+test('logs a redacted object with keys named after Object.prototype members', async () => {
+  const stream = sink()
+  const instance = pino({ redact: ['secret'] }, stream)
+  instance.info({ toString: 'a', valueOf: 'b', secret: 'x' }, 'incoming request')
+  const result = await once(stream, 'data')
+  check(assert.equal.bind(assert), result, 30, 'incoming request')
+  assert.equal(result.toString, 'a')
+  assert.equal(result.valueOf, 'b')
+  assert.equal(result.secret, '[Redacted]')
+})


### PR DESCRIPTION
## Problem

Logging an object that has an own enumerable `__proto__` key crashes the logger and drops the log line:

```js
const pino = require('pino')
pino().info(JSON.parse('{"__proto__":{"x":1},"user":"bob"}'), 'incoming request')
// TypeError: serializers[key] is not a function
// nothing is written
```

Such an object is the normal result of parsing untrusted JSON. `JSON.parse('{"__proto__":{...}}')` defines `__proto__` as an own enumerable data property rather than setting the prototype, so any request body, queue message, or webhook payload routed straight into a log call can trigger it. `JSON.stringify` serializes the same object without issue, so the expected behavior is a single valid NDJSON line.

## Root cause

The serializers and stringifiers objects are merged in a way that leaves `Object.prototype` on their prototype chain. When the log object loop reaches `key === '__proto__'`, `serializers[key]` resolves to `Object.prototype`, which is truthy but not a function:

```js
if (serializers[key]) {        // Object.prototype is truthy
  value = serializers[key](value)  // throws: not a function
}
```

The same pattern affects the stringifier lookup in `_asJson`, the message key lookup, and the serializer and stringifier lookups for child bindings in `asChindings`.

## Fix

Guard each lookup with `typeof ... === 'function'` so inherited prototype members are ignored and only real serializer or stringifier functions are invoked. The `__proto__` key is then serialized as a plain data property, matching `JSON.stringify`.

## Verification

Added three regression tests in `test/basic.test.js` covering the top-level object path, the redaction path, and the child bindings path. Each fails on `main` with `TypeError: serializers[key] is not a function` and passes with this change.

```
$ npm run lint   # clean
$ npx borp --pattern test/basic.test.js   # all green
```

The full suite is green other than one pre-existing thread-stream async-flush test that times out waiting for a temp file, which fails the same way on an unmodified checkout in this environment and is unrelated to this change.
