### PR TITLE
build(deps): bump thread-stream from ^4.0.0 to ^4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,6 @@
     "real-require": "^1.0.0",
     "safe-stable-stringify": "^2.3.1",
     "sonic-boom": "^4.0.1",
-    "thread-stream": "^4.0.0"
+    "thread-stream": "^4.2.0"
   }
 }


### PR DESCRIPTION
A logger with a transport crashes under `node --watch` when thread-stream resolves to 4.0.0:

```
Error: this should not happen: undefined
    at Worker.onWorkerMessage (node_modules/thread-stream/index.js:190:23)
```

thread-stream fixed it in 4.2.0 (pinojs/thread-stream#212). pino still declares `^4.0.0`, so any lockfile written before 4.1.0 keeps installing the broken version, and a plain `npm install` after upgrading pino won't move it. Raising the floor does.

Verified on Node v24.18.0 with the repro from the issue: it crashes on 4.0.0 and logs cleanly on 4.2.0.

Fixes #2497