### PR TITLE
fix(child): give a child redactor the safe stringifier

### DIFF
--- a/lib/proto.js
+++ b/lib/proto.js
@@ -24,6 +24,7 @@ const {
   needsMetadataGsym,
   redactFmtSym,
   stringifySym,
+  stringifySafeSym,
   formatOptsSym,
   stringifiersSym,
   msgPrefixSym,
@@ -157,7 +158,13 @@ function child (bindings, options) {
   // redact must place before asChindings and only replace if exist
   if ((typeof options.redact === 'object' && options.redact !== null) || Array.isArray(options.redact)) {
     instance.redact = options.redact // replace redact directly
-    const stringifiers = redaction(instance.redact, stringify)
+    // redaction calls the serializer as a plain function, so it has to carry
+    // the safe stringifier with it the way pino.js does. Without the bind the
+    // fallback path throws and every value it touches turns into the
+    // "unable to serialize" placeholder.
+    const stringifiers = redaction(instance.redact, stringify.bind({
+      [stringifySafeSym]: instance[stringifySafeSym]
+    }))
     const formatOpts = { stringify: stringifiers[redactFmtSym] }
     instance[stringifySym] = stringify
     instance[stringifiersSym] = stringifiers

--- a/test/redact.test.js
+++ b/test/redact.test.js
@@ -848,6 +848,46 @@ test('redact safe stringify', async () => {
   assert.equal(other.mySecondBigInt, 222)
 })
 
+test('child redact safe stringify', async () => {
+  const stream = sink()
+  const instance = pino({}, stream).child({}, { redact: { paths: ['that.secret'] } })
+
+  instance.info({
+    that: {
+      secret: 'please hide me',
+      myBigInt: 123n
+    },
+    other: {
+      mySecondBigInt: 222n
+    }
+  })
+  const { that, other } = await once(stream, 'data')
+  assert.equal(that.secret, '[Redacted]')
+  assert.equal(that.myBigInt, 123)
+  assert.equal(other.mySecondBigInt, 222)
+})
+
+test('child redact handles a circular reference like the parent does', async () => {
+  const circular = () => {
+    const that = { secret: 'please hide me' }
+    that.self = that
+    return that
+  }
+
+  const parentStream = sink()
+  pino({ redact: { paths: ['that.secret'] } }, parentStream).info({ that: circular() })
+  const fromParent = await once(parentStream, 'data')
+
+  const childStream = sink()
+  pino({}, childStream)
+    .child({}, { redact: { paths: ['that.secret'] } })
+    .info({ that: circular() })
+  const fromChild = await once(childStream, 'data')
+
+  assert.deepStrictEqual(fromChild.that, fromParent.that)
+  assert.equal(fromChild.that.secret, '[Redacted]')
+})
+
 test('censor function should not be called for non-existent nested paths (issue #2313)', async () => {
   const stream = sink()
   const censorCalls = []


### PR DESCRIPTION
A child logger that sets its own `redact` destroys the object it was asked to redact whenever anything in it needs the safe stringifier.

```js
const pino = require('pino')

pino({ redact: { paths: ['that.secret'] } }, process.stdout)
  .info({ that: { secret: 'please hide me', myBigInt: 123n } })

pino({}, process.stdout)
  .child({}, { redact: { paths: ['that.secret'] } })
  .info({ that: { secret: 'please hide me', myBigInt: 123n } })
```

```
{"level":30,...,"that":{"myBigInt":123,"secret":"[Redacted]"}}
{"level":30,...,"that":"[unable to serialize, circular reference is too complex to analyze]"}
```

The parent is right. The child throws the whole branch away, including the key that was supposed to be redacted, so the record silently loses the data instead of hiding one field of it. A circular reference inside a redacted path does the same thing.

`pino.js` hands `redaction()` a serializer that carries the safe stringifier with it:

```js
const stringifyFn = stringify.bind({ [stringifySafeSym]: stringifySafe })
```

`child()` rebuilds the same wiring in `lib/proto.js` but passes the raw `stringify`. `@pinojs/redact` calls that serializer as a plain function, so `this` is undefined inside `stringify()`, reading `this[stringifySafeSym]` throws, and the outer catch returns the `[unable to serialize...]` literal for every value the fallback would have handled. The child also lost the configured `depthLimit` and `edgeLimit` along the way, since those live in the bound stringifier.

Binding it the way `pino.js` does is enough. The child already inherits `[stringifySafeSym]` from its parent through `Object.create(this)`, so it picks up that logger's limits rather than fresh defaults.

Two tests. The first mirrors the existing `redact safe stringify` test with the redaction set on a child instead of the root, since that test is the oracle for what the output should be. The second checks the child and the parent agree on a circular reference, rather than pinning a literal shape.

Both fail on main and pass here. `npx borp --timeout 60000` leaves one failure, `pino.transport with worker destination overridden by bundler and mjs transport`, which fails the same way on a clean checkout of main on this machine. `npx eslint .` is clean.
