### PR TITLE
fix: add setBindings to the browser logger

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -166,6 +166,15 @@ function pino (opts) {
   logger._serialize = serialize
   logger._stdErrSerialize = stdErrSerialize
   logger.child = function (...args) { return child.call(this, setOpts, ...args) }
+  logger.setBindings = function (newBindings) {
+    this.bindings = Object.assign({}, this.bindings, newBindings)
+    if (this._logEvent) {
+      this._logEvent.bindings.push(newBindings)
+    }
+    // reassigning the level rebuilds the log functions so the updated
+    // bindings are prepended to subsequent log calls
+    this.level = this._level
+  }
 
   if (transmit) logger._logEvent = createLogEventShape()
 

--- a/test/browser-set-bindings.test.js
+++ b/test/browser-set-bindings.test.js
@@ -1,0 +1,99 @@
+'use strict'
+const test = require('tape')
+const pino = require('../browser')
+
+test('setBindings is a function on the root logger', ({ end, is }) => {
+  const instance = pino({ browser: {} })
+
+  is(typeof instance.setBindings, 'function')
+  end()
+})
+
+test('setBindings adds bindings to subsequent log calls', ({ end, is }) => {
+  const instance = pino({
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.answer, 42)
+        is(o.msg, 'test')
+      }
+    }
+  })
+
+  instance.setBindings({ answer: 42 })
+  instance.info('test')
+  end()
+})
+
+test('setBindings merges with existing bindings', ({ end, is }) => {
+  let expected
+  const instance = pino({
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.a, expected.a)
+        is(o.b, expected.b)
+      }
+    }
+  })
+
+  instance.setBindings({ a: 1 })
+  expected = { a: 1, b: undefined }
+  instance.info('first')
+
+  instance.setBindings({ b: 2 })
+  expected = { a: 1, b: 2 }
+  instance.info('second')
+  end()
+})
+
+test('setBindings on a child logger merges with the child bindings', ({ end, is }) => {
+  const instance = pino({
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.child, true)
+        is(o.later, 'yes')
+        is(o.msg, 'test')
+      }
+    }
+  })
+
+  const child = instance.child({ child: true })
+  child.setBindings({ later: 'yes' })
+  child.info('test')
+  end()
+})
+
+test('setBindings works with customLevels', ({ end, is }) => {
+  const instance = pino({
+    customLevels: { success: 35 },
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.answer, 42)
+        is(o.msg, 'test')
+      }
+    }
+  })
+
+  instance.setBindings({ answer: 42 })
+  instance.success('test')
+  end()
+})
+
+test('setBindings bindings are transmitted', ({ end, same }) => {
+  const instance = pino({
+    browser: {
+      transmit: {
+        send (level, logEvent) {
+          same(logEvent.bindings, [{ answer: 42 }])
+        }
+      }
+    }
+  })
+
+  instance.setBindings({ answer: 42 })
+  instance.info('test')
+  end()
+})


### PR DESCRIPTION
Fixes #2021

## Problem

The browser logger (`browser.js`) never implemented `setBindings`, even though the TypeScript types declare it on `LoggerExtras` — so any code path that resolves the `browser` field of `package.json` throws `TypeError: logger.setBindings is not a function`. (To answer the question in the issue thread: it's a JS bug — a missing method in the browser implementation, not a typings problem. The named/default import distinction in the report was a red herring; both exports point at the same function, what differs is whether the bundler picked `pino.js` or `browser.js`.)

## Fix

Implement `setBindings` on the browser logger:

- merges the new bindings into the logger's `bindings` (children inherit the method through the prototype chain and merge into their own bindings),
- mirrors the new bindings into `_logEvent.bindings` so `browser.transmit` receives them, matching what `child()` does,
- rebuilds the level functions (same mechanism as the level setter) so subsequent log calls prepend the updated bindings.

Consistent with Node semantics: like `asChindings` in `lib/proto.js`, updating a parent's bindings does not retroactively affect already-created children.

## Testing

New `test/browser-set-bindings.test.js` (tape, same style as the other browser tests): method exists, bindings appear in subsequent logs, repeated calls merge, child loggers merge with their own bindings, works with `customLevels` (the issue's repro), and bindings are transmitted. All existing browser tests and lint pass.