### PR TITLE
docs: show child bindings access in logMethod hook

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -385,6 +385,23 @@ const hooks = {
 }
 ```
 
+Inside the hook, `this` is the logger instance the method was called on.
+For a child logger, `this.bindings()` provides the bindings set via
+[`logger.child()`](#logger-child-bindings), which allows adapting the
+message based on the child context:
+
+```js
+const hooks = {
+  logMethod (inputArgs, method) {
+    const context = this.bindings()
+    if (context.featureName) {
+      inputArgs[0] = `${context.featureName}: ${inputArgs[0]}`
+    }
+    return method.apply(this, inputArgs)
+  }
+}
+```
+
 
 <a id="streamWrite"></a>
 ##### `streamWrite`


### PR DESCRIPTION
## Summary

Fixes #897 — the `logMethod` hook has no obvious way to access the child
logger's bindings, making use cases like "prefix the message with the
child context" non-obvious.

## Change

The hook already receives the logger instance as `this`, and
`this.bindings()` exposes the bindings set via `logger.child()`. The
`logMethod` section of `docs/api.md` did not mention either fact.

Adds two short paragraphs and a second example after the existing
argument-flipping example:

```
Inside the hook, `this` is the logger instance the method was called on.
For a child logger, `this.bindings()` provides the bindings set via
logger.child(), which allows adapting the message based on the child context:
```

followed by a minimal example that prefixes the message with the child's
`featureName` binding — matching the exact request in #897 ("prepend that
name to message").

## Verification

Both snippets verified against the repo's own code (Node 24):

```js
const child = logger.child({ featureName: 'MY FEATURE' })
child.info('special')
// msg becomes "MY FEATURE: special"
```

`this.bindings()` inside `logMethod` returns `{"featureName":"MY
FEATURE"}` on a child logger and `{}` on the root logger. ✓
Docs-only change, no code touched.