### PR TITLE
docs: clarify stringification limits

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,8 +16,14 @@ Pino trusts the applications using it and the environment that it is running in.
 This includes all the application code, the transport, the filesystem and all
 non-externally provided input.
 
-Pino assumes all objects being logged, `logger.info(obj, message)`, are json-serializable.
-Use the `serializers` and `redact` features to sanitize them.
+Pino assumes all objects being logged, `logger.info(obj, message)`, are JSON-serializable.
+Applications are responsible for the data structures their code constructs and logs,
+including ensuring that their size, depth, breadth, and reference topology can be
+serialized within acceptable CPU, memory, and output-size bounds. Resource exhaustion
+caused by logging an application-constructed data structure is an application-level
+concern. The `depthLimit` and `edgeLimit` options apply only to Pino's fallback
+serializer after `JSON.stringify` throws; they are not general resource limits.
+Use the `serializers` and `redact` features to sanitize logged objects.
 
 Pino also assumes that applications control the top-level keys of logged objects
 and child logger bindings. Do not pass externally supplied objects directly as

--- a/docs/api.md
+++ b/docs/api.md
@@ -137,13 +137,19 @@ logger.info('hello') // Will throw an error saying info is not found in logger o
 
 Default: `5`
 
-Option to limit stringification at a specific nesting depth when logging circular objects.
+Maximum nesting depth used by Pino's fallback serializer.
 
 #### `edgeLimit` (Number)
 
 Default: `100`
 
-Option to limit stringification of properties/elements when logging a specific object/array with circular references.
+Maximum number of properties/elements per object or array used by Pino's fallback serializer.
+
+Pino uses the fallback serializer, and therefore applies `depthLimit` and `edgeLimit`, only after
+`JSON.stringify` throws. These options are not general limits on serialization work or output size.
+For example, `JSON.stringify` successfully serializes a non-circular object graph that contains
+repeated references to the same object. In that case, every reference is traversed and serialized
+in full, without applying either limit.
 
 <a id="opt-mixin"></a>
 #### `mixin` (Function):

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -687,12 +687,14 @@ declare namespace pino {
       };
 
       /**
-       * Stringification limit at a specific nesting depth when logging circular object. Default: `5`.
+       * Maximum nesting depth used by the fallback serializer after `JSON.stringify` throws. Default: `5`.
+       * This is not a general limit on serialization work or output size for values that `JSON.stringify` can serialize.
        */
       depthLimit?: number
 
       /**
-       * Stringification limit of properties/elements when logging a specific object/array with circular references. Default: `100`.
+       * Maximum properties/elements per object or array used by the fallback serializer after `JSON.stringify` throws. Default: `100`.
+       * This is not a general limit on serialization work or output size, including for non-circular shared-reference graphs.
        */
       edgeLimit?: number
 


### PR DESCRIPTION
## Summary

- clarify that `depthLimit` and `edgeLimit` apply only to the fallback serializer after `JSON.stringify` throws
- document that these options do not bound serialization work or output size for non-circular shared-reference graphs
- clarify that applications are responsible for the resource cost of data structures they construct and log

## Validation

- `npm run lint`
- `git diff --check`
