### PR TITLE
ci: check pull requests target main

### DIFF
--- a/.github/workflows/target-main.yml
+++ b/.github/workflows/target-main.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   comment:
-    if: ${{ github.base_ref != "master" }}
+    if: ${{ github.base_ref != "main" }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v9
@@ -19,5 +19,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '⚠️ This pull request does not target the master branch.'
+              body: '⚠️ This pull request does not target the main branch.'
             })


### PR DESCRIPTION
## What does this PR do?

Update the pull request target branch check to use `main` instead of `master`.

## Why?

Pino uses `main` as its default branch, but the workflow was still checking for `master`. This caused the workflow warning to reference the wrong branch.

## Changes

- Check `github.base_ref` against `main`.
- Update the warning message to mention `main`.

## Testing

- Reviewed the workflow diff.
- `git diff --check` passed.