### PR TITLE
feat: add raw serializer values

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -24,6 +24,7 @@
   * [logger.version](#version)
   * [logger.msgPrefix](#msgPrefix)
 * [Statics](#statics)
+  * [pino.raw()](#pino-raw)
   * [pino.destination()](#pino-destination)
   * [pino.transport()](#pino-transport)
   * [pino.multistream()](#pino-multistream)
@@ -470,6 +471,9 @@ The serializers are applied when a property in the logged object matches a prope
 in the serializers. The only exception is the `err` serializer as it is also applied in case
 the object is an instance of `Error`, e.g. `logger.info(new Error('kaboom'))`.
 See `errorKey` option to change `err` namespace.
+
+For performance-sensitive serializers that already produce JSON, return
+[`pino.raw(json)`](#pino-raw) to write that JSON directly as the property value.
 
 * See [pino.stdSerializers](#pino-stdserializers)
 
@@ -1238,6 +1242,19 @@ Exposes the cumulative `msgPrefix` of the logger.
 * See [`options.msgPrefix`](#options-msgPrefix)
 
 ## Statics
+
+<a id="pino-raw"></a>
+### `pino.raw(value) => RawJSON`
+
+Wraps a pre-serialized JSON string so a serializer can write it directly into
+the log output.
+
+* `value` (String): a valid JSON string.
+* Returns: an opaque marker object to return from a serializer.
+
+Pino does not validate the string. Invalid JSON will corrupt the log line.
+Values returned through `pino.raw()` bypass Pino's redaction, so apply any
+redaction inside the serializer before returning raw JSON.
 
 <a id="pino-destination"></a>
 ### `pino.destination([opts]) => SonicBoom`

--- a/lib/raw.js
+++ b/lib/raw.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const rawJSONSym = Symbol('pino.rawJSON')
+
+function raw (value) {
+  if (typeof value !== 'string') {
+    throw new TypeError(`pino.raw() expects a pre-serialized JSON string, received ${typeof value}`)
+  }
+
+  return { [rawJSONSym]: value }
+}
+
+module.exports = {
+  raw,
+  rawJSONSym
+}

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -27,6 +27,7 @@ const {
 } = require('./symbols')
 const { isMainThread } = require('worker_threads')
 const transport = require('./transport')
+const { rawJSONSym } = require('./raw')
 const [nodeMajor] = process.versions.node.split('.').map(v => Number(v))
 
 const asJsonChan = diagChan.tracingChannel('pino_asJson')
@@ -373,6 +374,10 @@ function createArgsNormalizer (defaultOptions) {
 }
 
 function stringify (obj, stringifySafeFn) {
+  if (obj !== null && typeof obj === 'object' && Object.prototype.hasOwnProperty.call(obj, rawJSONSym)) {
+    return obj[rawJSONSym]
+  }
+
   try {
     return JSON.stringify(obj)
   } catch (_) {

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -26,6 +26,7 @@ declare namespace pino {
     type TimeFn = () => string
     type MixinFn<CustomLevels extends string = never> = (mergeObject: object, level: number, logger:Logger<CustomLevels>) => object
     type MixinMergeStrategyFn = (mergeObject: object, mixinObject: object) => object
+    const rawJSONSym: unique symbol
 
     type CustomLevelLogger<CustomLevels extends string, UseOnlyCustomLevels extends boolean = boolean> = {
       /**
@@ -837,6 +838,23 @@ declare namespace pino {
     }
 
     /// Exported functions
+
+    /**
+     * Opaque marker for a pre-serialized JSON value.
+     */
+    export interface RawJSON {
+      readonly [rawJSONSym]: string;
+    }
+
+    /**
+     * Wraps a pre-serialized JSON string so a serializer can write it directly
+     * into the log output.
+     *
+     * The caller is responsible for providing valid JSON.
+     *
+     * @param value A valid JSON string.
+     */
+    export function raw (value: string): RawJSON
 
     /**
      * Create a Pino Destination instance: a stream-like object with significantly more throughput (over 30%) than a standard Node.js stream.

--- a/pino.js
+++ b/pino.js
@@ -46,6 +46,7 @@ const {
   msgPrefixSym,
   transportUsesMultistreamSym
 } = symbols
+const { raw } = require('./lib/raw')
 const { epochTime, nullTime } = time
 const { pid } = process
 const hostname = os.hostname()
@@ -253,6 +254,7 @@ module.exports.stdSerializers = serializers
 module.exports.stdTimeFunctions = Object.assign({}, time)
 module.exports.symbols = symbols
 module.exports.version = version
+module.exports.raw = raw
 
 // Enables default and name export with TypeScript and Babel
 module.exports.default = pino

--- a/test/serializers.test.js
+++ b/test/serializers.test.js
@@ -255,3 +255,53 @@ test('custom serializer for messageKey', async () => {
   const { msg } = await once(stream, 'data')
   assert.equal(msg, '422')
 })
+
+test('pino.raw() injects raw JSON object from serializer', async () => {
+  const stream = sink()
+  const instance = pino({
+    serializers: {
+      headers: () => pino.raw('{"host":"example.com","accept":"*/*"}')
+    }
+  }, stream)
+
+  instance.info({ headers: ['host', 'example.com'] })
+  const o = await once(stream, 'data')
+
+  assert.equal(o.headers.host, 'example.com')
+  assert.equal(o.headers.accept, '*/*')
+})
+
+test('pino.raw() injects raw JSON string from serializer', async () => {
+  const stream = sink()
+  const instance = pino({
+    serializers: {
+      data: () => pino.raw('"already-a-json-string"')
+    }
+  }, stream)
+
+  instance.info({ data: 'original' })
+  const o = await once(stream, 'data')
+
+  assert.equal(o.data, 'already-a-json-string')
+})
+
+test('pino.raw() works in child logger bindings', async () => {
+  const stream = sink()
+  const parent = pino({
+    serializers: {
+      headers: () => pino.raw('{"x-req-id":"abc123"}')
+    }
+  }, stream)
+  const child = parent.child({ headers: { 'x-req-id': 'abc123' } })
+
+  child.info('test')
+  const o = await once(stream, 'data')
+
+  assert.equal(o.headers['x-req-id'], 'abc123')
+})
+
+test('pino.raw() throws on non-string argument', async () => {
+  assert.throws(() => pino.raw(42), TypeError)
+  assert.throws(() => pino.raw({}), TypeError)
+  assert.throws(() => pino.raw(null), TypeError)
+})

--- a/test/types/pino-top-export.tst.ts
+++ b/test/types/pino-top-export.tst.ts
@@ -9,6 +9,8 @@ import {
   levels,
   multistream,
   type MultiStreamRes,
+  raw,
+  type RawJSON,
   type SerializedError,
   stdSerializers,
   stdTimeFunctions,
@@ -19,6 +21,7 @@ import {
 expect(destination('')).type.toBe<SonicBoom>()
 expect(levels).type.toBe<LevelMapping>()
 expect(multistream(process.stdout)).type.toBe<MultiStreamRes>()
+expect(raw('{"key":"value"}')).type.toBe<RawJSON>()
 expect(stdSerializers.err({} as Error)).type.toBe<SerializedError>()
 expect(stdTimeFunctions.isoTime()).type.toBe<string>()
 expect(stdTimeFunctions.isoTimeNano()).type.toBe<string>()

--- a/test/types/pino.tst.ts
+++ b/test/types/pino.tst.ts
@@ -615,6 +615,17 @@ parentLogger2.onChild = (child) => {
   expect(child).type.not.toHaveProperty('doesntExist')
 }
 
+const rawValue = pino.raw('{"key":"value"}')
+expect(rawValue).type.toBe<pino.RawJSON>()
+expect(pino.raw).type.toBeCallableWith('{"key":"value"}')
+expect(pino.raw).type.not.toBeCallableWith({ key: 'value' })
+
+pino({
+  serializers: {
+    headers: (value): pino.RawJSON => pino.raw(JSON.stringify(value))
+  }
+})
+
 const childLogger2 = parentLogger2.child({})
 expect(childLogger2).type.not.toHaveProperty('doesntExist')
 


### PR DESCRIPTION
## Summary

  Adds `pino.raw(value)` so serializers can return pre-serialized JSON values without Pino stringifying them again.

  This is intended for performance-sensitive serializers that already produce valid JSON.

  ## Example

  ```js
  const logger = pino({
    serializers: {
      details (value) {
        return pino.raw(JSON.stringify(value))
      }
    }
})

logger.info({ details: { answer: 42 } })
```

  Produces details as an object value in the log line, not as an escaped JSON string.

  ## Notes

`pino.raw()` accepts only strings and returns an opaque marker object.

Pino does not validate the string passed to pino.raw(). Invalid JSON will corrupt the log line. Values returned through `pino.raw()` bypass Pino's redaction, so callers should apply any needed redaction inside the serializer before returning raw JSON.

  ## Tests

- Added serializer tests for raw object JSON, raw string JSON, child logger bindings, and invalid arguments.
- Added type tests for pino.raw() and pino.RawJSON.

```sh
node --test test/serializers.test.js
```

## References

- Refs #1846.
- Follows up on #2393.