### PR TITLE
Add bindings() method to browser logger

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -49,6 +49,9 @@ function levelToValue (level, logger) {
 const baseLogFunctionSymbol = Symbol('pino.logFuncs')
 const hierarchySymbol = Symbol('pino.hierarchy')
 
+const ownBindingsSymbol = Symbol('pino.ownBindings')
+const bindingsSymbol = Symbol('pino.bindings')
+
 const logFallbackMap = {
   error: 'log',
   fatal: 'error',
@@ -122,6 +125,8 @@ function pino (opts) {
   // setup root hierarchy entry
   appendChildLogger({}, logger)
 
+  logger[bindingsSymbol] = {}
+
   Object.defineProperty(logger, 'levelVal', {
     get: getLevelVal
   })
@@ -166,8 +171,14 @@ function pino (opts) {
   logger._serialize = serialize
   logger._stdErrSerialize = stdErrSerialize
   logger.child = function (...args) { return child.call(this, setOpts, ...args) }
+
+  logger.bindings = function () {
+    return Object.assign({}, this[bindingsSymbol])
+  }
+
   logger.setBindings = function (newBindings) {
-    this.bindings = Object.assign({}, this.bindings, newBindings)
+    this[ownBindingsSymbol] = Object.assign({}, this[ownBindingsSymbol], newBindings)
+    this[bindingsSymbol] = Object.assign({}, this[bindingsSymbol], newBindings)
     if (this._logEvent) {
       this._logEvent.bindings.push(newBindings)
     }
@@ -224,7 +235,13 @@ function pino (opts) {
       this._childLevel = (parent._childLevel | 0) + 1
 
       // make sure bindings are available in the `set` function
-      this.bindings = bindings
+      this[ownBindingsSymbol] = bindings
+
+      this[bindingsSymbol] = Object.assign(
+        {},
+        parent[bindingsSymbol],
+        bindings
+      )
 
       if (childSerializers) {
         this.serializers = childSerializers
@@ -295,16 +312,16 @@ pino.stdTimeFunctions = Object.assign({}, { nullTime, epochTime, unixTime, isoTi
 
 function getBindingChain (logger) {
   const bindings = []
-  if (logger.bindings) {
-    bindings.push(logger.bindings)
+  if (logger[ownBindingsSymbol]) {
+    bindings.push(logger[ownBindingsSymbol])
   }
 
   // traverse up the tree to get all bindings
   let hierarchy = logger[hierarchySymbol]
   while (hierarchy.parent) {
     hierarchy = hierarchy.parent
-    if (hierarchy.logger.bindings) {
-      bindings.push(hierarchy.logger.bindings)
+    if (hierarchy.logger[ownBindingsSymbol]) {
+      bindings.push(hierarchy.logger[ownBindingsSymbol])
     }
   }
 

--- a/test/browser-bindings.test.js
+++ b/test/browser-bindings.test.js
@@ -1,0 +1,114 @@
+'use strict'
+
+const test = require('tape')
+const pino = require('../browser')
+
+test('bindings returns an empty object on the root logger', ({ end, same }) => {
+  const instance = pino({ browser: {} })
+
+  same(instance.bindings(), {})
+
+  end()
+})
+
+test('bindings contains child bindings', ({ end, same }) => {
+  const instance = pino({ browser: {} })
+  const child = instance.child({ foo: 'bar' })
+
+  same(child.bindings(), { foo: 'bar' })
+
+  end()
+})
+
+test('bindings contains bindings from nested children', ({ end, same }) => {
+  const instance = pino({ browser: {} })
+  const child = instance
+    .child({ foo: 'bar' })
+    .child({ a: 2 })
+
+  same(child.bindings(), { foo: 'bar', a: 2 })
+
+  end()
+})
+
+test('child bindings overwrite parent bindings with the same key', ({ end, same }) => {
+  const instance = pino({ browser: {} })
+  const child = instance
+    .child({ foo: 'bar' })
+    .child({ foo: 'baz' })
+
+  same(child.bindings(), { foo: 'baz' })
+
+  end()
+})
+
+test('bindings contains bindings added with setBindings', ({ end, same }) => {
+  const instance = pino({ browser: {} })
+
+  instance.setBindings({ foo: 'bar' })
+
+  same(instance.bindings(), { foo: 'bar' })
+
+  end()
+})
+
+test('newly set bindings overwrite old bindings', ({ end, same }) => {
+  const instance = pino({ browser: {} })
+
+  instance.setBindings({ foo: 'bar' })
+  instance.setBindings({ foo: 'baz' })
+
+  same(instance.bindings(), { foo: 'baz' })
+
+  end()
+})
+
+test('setBindings on child merges with child bindings', ({ end, same }) => {
+  const instance = pino({ browser: {} })
+  const child = instance.child({ child: true })
+
+  child.setBindings({ later: 'yes' })
+
+  same(child.bindings(), {
+    child: true,
+    later: 'yes'
+  })
+
+  end()
+})
+
+test('child inherits bindings set on parent before child creation', ({ end, same }) => {
+  const instance = pino({ browser: {} })
+
+  instance.setBindings({ foo: 'bar' })
+
+  const child = instance.child({})
+
+  same(child.bindings(), { foo: 'bar' })
+
+  end()
+})
+
+test('child does not inherit bindings set on parent after child creation', ({ end, same }) => {
+  const instance = pino({ browser: {} })
+  const child = instance.child({})
+
+  instance.setBindings({ foo: 'bar' })
+
+  same(instance.bindings(), { foo: 'bar' })
+  same(child.bindings(), {})
+
+  end()
+})
+
+test('bindings returns a copy of the bindings', ({ end, same }) => {
+  const instance = pino({ browser: {} })
+  instance.setBindings({ foo: 'bar' })
+
+  const bindings = instance.bindings()
+  bindings.foo = 'baz'
+
+  same(instance.bindings(), { foo: 'bar' })
+
+  end()
+})


### PR DESCRIPTION
## Summary

Adds `bindings()` support to the browser logger to match the Node implementation.

- Adds `bindings()` to browser logger instances
- Preserves bindings inherited when child loggers are created
- Ensures later parent `setBindings()` calls do not affect existing children
- Keeps internal binding state separate from the public `bindings()` method
- Adds browser tests for bindings behavior

Fixes #1177

## Testing

- Added `test/browser-bindings.test.js`
- Existing `browser-set-bindings.test.js` tests pass
- `CI=1 npm test` passes