### PR TITLE
test(transport): keep event loop alive while awaiting async flush

### DIFF
--- a/test/transport/sync-false.test.js
+++ b/test/transport/sync-false.test.js
@@ -6,6 +6,7 @@ const os = require('node:os')
 const { join } = require('node:path')
 const { readFile } = require('node:fs').promises
 const { promisify } = require('node:util')
+const { once } = require('node:events')
 
 const pino = require('../..')
 const { watchFileCreated, watchForWrite, file } = require('../helper')
@@ -47,6 +48,14 @@ test('thread-stream async flush should call the passed callback', async () => {
   const instance = pino(transport)
   const flushPromise = promisify(instance.flush).bind(instance)
 
+  // The worker thread backing the transport is unref'd once it becomes ready
+  // (see lib/transport.js) so it does not keep the process alive. Because this
+  // test awaits `flush()` on an otherwise idle event loop, re-ref the worker
+  // after it is ready so the loop stays alive until the flush callback runs;
+  // otherwise the awaited promise never settles and the test hangs.
+  await once(transport, 'ready')
+  transport.ref()
+
   instance.info('hello')
   await flushPromise()
   await watchFileCreated(outputPath)
@@ -64,4 +73,7 @@ test('thread-stream async flush should call the passed callback', async () => {
   const afterSecondFlush = await getOutputLogLines()
   assert.equal(afterSecondFlush.length, 2)
   assert.equal(afterSecondFlush[1].msg, 'world')
+
+  // Restore the unref'd state so the test process can exit cleanly.
+  transport.unref()
 })


### PR DESCRIPTION
Fixes #2469

## Problem

The `thread-stream async flush should call the passed callback` test in `test/transport/sync-false.test.js` hangs **deterministically** under the `node:test` runner on Node.js 22 and 24, failing with:

```
Promise resolution is still pending but the event loop has already resolved
```

## Root cause

A transport's worker thread is `unref()`'d once it becomes ready (see `lib/transport.js`) so that it does not keep the process alive — this is by design and lets applications exit cleanly. `flush()` is also documented as an "asynchronous, best used as fire and forget" operation.

The failing test, however, `await`s `flush()` on an otherwise idle event loop. Because the worker is unref'd, nothing keeps the loop alive while the flush is in flight, so the loop drains before the worker delivers the flush-completion message. The passed callback is therefore never invoked and the awaited promise never settles, which the `node:test` runner reports as the error above.

The other test in the same file passes because it uses `flush()` as fire-and-forget and then `await`s `watchFileCreated(...)`, whose `fs.watch` handle keeps the loop alive while the flush completes in the background.

## Fix

Wait for the transport to become `ready` and re-`ref()` the worker while awaiting the flush, restoring the unref'd state afterwards. This mirrors the `ref()`/`unref()` pattern pino already uses in `lib/transport.js`, and keeps the change scoped to the test. No production code is touched.

## Testing

- Before the change: the test file fails 5/5 runs (`1 pass, 1 cancelled`) on Node 22.
- After the change: the test file passes 5/5 runs (`2 pass`) on Node 22, and passes on Node 20.
- `npx borp --timeout 60000 "test/transport/*.test.js"` (after `npm run transpile`): **67 pass, 0 fail**.
- `npx eslint test/transport/sync-false.test.js`: clean.
