### PR TITLE
fix: pass worker options from pipeline targets to worker thread (#1856)

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -190,7 +190,7 @@ function flush (stream) {
 }
 
 function transport (fullOptions) {
-  const { pipeline, targets, levels, dedupe, worker = {}, caller = getCallers(), sync = false } = fullOptions
+  let { pipeline, targets, levels, dedupe, worker = {}, caller = getCallers(), sync = false } = fullOptions
 
   const options = {
     ...fullOptions.options
@@ -240,6 +240,16 @@ function transport (fullOptions) {
   } else if (pipeline) {
     target = bundlerOverrides['pino-worker'] || join(__dirname, 'worker.js')
     options.pipelines = [pipeline.map((dest) => {
+      // Merge per-target worker options (workerData, transferList) into
+      // the top-level worker so they apply when creating the worker thread.
+      if (dest.worker) {
+        if (dest.worker.workerData) {
+          worker = { ...worker, workerData: { ...dest.worker.workerData, ...worker.workerData } }
+        }
+        if (dest.worker.transferList) {
+          worker = { ...worker, transferList: [...(worker.transferList || []), ...dest.worker.transferList] }
+        }
+      }
       return {
         ...dest,
         target: fixTarget(dest.target)


### PR DESCRIPTION
When using a pipeline transport, the \worker\ option (containing \workerData\ and \	ransferList\) on individual pipeline targets was ignored. This meant that passing a MessagePort with \	ransferList\ to a pipeline transport caused a TypeError because the transferable objects were never forwarded to the worker thread.

For non-pipeline transport (\pino.transport({ target: ..., worker: ... })\), this worked correctly because the \worker\ option was passed directly to \uildStream()\. But in the pipeline path, each pipeline target was mapped with a plain spread (\{...dest}\) and the \worker\ property was never extracted and forwarded to the top-level worker parameter.

**Fix:** When processing pipeline targets, merge each target's \worker.workerData\ and \worker.transferList\ into the top-level \worker\ option before passing it to \uildStream()\.

Fixes #1856

## Changes
- \lib/transport.js\: Changed \worker\ from \const\ to \let\, per-pipeline-target \worker.workerData\ and \worker.transferList\ are now merged into the shared \worker\ object so they reach the ThreadStream Worker constructor.