### PR TITLE
test: use fs rename for cross-platform transpilation

### DIFF
--- a/test/fixtures/ts/transpile.cjs
+++ b/test/fixtures/ts/transpile.cjs
@@ -5,6 +5,7 @@ const fs = require('node:fs')
 
 const existsSync = fs.existsSync
 const stat = fs.promises.stat
+const rename = fs.promises.rename
 
 // Hardcoded parameters
 const esVersions = ['es6', 'es2017', 'esnext']
@@ -24,7 +25,7 @@ async function transpile () {
 
       if (shouldTranspile) {
         await execa('tsc', [ '--ignoreConfig', '--types', 'node', '--target', esVersion, '--module', 'commonjs', sourceFileName ])
-        await execa('mv', [ intermediateFileName, targetFileName ])
+        await rename(intermediateFileName, targetFileName)
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?

Use `fs.promises.rename` instead of the Unix-only `mv` command in the TypeScript fixture transpilation helper.

## Why?

`npm run test-ci` failed on Windows because `mv` is not available as a native command.

## Testing

- `npm run lint`
- `npm run test-types`
- `npm run transpile`
- `npx borp test/transport/core.test.js --timeout 60000`
- `git diff --check`

All checks passed.

This change keeps the behavior the same while making the transpilation step cross-platform.