### PR TITLE
docs: add @stitchapi/pino to the ecosystem list

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -72,6 +72,7 @@ according to a given format string.
 + [`@google-cloud/pino-logging-gcp-config`](https://www.npmjs.com/package/@google-cloud/pino-logging-gcp-config): Config helper and formatter to output [Google Cloud Platform Structured Logging](https://cloud.google.com/logging/docs/structured-logging)
 + [`@newrelic/pino-enricher`](https://github.com/newrelic/newrelic-node-log-extensions/blob/main/packages/pino-log-enricher): a log customization to add New Relic context to use [Logs In Context](https://docs.newrelic.com/docs/logs/logs-context/logs-in-context/)
 + [`@sentry/node`](https://docs.sentry.io/platforms/javascript/guides/node/configuration/integrations/pino/): Sentry SDK with native pinoIntegration for direct Pino instrumentation and error tracking.
++ [`@stitchapi/pino`](https://github.com/rejifald/StitchAPI/tree/main/packages/pino): a trace sink for [StitchAPI](https://stitchapi.dev) that logs each outbound HTTP call as a structured, metadata-only Pino record.
 + [`cloud-pine`](https://github.com/metcoder95/cloud-pine): transport that provides abstraction and compatibility with [`@google-cloud/logging`](https://www.npmjs.com/package/@google-cloud/logging).
 + [`cls-proxify`](https://github.com/keenondrums/cls-proxify): integration of pino and [CLS](https://github.com/jeff-lewis/cls-hooked). Useful for creating dynamically configured child loggers (e.g. with added trace ID) for each request.
 + [`crawlee-pino`](https://github.com/imyelo/crawlee-pino): use Pino to log within Crawlee


### PR DESCRIPTION
Adds [`@stitchapi/pino`](https://github.com/rejifald/StitchAPI/tree/main/packages/pino) to the **Community** section of `docs/ecosystem.md`.

It is a community Pino `TraceSink` for [StitchAPI](https://stitchapi.dev): attaching `pinoSink(pino())` to a seam turns its HTTP-call event stream into structured Pino logs — one record per event, mapped to the right level, with no change to the call site.

- Imports no logger; runs on a small structural `PinoLoggerLike` surface, with `pino` (v8 + v9) as the single peer dependency.
- Logs **metadata only** (stitch name, method, redacted URL, status, timing) — never `input`/headers, the response body, or `delta` chunks — so it is safe on a secret-bearing client.

Guidelines:
- [x] Searched existing entries — no duplicate.
- [x] Tested and documented (README + published on npm).
- [x] Individual PR for a single suggestion.
- [x] Format `+ [`PACKAGE`](LINK): DESCRIPTION.`, placed alphabetically under Community.