### PR TITLE
fix: build the redaction shape without Object.prototype

### DIFF
--- a/lib/redaction.js
+++ b/lib/redaction.js
@@ -64,14 +64,19 @@ function redaction (opts, serialize) {
 
     o[ns].push(nextPath)
     return o
-  }, {})
+    // The keys here are the first segment of each redact path, so they are the
+    // user's strings. On a plain object a path like 'constructor.secret' reads
+    // the inherited function, and `o[ns] = o[ns] || []` keeps it.
+  }, Object.create(null))
 
   // the redactor assigned to the format symbol key
   // provides top level redaction for instances where
   // an object is interpolated into the msg string
-  const result = {
+  // Same reason as the shape above: the keys come from the redact paths, and
+  // this object is later indexed with them by `asJson`.
+  const result = Object.assign(Object.create(null), {
     [redactFmtSym]: Redact({ paths, censor, serialize, strict, remove })
-  }
+  })
 
   const topCensor = (...args) => {
     return typeof censor === 'function' ? serialize(censor(...args)) : serialize(censor)

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -891,3 +891,33 @@ test('censor function should not be called for non-existent nested paths (issue 
   assert.equal(censorCalls[0].path, 'req.authorization')
   assert.equal(censorCalls[0].value, 'bearer token')
 })
+
+test('redact option – a path whose first segment names an Object.prototype member', async () => {
+  // The shape of the redactor is keyed by the first segment of each path, and
+  // those come from the caller. On a plain object 'constructor.secret' reads the
+  // inherited function, and building the logger threw
+  // "o[ns].push is not a function" before it could log anything.
+  const stream = sink()
+  const instance = pino({ redact: ['constructor.secret'] }, stream)
+  instance.info({ constructor: { secret: 'hunter2', keep: 'me' } }, 'hello')
+  const o = await once(stream, 'data')
+  assert.equal(o.constructor.secret, '[Redacted]')
+  assert.equal(o.constructor.keep, 'me')
+})
+
+test('redact option – other inherited names no longer throw while building', async () => {
+  for (const name of ['toString', 'valueOf', 'hasOwnProperty', 'isPrototypeOf', '__proto__']) {
+    assert.doesNotThrow(() => {
+      pino({ redact: [`${name}.secret`] }, sink())
+    }, `redact path under ${name}`)
+  }
+})
+
+test('redact option – top level path named after an Object.prototype member', async () => {
+  const stream = sink()
+  const instance = pino({ redact: ['constructor'] }, stream)
+  instance.info({ constructor: 'hunter2', keep: 'me' }, 'hello')
+  const o = await once(stream, 'data')
+  assert.equal(o.constructor, '[Redacted]')
+  assert.equal(o.keep, 'me')
+})


### PR DESCRIPTION
Building a logger with a redact path whose first segment is named after a member of `Object.prototype` throws before the logger exists:

```js
pino({ redact: ['constructor.secret'] })
// TypeError: o[ns].push is not a function
```

The shape in `lib/redaction.js` is keyed by the first segment of each path, and those strings come from the caller. The accumulator was a plain object, so `o['constructor']` reads the inherited function, `o[ns] = o[ns] || []` keeps it because a function is truthy, and the `push` on the next line has nothing to push onto.

Same for `toString`, `valueOf`, `hasOwnProperty` and `__proto__`. A single-segment path such as `['constructor']` was fine, since that branch assigns rather than reads, which is part of why this stayed hidden.

Not exotic in practice: redacting a field under something an API called `constructor` is an ordinary thing to want, and the failure gives no hint that the path is the cause. It names an internal variable.

### The change

Two accumulators lose their prototype. The shape, for the reason above, and the map of stringifiers built from it, since it is keyed with the same strings and indexed with them later in `asJson`. Nothing reads either object except by key, `Object.keys` and `Object.getOwnPropertySymbols`, so no behaviour depends on the prototype being there.

### Tests

Three added to `test/redact.test.js`. Two fail on `main`:

```
not ok - redact option – a path whose first segment names an Object.prototype member
  error: 'o[ns].push is not a function'
not ok - redact option – other inherited names no longer throw while building
  error: 'o[ns].push is not a function'
```

The third covers the single-segment path that already worked, so the change cannot quietly break it.

`redaction.js` stays at 100% statements, branches, functions and lines. Full run with `borp --coverage --check-coverage` at the configured thresholds passes, and the failure count is zero both with and without the change.

### One thing I found next door and did not touch

While tracing this I noticed the same shape of problem in `asJson`, reachable with no configuration at all, just by logging an object whose field is named after one of these. On `main`:

| field | result |
|---|---|
| `toString` | log line is not valid JSON |
| `constructor` | log line is not valid JSON |
| `valueOf` | throws `TypeError` |
| `hasOwnProperty` | throws `TypeError` |
| `propertyIsEnumerable` | throws `TypeError` |
| `toLocaleString` | throws `TypeError` |

That lives in `lib/tools.js`, which is exactly where #2457 is working, and it is already approved, so I would rather not step on it. I have left the measurements as a comment there instead. This PR stays in `lib/redaction.js`, which nothing else open is touching.
