### PR TITLE
browser: forward remaining log arguments to write in asObject mode

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -449,7 +449,7 @@ function asObject (logger, level, args, ts, opts) {
     if (opts.redactFn) {
       formattedLogObject = opts.redactFn(formattedLogObject)
     }
-    return [formattedLogObject]
+    return [formattedLogObject, ...argsCloned]
   }
 }
 

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -203,6 +203,24 @@ test('opts.browser.asObjectBindingsOnly passes the bindings but keep the message
   end()
 })
 
+test('opts.browser.write func passes additional arguments when asObject is enabled', ({ end, ok, is, deepEqual }) => {
+  const instance = pino({
+    browser: {
+      asObject: true,
+      write: function (o, ...args) {
+        is(o.level, 30)
+        is(o.msg, 'test')
+        ok(o.time)
+        deepEqual(args, [{ di: 'da' }])
+      }
+    }
+  })
+
+  instance.info('test', { di: 'da' })
+
+  end()
+})
+
 test('opts.browser.formatters (level) logs pino-like object to console', ({ end, ok, is }) => {
   const info = console.info
   console.info = function (o) {


### PR DESCRIPTION
Fixes #2244

## Problem

When a custom `browser.write` is used (which forces `asObject` mode), extra arguments passed to the log methods never reach the `write` function:

```js
const logger = pino({ browser: { write: (logObj, ...logParams) => { /* ... */ } } })
logger.debug('bla', { di: 'da' })
```

Here `{ di: 'da' }` is silently dropped: `logParams` is always empty because `asObject()` only returns the formatted log object.

`asObjectBindingsOnly` mode already forwards the remaining arguments (`return [formattedLogObject, ...argsCloned]`), but the regular `asObject` branch dropped them.

## Change

Mirror the `asObjectBindingsOnly` branch in `browser.js` and return the remaining (unconsumed) arguments alongside the formatted log object:

```js
return [formattedLogObject, ...argsCloned]
```

## Verification

Added a regression test in `test/browser.test.js`:

- `logger.info('test', { di: 'da' })` now calls `write(logObj, { di: 'da' })`.

The new test fails on `main` and passes with this change:

```
npx tape test/browser.test.js
```