### PR TITLE
feat(browser): support nestedKey in asObject mode and browser.write

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -142,6 +142,7 @@ function pino (opts) {
     levels,
     timestamp: getTimeFunction(opts),
     messageKey: opts.messageKey || 'msg',
+    nestedKey: opts.nestedKey || opts.browser.nestedKey || null,
     onChild: opts.onChild || noop,
     redactFn
   }
@@ -426,7 +427,10 @@ function asObject (logger, level, args, ts, opts) {
   if (opts.asObjectBindingsOnly) {
     if (msg !== null && typeof msg === 'object') {
       while (lvl-- && typeof argsCloned[0] === 'object') {
-        Object.assign(logObject, argsCloned.shift())
+        const target = (lvl === 0 && opts.nestedKey)
+          ? (logObject[opts.nestedKey] = logObject[opts.nestedKey] || {})
+          : logObject
+        Object.assign(target, argsCloned.shift())
       }
     }
 
@@ -439,7 +443,10 @@ function asObject (logger, level, args, ts, opts) {
     // deliberate, catching objects, arrays
     if (msg !== null && typeof msg === 'object') {
       while (lvl-- && typeof argsCloned[0] === 'object') {
-        Object.assign(logObject, argsCloned.shift())
+        const target = (lvl === 0 && opts.nestedKey)
+          ? (logObject[opts.nestedKey] = logObject[opts.nestedKey] || {})
+          : logObject
+        Object.assign(target, argsCloned.shift())
       }
       msg = argsCloned.length ? format(argsCloned.shift(), argsCloned) : undefined
     } else if (typeof msg === 'string') msg = format(argsCloned.shift(), argsCloned)

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -184,6 +184,42 @@ test('opts.browser.asObject uses opts.messageKey in logs', ({ end, ok, is }) => 
   end()
 })
 
+test('opts.nestedKey nests logged object payload under specified key in asObject mode', ({ end, is, same }) => {
+  const instance = require('../browser')({
+    nestedKey: 'payload',
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.level, 30)
+        is(o.msg, 'hello')
+        same(o.payload, { foo: 'bar', count: 42 })
+      }
+    }
+  })
+
+  instance.info({ foo: 'bar', count: 42 }, 'hello')
+  end()
+})
+
+test('opts.nestedKey with child loggers keeps bindings at top level and payload nested', ({ end, is, same }) => {
+  const instance = require('../browser')({
+    nestedKey: 'payload',
+    browser: {
+      asObject: true,
+      write: function (o) {
+        is(o.level, 30)
+        is(o.childKey, 'childVal')
+        is(o.msg, 'child message')
+        same(o.payload, { inner: 'data' })
+      }
+    }
+  })
+
+  const child = instance.child({ childKey: 'childVal' })
+  child.info({ inner: 'data' }, 'child message')
+  end()
+})
+
 test('opts.browser.asObjectBindingsOnly passes the bindings but keep the message unformatted', ({ end, ok, is, deepEqual }) => {
   const messageKey = 'message'
   const instance = require('../browser')({


### PR DESCRIPTION
## Problem

When using `pino` in browser / isomorphic environments with `browser.asObject: true` (or custom `browser.write`), the `nestedKey` configuration option was ignored. Logged payload objects were assigned directly to the top-level log object rather than nested under `nestedKey`, creating an inconsistency between Node.js and browser runtimes.

## Root Cause

- `setOpts` in `browser.js` did not store `nestedKey`.
- `asLogObject` unconditionally called `Object.assign(logObject, argsCloned.shift())` for all object arguments instead of nesting payload objects under `logObject[opts.nestedKey]` while keeping bindings at the top level.

## Fix

- Stored `nestedKey: opts.nestedKey || opts.browser.nestedKey || null` in `setOpts`.
- Updated `asLogObject` to assign payload objects (`lvl === 0`) to `logObject[opts.nestedKey]` while assigning binding objects (`lvl > 0`) to the top-level `logObject`.

## Testing

- Added unit tests in `test/browser.test.js` verifying that `nestedKey` nests payload objects under the configured key in root and child loggers.
- Verified all 198 browser tests and lint pass cleanly.