### PR TITLE
fix(browser): keep the merging object when setBindings is used on the root logger

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -336,6 +336,9 @@ function set (self, opts, rootLogger, level) {
 
   // prepend bindings if it is not the root logger
   const bindings = getBindingChain(self)
+  // asObject() has to skip exactly the bindings prepended here before it
+  // reaches the caller's own merging object, so record how many that is
+  self._bindingsDepth = bindings.length
   if (bindings.length === 0) {
     // early exit in case for rootLogger
     return
@@ -409,7 +412,7 @@ function asObject (logger, level, args, ts, opts) {
   let msg = argsCloned[0]
   const logObject = {}
 
-  let lvl = (logger._childLevel | 0) + 1
+  let lvl = (logger._bindingsDepth | 0) + 1
   if (lvl < 1) lvl = 1
 
   if (ts) {

--- a/test/browser-set-bindings.test.js
+++ b/test/browser-set-bindings.test.js
@@ -97,3 +97,59 @@ test('setBindings bindings are transmitted', ({ end, same }) => {
   instance.info('test')
   end()
 })
+
+function collect (opts) {
+  let logged
+  const instance = pino(Object.assign({
+    browser: { asObject: true, write (o) { logged = o } }
+  }, opts))
+  return { instance, get: () => logged }
+}
+
+test('setBindings keeps the merging object of subsequent log calls', ({ end, is }) => {
+  const { instance, get } = collect()
+
+  instance.setBindings({ answer: 42 })
+  instance.info({ a: 1 }, 'test')
+
+  is(get().answer, 42)
+  is(get().a, 1)
+  is(get().msg, 'test')
+  end()
+})
+
+test('setBindings keeps the merging object for child loggers', ({ end, is }) => {
+  const { instance, get } = collect()
+
+  instance.setBindings({ answer: 42 })
+  instance.child({ child: true }).info({ a: 1 }, 'test')
+
+  is(get().answer, 42)
+  is(get().child, true)
+  is(get().a, 1)
+  is(get().msg, 'test')
+  end()
+})
+
+test('setBindings keeps format arguments of subsequent log calls', ({ end, is }) => {
+  const { instance, get } = collect()
+
+  instance.setBindings({ answer: 42 })
+  instance.info({ a: 1 }, 'hello %s', 'world')
+
+  is(get().a, 1)
+  is(get().msg, 'hello world')
+  end()
+})
+
+test('setBindings still merges only one object of subsequent log calls', ({ end, is, same }) => {
+  const { instance, get } = collect()
+
+  instance.setBindings({ answer: 42 })
+  instance.info({ a: 1 }, { b: 2 })
+
+  is(get().a, 1)
+  is(get().b, undefined)
+  same(get().msg, { b: 2 })
+  end()
+})

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -531,7 +531,7 @@ test('opts.browser.asObject defensively mitigates naughty numbers', ({ end, pass
     browser: { asObject: true, write: () => {} }
   })
   const child = instance.child({ test: 'test' })
-  child._childLevel = -10
+  child._bindingsDepth = -10
   child.info('test')
   pass() // if we reached here, there was no infinite loop, so, .. pass.
 


### PR DESCRIPTION
`setBindings()` on the **root** browser logger destroys the merging object of every later call:

```js
const logger = pino({ browser: { asObject: true, write: console.log } })
logger.setBindings({ requestId: 'abc' })
logger.info({ userId: 42 }, 'order placed')
// browser: { level: 30, requestId: 'abc', msg: '{"userId":42} ' }
// node:    { level: 30, requestId: 'abc', userId: 42, msg: 'order placed' }
```

The fields and the message are both lost. `asObject()` takes the number of prepended bindings from `_childLevel`, but they are prepended from `getBindingChain()`, which also counts the logger's own bindings. Before #2471 only children had bindings, so the two agreed by accident. Children created after the `setBindings()` call are affected too.

So the fix records the length of the chain `set()` actually prepends. Recomputing `getBindingChain()` inside `asObject()` looks equivalent but isn't: the chain is captured in a closure, so a child created *before* `setBindings()` would over-merge and swallow a second object argument.

Not fixed here, and I'd rather ask than guess. `setBindings()` pushes `newBindings` into `_logEvent.bindings` while storing a different merged object, so `transmit`'s reference filter misses it and those bindings also appear in `logEvent.messages`. What that array should hold for a root logger isn't obvious to me.

All six existing `browser-set-bindings` tests log with a string first argument, which is why this was invisible. Added four object-first cases; all four fail with the `browser.js` change reverted. The naughty-numbers guard test is re-pointed at the field the loop now reads so it keeps guarding. `npm run test-ci` green, 381 assertions vs 369 before.
