### PR TITLE
docs: clarify redact wildcards match whole path segments

### DIFF
--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -109,6 +109,13 @@ By way of example, the following are all valid paths:
 * `a.b.*`
 * `a[*].b`
 
+The asterisk matches an entire path segment (a whole key name or array
+index), not a substring within a key. For example, `*.secret` redacts
+the `secret` key under any parent object, but `*secret` is not valid and
+will not redact keys such as `my_secret` or `another_secret`. To redact
+those keys, list each path explicitly (for example `my_secret` and
+`another_secret`).
+
 ## Overhead
 
 Pino's redaction functionality is built on top of [`fast-redact`](https://github.com/davidmarkclements/fast-redact)


### PR DESCRIPTION
## Summary
- Clarifies that `redact` path wildcards (`*`) match an entire key or array index, not a substring within a key name.
- Documents that patterns like `*secret` are not supported; keys such as `my_secret` must be listed explicitly.

Fixes #1392

## Test plan
- [x] Confirmed with `fast-redact` that `*secret` is rejected and `*.secret` only matches a key named `secret`
- [ ] Docs render correctly on the site / GitHub preview