### PR TITLE
fix(multistream): resolve string level labels in write()

### DIFF
--- a/lib/multistream.js
+++ b/lib/multistream.js
@@ -48,7 +48,13 @@ function multistream (streamsArray, opts) {
   // we can exit early because the streams are ordered by level
   function write (data) {
     let dest
-    const level = this.lastLevel
+    // `lastLevel` is normally the numeric level, but a source may relay a
+    // level label string (e.g. pino-abstract-transport forwarding lines
+    // produced with a `formatters.level` option). Resolve it to a number so
+    // the level comparisons below don't silently drop the record.
+    const level = typeof this.lastLevel === 'string'
+      ? (this.streamLevels || streamLevels)[this.lastLevel]
+      : this.lastLevel
     const { streams } = this
     // for handling situation when several streams has the same level
     let recordedLevel = 0

--- a/test/multistream.test.js
+++ b/test/multistream.test.js
@@ -678,6 +678,36 @@ test('multistream.write should not throw if one stream fails', async () => {
   assert.equal(messageCount, 3)
 })
 
+test('write routes correctly when the source sets a string lastLevel', async () => {
+  // A source that formats levels as labels (e.g. pino-abstract-transport
+  // relaying lines produced with a `formatters.level` option) assigns the
+  // string label to `lastLevel` via the metadata protocol. multistream must
+  // resolve that label to a numeric value before comparing against the
+  // per-stream levels, otherwise the log line is silently dropped.
+  const received = []
+  const mkStream = (name) => writeStream(function (data, enc, cb) {
+    received.push(name)
+    cb()
+  })
+  const streams = [
+    { level: 'debug', stream: mkStream('debug') },
+    { level: 'error', stream: mkStream('error') }
+  ]
+  const multi = multistream(streams, { levels: pino.levels.values })
+
+  // Emulate the metadata protocol used by pino / pino-abstract-transport,
+  // but with a level label string instead of a number.
+  multi.lastLevel = 'error'
+  multi.lastMsg = 'boom'
+  multi.lastObj = {}
+  multi.lastTime = Date.now()
+  multi.write('{"level":"error","msg":"boom"}\n')
+
+  // An error-level record must reach both the debug (<= error) and error
+  // streams, exactly as it would when lastLevel is the numeric 50.
+  assert.deepStrictEqual(received.sort(), ['debug', 'error'])
+})
+
 test('flushSync', async (t) => {
   const plan = tspl(t, { plan: 2 })
   const tmp = file()


### PR DESCRIPTION
## Problem

When a source relays a level label string via the metadata protocol (e.g. `pino-abstract-transport` forwarding lines produced with a `formatters.level` option), `lastLevel` is a string such as `"error"` instead of a number. The `dest.level <= level` comparisons in `write()` then evaluate against `NaN`, so the record matches no stream and is silently dropped.

## Fix

Normalize a string `lastLevel` through `streamLevels` before comparing, mirroring the resolution already done for stream levels in `add()`.

## Testing

Added a regression test that drives `multistream` via the metadata protocol with a string `lastLevel` (`"error"`) and asserts the record still reaches both the `debug` (`<= error`) and `error` streams, exactly as it would when `lastLevel` is the numeric `50`.

Closes #1413
