### PR TITLE
browser: serialize Error under errorKey and honor messageKey in asObject mode

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -142,6 +142,7 @@ function pino (opts) {
     levels,
     timestamp: getTimeFunction(opts),
     messageKey: opts.messageKey || 'msg',
+    errorKey: opts.errorKey || 'err',
     onChild: opts.onChild || noop,
     redactFn
   }
@@ -350,7 +351,7 @@ function createWrap (self, opts, rootLogger, level) {
 
       var argsIsSerialized = false
       if (opts.serialize) {
-        applySerializers(args, this._serialize, this.serializers, this._stdErrSerialize)
+        applySerializers(args, this._serialize, this.serializers, this._stdErrSerialize, opts.asObject, opts.errorKey, opts.messageKey)
         argsIsSerialized = true
       }
       if (opts.asObject || opts.formatters) {
@@ -444,10 +445,25 @@ function asObject (logger, level, args, ts, opts) {
   }
 }
 
-function applySerializers (args, serialize, serializers, stdErrSerialize) {
+function applySerializers (args, serialize, serializers, stdErrSerialize, wrapErrors, errorKey, messageKey) {
+  errorKey = errorKey || 'err'
+  messageKey = messageKey || 'msg'
   for (const i in args) {
     if (stdErrSerialize && args[i] instanceof Error) {
-      args[i] = pino.stdSerializers.err(args[i])
+      const err = args[i]
+      const serialized = pino.stdSerializers.err(err)
+      if (wrapErrors) {
+        // For object output, nest the serialized error under the error key
+        // (matching the Node transport) instead of flattening its properties
+        // onto the log object, and surface its message under messageKey.
+        const wrapped = { [errorKey]: serialized }
+        if (wrapped[messageKey] === undefined) {
+          wrapped[messageKey] = err.message
+        }
+        args[i] = wrapped
+      } else {
+        args[i] = serialized
+      }
     } else if (typeof args[i] === 'object' && !Array.isArray(args[i]) && serialize) {
       for (const k in args[i]) {
         if (serialize.indexOf(k) > -1 && k in serializers) {

--- a/test/browser-transmit.test.js
+++ b/test/browser-transmit.test.js
@@ -298,7 +298,7 @@ test('applies all serializers to messages and bindings (serialize:true)', ({ end
           same(bindings[0], { first: 'first' })
           same(bindings[1], { second: 'second' })
           same(messages[0], { test: 'serialize it' })
-          is(messages[1].type, 'Error')
+          is(messages[1].err.type, 'Error')
         }
       }
     }

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -184,6 +184,32 @@ test('opts.browser.asObject uses opts.messageKey in logs', ({ end, ok, is }) => 
   end()
 })
 
+test('opts.browser.asObject nests a serialized Error under errorKey and sets messageKey', ({ end, ok, is }) => {
+  const err = new Error('Something went wrong')
+  const instance = require('../browser')({
+    messageKey: 'message',
+    browser: {
+      asObject: true,
+      serialize: true,
+      write: function (o) {
+        is(o.level, 50)
+        ok(o.time)
+        // the error is nested under `err`, not flattened onto the log object
+        is(o.type, undefined)
+        is(o.stack, undefined)
+        ok(o.err)
+        is(o.err.type, 'Error')
+        ok(o.err.stack)
+        // and its message is surfaced under the configured messageKey
+        is(o.message, 'Something went wrong')
+      }
+    }
+  })
+
+  instance.error(err)
+  end()
+})
+
 test('opts.browser.asObjectBindingsOnly passes the bindings but keep the message unformatted', ({ end, ok, is, deepEqual }) => {
   const messageKey = 'message'
   const instance = require('../browser')({


### PR DESCRIPTION
Fixes #2132

## Problem

In the browser build, logging an `Error` in `asObject` mode with `serialize` enabled diverged from the Node transport (as @mcollina noted on the issue, and invited a PR):

```js
pino({ browser: { asObject: true, serialize: true }, messageKey: 'message' })
  .error(new Error('Something went wrong'))
```

**Node output:**
```json
{ "level":50, "err":{ "type":"Error", "message":"...", "stack":"..." }, "message":"Something went wrong" }
```

**Browser output (before):**
```json
{ "level":50, "type":"Error", "msg":"Something went wrong", "stack":"..." }
```

The serialized error properties were flattened onto the log object, and `messageKey` was ignored (the message stayed under `msg`).

## Fix

In the object-output path, nest the serialized error under the error key (default `err`) instead of flattening it, and surface its message under `messageKey` — matching the Node transport. This also honors a configurable `errorKey` in the browser, mirroring Node.

The change is gated on `asObject`: the raw-console path and the `transmit` + `serialize:false` path keep their existing (flat) behavior, so this only affects structured object output.

## Tests

- Added a regression test (`opts.browser.asObject nests a serialized Error under errorKey and sets messageKey`) asserting the error nests under `err` and the message lands under the configured `messageKey`.
- Updated the one `transmit` `serialize:true` assertion that exercised the old flat shape (`messages[1].type` → `messages[1].err.type`).

All browser test suites pass (`browser`, `browser-serializers`, `browser-transmit`, `browser-redaction`, `browser-child`, `browser-levels`, `browser-timestamp`, `browser-disabled`, `browser-is-level-enabled`), plus `lint` and `test-types` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)