### PR TITLE
docs: Note that serializers run on child bindings at creation time

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -471,6 +471,13 @@ in the serializers. The only exception is the `err` serializer as it is also app
 the object is an instance of `Error`, e.g. `logger.info(new Error('kaboom'))`.
 See `errorKey` option to change `err` namespace.
 
+Serializers are also applied to the [bindings passed to `logger.child()`](#logger-child-bindings).
+Child bindings are serialized once, when the child logger is created, so a matching
+serializer runs at that point rather than on every subsequent log call. This is
+deliberate: it allows a child logger to precompute its bindings and stay fast at log
+time. If a serializer needs to run per log call, pass the value to the log method
+instead of to `child()`.
+
 * See [pino.stdSerializers](#pino-stdserializers)
 
 #### `msgPrefix` (String)


### PR DESCRIPTION
Closes #679

## What

`#679` reported that a global serializer fires when `logger.child()` is called rather than on each log call. The conclusion in that thread was that the behaviour is intentional — [@mcollina](https://github.com/mcollina): *"We added this to make child logger extremely fast"* — and that the real fix is documentation ([@jsumners](https://github.com/jsumners): *"No real solution other than to document the behavior"*).

This documents it. Still accurate on `main` today: [`asChindings()`](https://github.com/pinojs/pino/blob/main/lib/tools.js) applies `serializers[key](value)` while building the child's precomputed chindings string, so a serializer keyed to a child binding runs exactly once, at child creation.

The note is added to the [`serializers` option](https://github.com/pinojs/pino/blob/main/docs/api.md#opt-serializers) section, explains *why* the behaviour exists rather than just stating it, and tells readers what to do instead when they need per-call serialization.

## Notes

- Docs only — no code, no test or coverage impact.
- The one link added resolves to the existing `#logger-child-bindings` anchor, matching how that section is referenced elsewhere in `api.md`.
- Happy to reword if you'd rather it live in the `logger.child()` section instead, or in addition.
