### PR TITLE
fix: invoke flush callback when transport worker is unref'd

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -143,6 +143,29 @@ function buildStream (filename, workerData, workerOpts, sync, name) {
     sync
   })
 
+  // Keep the worker referenced while a flush(cb) is in flight. The worker is
+  // unref'd after ready so the process can exit, but that also means an idle
+  // event loop can drain before the flush-completion message is delivered.
+  // See https://github.com/pinojs/pino/issues/2481
+  const originalFlush = stream.flush.bind(stream)
+  let flushPending = 0
+  stream.flush = function (cb) {
+    if (typeof cb !== 'function') {
+      return originalFlush(cb)
+    }
+    flushPending++
+    if (flushPending === 1) {
+      stream.ref()
+    }
+    originalFlush(function (err) {
+      flushPending--
+      if (flushPending === 0) {
+        stream.unref()
+      }
+      cb(err)
+    })
+  }
+
   stream.on('ready', onReady)
   stream.on('close', function () {
     process.removeListener('exit', onExit)
@@ -152,7 +175,10 @@ function buildStream (filename, workerData, workerOpts, sync, name) {
 
   function onReady () {
     process.removeListener('exit', onExit)
-    stream.unref()
+    // Do not unref while a flush callback is waiting for the worker.
+    if (flushPending === 0) {
+      stream.unref()
+    }
 
     if (workerOpts.autoEnd !== false) {
       setupOnExit(stream)

--- a/test/fixtures/transport-flush-idle.js
+++ b/test/fixtures/transport-flush-idle.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const fs = require('node:fs')
+const { join } = require('node:path')
+const { tmpdir } = require('node:os')
+const pino = require('../..')
+
+const dest = join(tmpdir(), `pino-flush-idle-${process.pid}.log`)
+fs.writeFileSync(dest, '')
+
+const transport = pino.transport({
+  target: 'pino/file',
+  options: { destination: dest }
+})
+
+const logger = pino(transport)
+logger.info({ marker: 'first-log' })
+
+let callbackFired = false
+logger.flush((err) => {
+  callbackFired = true
+  if (err) {
+    console.error(err)
+    process.exitCode = 1
+    return
+  }
+  console.log('callback-fired')
+})
+
+process.on('exit', () => {
+  if (!callbackFired) {
+    console.error('callback-missing')
+  }
+})

--- a/test/transport/sync-false.test.js
+++ b/test/transport/sync-false.test.js
@@ -3,8 +3,10 @@
 const test = require('node:test')
 const assert = require('node:assert')
 const os = require('node:os')
+const { tmpdir } = require('node:os')
 const { join } = require('node:path')
 const { readFile } = require('node:fs').promises
+const { unlink } = require('node:fs/promises')
 const { promisify } = require('node:util')
 
 const execa = require('execa')
@@ -73,9 +75,13 @@ test('flush callback is invoked on an idle event loop with transport', async () 
     timeout: 15000,
     killSignal: 'SIGKILL'
   })
-
-  const { stdout, stderr, exitCode } = await child
-  assert.equal(exitCode, 0, stderr)
-  assert.match(stdout, /callback-fired/)
-  assert.doesNotMatch(stdout + stderr, /callback-missing/)
+  const dest = join(tmpdir(), `pino-flush-idle-${child.pid}.log`)
+  try {
+    const { stdout, stderr, exitCode } = await child
+    assert.equal(exitCode, 0, stderr)
+    assert.match(stdout, /callback-fired/)
+    assert.doesNotMatch(stdout + stderr, /callback-missing/)
+  } finally {
+    await unlink(dest).catch(() => {})
+  }
 })

--- a/test/transport/sync-false.test.js
+++ b/test/transport/sync-false.test.js
@@ -6,7 +6,8 @@ const os = require('node:os')
 const { join } = require('node:path')
 const { readFile } = require('node:fs').promises
 const { promisify } = require('node:util')
-const { once } = require('node:events')
+
+const execa = require('execa')
 
 const pino = require('../..')
 const { watchFileCreated, watchForWrite, file } = require('../helper')
@@ -48,14 +49,6 @@ test('thread-stream async flush should call the passed callback', async () => {
   const instance = pino(transport)
   const flushPromise = promisify(instance.flush).bind(instance)
 
-  // The worker thread backing the transport is unref'd once it becomes ready
-  // (see lib/transport.js) so it does not keep the process alive. Because this
-  // test awaits `flush()` on an otherwise idle event loop, re-ref the worker
-  // after it is ready so the loop stays alive until the flush callback runs;
-  // otherwise the awaited promise never settles and the test hangs.
-  await once(transport, 'ready')
-  transport.ref()
-
   instance.info('hello')
   await flushPromise()
   await watchFileCreated(outputPath)
@@ -73,7 +66,16 @@ test('thread-stream async flush should call the passed callback', async () => {
   const afterSecondFlush = await getOutputLogLines()
   assert.equal(afterSecondFlush.length, 2)
   assert.equal(afterSecondFlush[1].msg, 'world')
+})
 
-  // Restore the unref'd state so the test process can exit cleanly.
-  transport.unref()
+test('flush callback is invoked on an idle event loop with transport', async () => {
+  const child = execa(process.argv[0], [join(__dirname, '..', 'fixtures', 'transport-flush-idle.js')], {
+    timeout: 15000,
+    killSignal: 'SIGKILL'
+  })
+
+  const { stdout, stderr, exitCode } = await child
+  assert.equal(exitCode, 0, stderr)
+  assert.match(stdout, /callback-fired/)
+  assert.doesNotMatch(stdout + stderr, /callback-missing/)
 })


### PR DESCRIPTION
## Summary
- Transport workers are unref'd after ready so the process can exit, which meant `logger.flush(cb)` never got its completion message on an idle event loop.
- Keep the worker referenced while a flush callback is in flight, and skip the ready-time unref if a flush is already pending.
- Add an idle-loop regression fixture and drop the old test-side keep-alive workaround.

Fixes #2481

## Test plan
- [x] `npx borp --timeout 60000 test/transport/sync-false.test.js test/syncfalse.test.js test/exit.test.js test/transport/core.test.js` (51 passed)
- [x] `node test/fixtures/transport-flush-idle.js` prints `callback-fired` and exits 0