### PR TITLE
fix(browser): expose symbols and version on browser export

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -2,6 +2,8 @@
 
 const format = require('quick-format-unescaped')
 const Redact = require('@pinojs/redact')
+const symbols = require('./lib/symbols')
+const { version } = require('./lib/meta')
 
 module.exports = pino
 
@@ -292,6 +294,8 @@ pino.levels = {
 
 pino.stdSerializers = stdSerializers
 pino.stdTimeFunctions = Object.assign({}, { nullTime, epochTime, unixTime, isoTime })
+pino.symbols = symbols
+pino.version = version
 
 function getBindingChain (logger) {
   const bindings = []

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -118,6 +118,18 @@ test('exposes err stdSerializer', ({ end, ok }) => {
   end()
 })
 
+test('exposes symbols object', ({ end, is, same }) => {
+  is(typeof pino.symbols, 'object')
+  same(pino.symbols, require('../lib/symbols'))
+  end()
+})
+
+test('exposes version string', ({ end, is }) => {
+  is(typeof pino.version, 'string')
+  is(pino.version, require('../lib/meta').version)
+  end()
+})
+
 consoleMethodTest('error')
 consoleMethodTest('fatal', 'error')
 consoleMethodTest('warn')


### PR DESCRIPTION
## Problem

When `pino` is bundled or resolved in browser and edge worker environments (such as Cloudflare Workers, Vite, and Webpack via `package.json` `browser` field), `pino.symbols` and `pino.version` are `undefined`. This breaks consumers and utilities that inspect logger symbols or package version in isomorphic/worker runtimes.

## Root Cause

`browser.js` exposed `pino.levels`, `pino.stdSerializers`, and `pino.stdTimeFunctions`, but omitted attaching `symbols` (from `./lib/symbols`) and `version` (from `./lib/meta`) to the exported `pino` function.

## Fix

- Imported `symbols` from `./lib/symbols` and `version` from `./lib/meta` in `browser.js`.
- Assigned `pino.symbols = symbols` and `pino.version = version` alongside `pino.levels` and `pino.stdSerializers`.

## Testing

- Added unit tests in `test/browser.test.js` asserting `pino.symbols` is deeply equivalent to `./lib/symbols` and `pino.version` matches `./lib/meta.version`.
- Verified all 194 browser tests and lint pass cleanly.