### PR TITLE
types: declare caller option on TransportBaseOptions

### DIFF
--- a/pino.d.ts
+++ b/pino.d.ts
@@ -256,6 +256,7 @@ declare namespace pino {
     export interface TransportBaseOptions<TransportOptions = Record<string, any>> {
       options?: TransportOptions
       worker?: WorkerOptions & { autoEnd?: boolean }
+      caller?: string | string[]
     }
 
     export interface TransportSingleOptions<TransportOptions = Record<string, any>> extends TransportBaseOptions<TransportOptions> {

--- a/test/types/pino-transport.tst.ts
+++ b/test/types/pino-transport.tst.ts
@@ -98,6 +98,42 @@ const transportsWithoutOptions = pino.transport({
 pino(transportsWithoutOptions)
 
 expect(
+  pino.transport({
+    target: '#pino/pretty',
+    caller: '/path/to/caller.js'
+  })
+).type.toBe<ReturnType<typeof pino.transport>>()
+
+expect(
+  pino.transport({
+    targets: [
+      { target: '#pino/pretty' }
+    ],
+    caller: ['/path/to/caller.js']
+  })
+).type.toBe<ReturnType<typeof pino.transport>>()
+
+expect(
+  pino({
+    transport: {
+      target: 'pino-pretty',
+      caller: '/path/to/caller.js'
+    }
+  })
+).type.toBe<pino.Logger>()
+
+expect(
+  pino({
+    transport: {
+      targets: [
+        { target: '#pino/pretty' }
+      ],
+      caller: ['/path/to/caller.js']
+    }
+  })
+).type.toBe<pino.Logger>()
+
+expect(
   pino({
     transport: {
       targets: [


### PR DESCRIPTION
## Problem

While `caller` is supported by `pino.transport` and documented in `docs/api.md` for framework integrations requiring custom caller resolution, passing `caller` to `pino.transport(...)` or `pino({ transport: { caller: ... } })` resulted in a TypeScript compilation error because `caller` was omitted from `TransportBaseOptions` in `pino.d.ts`.

## Cause

`TransportBaseOptions` declared `options` and `worker` properties, but did not declare `caller?: string | string[]`, causing TypeScript to reject object literals containing `caller` due to excess property checks on `TransportSingleOptions`, `TransportMultiOptions`, and `TransportPipelineOptions`.

## Fix

- Added `caller?: string | string[]` to `pino.TransportBaseOptions` in `pino.d.ts`.

## Testing

- Added type assertions in `test/types/pino-transport.tst.ts` covering `pino.transport` with single and multiple targets as well as `pino({ transport: { ... } })` with string and string array `caller` options.
- Verified `npm run test-types` passes cleanly across all targets with attw verification.