### PR TITLE
fix(multistream): fix clone add crash and missing end/remove methods

### DIFF
--- a/lib/multistream.js
+++ b/lib/multistream.js
@@ -105,7 +105,7 @@ function multistream (streamsArray, opts) {
 
   function add (dest) {
     if (!dest) {
-      return res
+      return this
     }
 
     // Check that dest implements either StreamEntry or DestinationStream
@@ -141,7 +141,7 @@ function multistream (streamsArray, opts) {
 
     this.minLevel = streams[0].level
 
-    return res
+    return this
   }
 
   function remove (id) {
@@ -154,7 +154,7 @@ function multistream (streamsArray, opts) {
       this.minLevel = streams.length > 0 ? streams[0].level : -1
     }
 
-    return res
+    return this
   }
 
   function end () {
@@ -180,12 +180,14 @@ function multistream (streamsArray, opts) {
       write,
       add,
       remove,
+      emit,
+      flushSync,
+      end,
       minLevel: level,
       streams,
       clone,
-      emit,
-      flushSync,
-      [metadata]: true
+      [metadata]: true,
+      streamLevels
     }
   }
 }

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -301,7 +301,9 @@ declare namespace pino {
     export interface MultiStreamRes<TOriginLevel = Level> {
       write: (data: any) => void,
       add: <TLevel = Level>(dest: StreamEntry<TLevel> | DestinationStream) => MultiStreamRes<TOriginLevel & TLevel>,
+      remove: (id: number) => MultiStreamRes<TOriginLevel>,
       flushSync: () => void,
+      end: () => void,
       minLevel: number,
       streams: StreamEntry<TOriginLevel>[],
       clone<const TLevel = Level>(level: TLevel): MultiStreamRes<TLevel>,

--- a/test/multistream.test.js
+++ b/test/multistream.test.js
@@ -414,6 +414,40 @@ test('clone generates a new multistream with all stream at the same level', asyn
   await plan
 })
 
+test('clone supports add, remove, and end methods correctly', async (t) => {
+  const plan = tspl(t, { plan: 5 })
+  const stream1 = writeStream(function (data, enc, cb) {
+    cb()
+  })
+  const stream2 = writeStream(function (data, enc, cb) {
+    cb()
+  })
+
+  const ms = multistream([{ stream: stream1 }])
+  const clone = ms.clone(30)
+
+  // Verify that adding a stream with a string level doesn't throw and returns the clone
+  const updatedClone = clone.add({ level: 'info', stream: stream2 })
+  plan.equal(updatedClone, clone)
+  plan.equal(clone.streams.length, 2)
+
+  // Verify remove returns the clone and works correctly
+  const stream2Entry = clone.streams.find(s => s.stream === stream2)
+  if (stream2Entry) {
+    const afterRemove = clone.remove(stream2Entry.id)
+    plan.equal(afterRemove, clone)
+    plan.equal(clone.streams.length, 1)
+  } else {
+    plan.fail('stream2 entry not found')
+  }
+
+  // Verify end method is present and can be called without errors
+  plan.equal(typeof clone.end, 'function')
+  clone.end()
+
+  await plan
+})
+
 test('one stream', async () => {
   let messageCount = 0
   const stream = writeStream(function (data, enc, cb) {


### PR DESCRIPTION
This PR resolves multiple runtime exceptions and TypeScript typing mismatches associated with the multistream.js API in multistream.js.
  
  Specifically, it ensures cloned multistreams are fully compatible with their original counterpart's interface and behaves correctly as a builder pattern.
  
## Issues Addressed
  
  1. Crash on Cloned multistream.js with String Levels:
  Cloned multistream objects were missing the streamLevels mapping. Invoking multistream.js with string-based log levels (e.g. 'info') threw a TypeError: Cannot read properties of undefined (reading 'info').
  2. Missing Lifecycle multistream.js on Cloned Multistream:
  The cloned instance omitted the multistream.js method, causing crashes when streams were shut down.
  3. TypeScript Typings Mismatch:
  The pino.d.ts interface in pino.d.ts did not declare the public .end() and .remove() methods.
  4. Fluent API Discrepancy:
  Calling multistream.js or multistream.js on a cloned multistream incorrectly returned the original res instance instead of the cloned one (this), breaking clone isolation.             
  
## Changes
  
  • **multistream.js**:
      • Propagated streamLevels, end, and emit properties inside the multistream.js return block.
      • Updated multistream.js and multistream.js methods to return this instead of the closure-scoped original res.
  • **pino.d.ts**:
      • Exposes .end() and .remove() signatures on the pino.d.ts interface.
  • **multistream.test.js**:
      • Added a dedicated unit test suite (clone supports add, remove, and end methods correctly) to verify fluent returns, successful stream additions, and correct stream lifecycle     
      endings.
  

  ## Verification
  
  • Ran eslint checking and all style rules pass.
  • Executed the unit test suite and verified the newly added tests successfully validate the changes without regressions.

