### PR TITLE
fix(multistream): keep stream ids on clone so remove() works

### DIFF
--- a/lib/multistream.js
+++ b/lib/multistream.js
@@ -172,6 +172,11 @@ function multistream (streamsArray, opts) {
     for (let i = 0; i < streams.length; i++) {
       streams[i] = {
         level,
+        // preserve the assigned id so remove() keeps working on clones;
+        // without it every inherited entry has `id: undefined` and
+        // remove() would strip an arbitrary entry instead of the
+        // requested one.
+        id: this.streams[i].id,
         stream: this.streams[i].stream
       }
     }

--- a/test/multistream.test.js
+++ b/test/multistream.test.js
@@ -415,7 +415,7 @@ test('clone generates a new multistream with all stream at the same level', asyn
 })
 
 test('clone supports add, remove, and end methods correctly', async (t) => {
-  const plan = tspl(t, { plan: 5 })
+  const plan = tspl(t, { plan: 6 })
   const stream1 = writeStream(function (data, enc, cb) {
     cb()
   })
@@ -440,6 +440,13 @@ test('clone supports add, remove, and end methods correctly', async (t) => {
   } else {
     plan.fail('stream2 entry not found')
   }
+
+  // Inherited entries keep their assigned id, so remove() can target them;
+  // without this, every cloned entry has `id: undefined` and remove() would
+  // strip an arbitrary entry instead of the requested one.
+  clone.streams.forEach((entry) => {
+    plan.equal(typeof entry.id, 'number')
+  })
 
   // Verify end method is present and can be called without errors
   plan.equal(typeof clone.end, 'function')


### PR DESCRIPTION
## Problem

`clone(level)` rebuilt each stream entry with only `{ level, stream }`, dropping the `id` assigned by `add()`. Every inherited entry on the clone then had `id: undefined`, so the documented `remove(id)` could never match the entry the caller asked for:

```js
const base = multistream([A, B])
const clone = base.clone('trace')

const entry = clone.streams.find(s => s.stream === B)
console.log(entry.id)        // undefined
clone.remove(entry.id)       // findIndex(s => s.id === undefined) -> no-op
                             // (or strips an arbitrary undefined-id entry)
```

The instance-level test added in #2493 passed because it removed a stream that had been **added to the clone** (which gets a fresh id); inherited entries were never covered.

## Fix

Copy the source entry's `id` into cloned entries. Adding to a clone still assigns fresh ids from the shared counter, so uniqueness across base and clones is preserved.

## Testing

- extended `clone supports add, remove, and end methods correctly` in `test/multistream.test.js` to assert every cloned entry keeps a numeric id
- `node --test test/multistream.test.js`: 32 passing
- full suite: 537 unit tests passing (one unrelated `transport/big.test.js` timeout under parallel load; passes in isolation)