### PR TITLE
fix logging edge cases

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -218,7 +218,9 @@ function pino (opts) {
         ? Object.keys(childSerializers)
         : serialize
       delete bindings.serializers
-      applySerializers([bindings], childSerialize, childSerializers, this._stdErrSerialize)
+      const serializedBindings = [bindings]
+      applySerializers(serializedBindings, childSerialize, childSerializers, this._stdErrSerialize)
+      bindings = serializedBindings[0]
     }
     function Child (parent) {
       this._childLevel = (parent._childLevel | 0) + 1
@@ -359,7 +361,7 @@ function createWrap (self, opts, rootLogger, level) {
 
       var argsIsSerialized = false
       if (opts.serialize) {
-        applySerializers(args, this._serialize, this.serializers, this._stdErrSerialize)
+        applySerializers(args, this._serialize, this.serializers, this._stdErrSerialize, this._logEvent)
         argsIsSerialized = true
       }
       if (opts.asObject || opts.formatters) {
@@ -453,14 +455,23 @@ function asObject (logger, level, args, ts, opts) {
   }
 }
 
-function applySerializers (args, serialize, serializers, stdErrSerialize) {
+function applySerializers (args, serialize, serializers, stdErrSerialize, logEvent) {
   for (const i in args) {
     if (stdErrSerialize && args[i] instanceof Error) {
       args[i] = pino.stdSerializers.err(args[i])
     } else if (typeof args[i] === 'object' && !Array.isArray(args[i]) && serialize) {
-      for (const k in args[i]) {
+      const original = args[i]
+      let cloned
+      for (const k in original) {
         if (serialize.indexOf(k) > -1 && k in serializers) {
-          args[i][k] = serializers[k](args[i][k])
+          if (!cloned) {
+            args[i] = cloned = { ...original }
+            if (logEvent) {
+              const bindingIndex = logEvent.bindings.indexOf(original)
+              if (bindingIndex !== -1) logEvent.bindings[bindingIndex] = cloned
+            }
+          }
+          cloned[k] = serializers[k](cloned[k])
         }
       }
     }
@@ -480,7 +491,8 @@ function transmit (logger, opts, args, argsIsSerialized = false) {
       args,
       logger._serialize || Object.keys(logger.serializers),
       logger.serializers,
-      logger._stdErrSerialize === undefined ? true : logger._stdErrSerialize
+      logger._stdErrSerialize === undefined ? true : logger._stdErrSerialize,
+      logger._logEvent
     )
   }
 

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -24,6 +24,7 @@ const stringifiersSym = Symbol('pino.stringifiers')
 const endSym = Symbol('pino.end')
 const formatOptsSym = Symbol('pino.formatOpts')
 const messageKeySym = Symbol('pino.messageKey')
+const messageKeyStrSym = Symbol('pino.messageKeyStr')
 const errorKeySym = Symbol('pino.errorKey')
 const nestedKeySym = Symbol('pino.nestedKey')
 const nestedKeyStrSym = Symbol('pino.nestedKeyStr')
@@ -62,6 +63,7 @@ module.exports = {
   endSym,
   formatOptsSym,
   messageKeySym,
+  messageKeyStrSym,
   errorKeySym,
   nestedKeySym,
   wildcardFirstSym,

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -21,6 +21,7 @@ const {
   nestedKeySym,
   formattersSym,
   messageKeySym,
+  messageKeyStrSym,
   errorKeySym,
   nestedKeyStrSym,
   msgPrefixSym
@@ -201,6 +202,7 @@ function _asJson (obj, msg, num, time) {
 
   let msgStr = ''
   if (msg !== undefined) {
+    const strMessageKey = this[messageKeyStrSym]
     value = serializers[messageKey] ? serializers[messageKey](msg) : msg
     const stringifier = stringifiers[messageKey] || wildcardStringifier
 
@@ -214,15 +216,15 @@ function _asJson (obj, msg, num, time) {
       // this case explicitly falls through to the next one
       case 'boolean':
         if (stringifier) value = stringifier(value)
-        msgStr = ',"' + messageKey + '":' + value
+        msgStr = ',' + strMessageKey + ':' + value
         break
       case 'string':
         value = (stringifier || asString)(value)
-        msgStr = ',"' + messageKey + '":' + value
+        msgStr = ',' + strMessageKey + ':' + value
         break
       default:
         value = (stringifier || stringify)(value, stringifySafe)
-        msgStr = ',"' + messageKey + '":' + value
+        msgStr = ',' + strMessageKey + ':' + value
     }
   }
 
@@ -252,7 +254,7 @@ function asChindings (instance, bindings) {
       key !== 'serializers' &&
       key !== 'formatters' &&
       key !== 'customLevels')) &&
-      bindings.hasOwnProperty(key) &&
+      Object.prototype.hasOwnProperty.call(bindings, key) &&
       value !== undefined
     if (valid === true) {
       value = serializers[key] ? serializers[key](value) : value

--- a/pino.js
+++ b/pino.js
@@ -34,6 +34,7 @@ const {
   endSym,
   formatOptsSym,
   messageKeySym,
+  messageKeyStrSym,
   errorKeySym,
   nestedKeySym,
   mixinSym,
@@ -169,11 +170,11 @@ function pino (...args) {
   const levels = mappings(customLevels, useOnlyCustomLevels)
 
   if (stream && stream[transportUsesMultistreamSym] === true) {
-    let sampleLabel = typeof level === 'string' ? level : undefined
-    if (!sampleLabel || levels[sampleLabel] === undefined) {
-      sampleLabel = Object.keys(levels)[0]
+    let sampleLabel = typeof level === 'string' ? level : levels.labels[level]
+    if (!sampleLabel || levels.values[sampleLabel] === undefined) {
+      sampleLabel = Object.keys(levels.values)[0]
     }
-    const sampleNumber = levels[sampleLabel]
+    const sampleNumber = levels.values[sampleLabel]
     let ok = false
     try {
       const formatted = formatters.level(sampleLabel, sampleNumber)
@@ -210,6 +211,7 @@ function pino (...args) {
     [endSym]: end,
     [formatOptsSym]: formatOpts,
     [messageKeySym]: messageKey,
+    [messageKeyStrSym]: JSON.stringify(messageKey),
     [errorKeySym]: errorKey,
     [nestedKeySym]: nestedKey,
     // protect against injection

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -916,6 +916,14 @@ test('logs child bindings with an own enumerable __proto__ key', async () => {
   assert.equal(result.reqId, 'abc')
 })
 
+test('logs child bindings with a hasOwnProperty key', async () => {
+  const stream = sink()
+  const instance = pino(stream).child({ hasOwnProperty: 'value' })
+  instance.info('incoming request')
+  const result = await once(stream, 'data')
+  assert.equal(result.hasOwnProperty, 'value')
+})
+
 test('logs an object with keys named after Object.prototype members', async () => {
   const stream = sink()
   const instance = pino(stream)

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -184,6 +184,25 @@ test('opts.browser.asObject uses opts.messageKey in logs', ({ end, ok, is }) => 
   end()
 })
 
+test('opts.browser.serialize does not mutate logged objects', ({ end, deepEqual }) => {
+  const input = { payload: { secret: 'value' } }
+  const original = input.payload
+  const instance = require('../browser')({
+    serializers: {
+      payload: () => ({ redacted: true })
+    },
+    browser: {
+      serialize: ['payload'],
+      write: function () {}
+    }
+  })
+
+  instance.info(input)
+  deepEqual(input, { payload: { secret: 'value' } })
+  deepEqual(input.payload, original)
+  end()
+})
+
 test('opts.browser.asObjectBindingsOnly passes the bindings but keep the message unformatted', ({ end, ok, is, deepEqual }) => {
   const messageKey = 'message'
   const instance = require('../browser')({

--- a/test/escaping.test.js
+++ b/test/escaping.test.js
@@ -53,6 +53,16 @@ test('correctly escape child binding keys', async () => {
   })
 })
 
+test('correctly escape messageKey', async () => {
+  const stream = sink()
+  const key = 'x"}\n{"level":60,"msg":"forged"}\n{"swallow'
+  const instance = pino({ messageKey: key }, stream)
+
+  instance.info('hello')
+  const result = await once(stream, 'data')
+  assert.equal(result[key], 'hello')
+})
+
 const toEscape = [
   '\u0000', // NUL  Null character
   '\u0001', // SOH  Start of Heading

--- a/test/transport/core.test.js
+++ b/test/transport/core.test.js
@@ -581,6 +581,65 @@ test('warns when custom formatters.level is incompatible with multi-target trans
   assert.equal(warnings[0].options.code, 'PINO_TRANSPORT_MULTI_TARGETS_LEVEL_FORMATTER')
 })
 
+test('does not warn for a compatible formatter for the configured level', async (t) => {
+  const warnings = []
+  const originalEmitWarning = process.emitWarning
+  process.emitWarning = function (warning, options) {
+    warnings.push({ warning, options })
+  }
+  t.after(() => {
+    process.emitWarning = originalEmitWarning
+  })
+
+  const transport = pino.transport({
+    targets: [
+      { target: join(__dirname, '..', 'fixtures', 'noop-transport.js') },
+      { target: join(__dirname, '..', 'fixtures', 'noop-transport.js') }
+    ]
+  })
+  t.after(transport.end.bind(transport))
+
+  pino({
+    formatters: {
+      level (label, number) {
+        return label === 'info' ? { level: number } : {}
+      }
+    }
+  }, transport)
+
+  assert.equal(warnings.length, 0)
+})
+
+test('warns when a formatter drops the configured level field', async (t) => {
+  const warnings = []
+  const originalEmitWarning = process.emitWarning
+  process.emitWarning = function (warning, options) {
+    warnings.push({ warning, options })
+  }
+  t.after(() => {
+    process.emitWarning = originalEmitWarning
+  })
+
+  const transport = pino.transport({
+    targets: [
+      { target: join(__dirname, '..', 'fixtures', 'noop-transport.js') },
+      { target: join(__dirname, '..', 'fixtures', 'noop-transport.js') }
+    ]
+  })
+  t.after(transport.end.bind(transport))
+
+  pino({
+    formatters: {
+      level (label, number) {
+        return label === 'labels' ? { level: number } : { severity: label }
+      }
+    }
+  }, transport)
+
+  assert.equal(warnings.length, 1)
+  assert.equal(warnings[0].options.code, 'PINO_TRANSPORT_MULTI_TARGETS_LEVEL_FORMATTER')
+})
+
 test('stdout in worker', async () => {
   let actual = ''
   const child = execa(process.argv[0], [join(__dirname, '..', 'fixtures', 'transport-main.js')])


### PR DESCRIPTION
## Summary

Fix several logging edge cases affecting JSON output, child bindings, transport level validation, and browser serializers.

## Changes

- Escape custom `messageKey` values to keep emitted logs valid JSON.
- Support child bindings named `hasOwnProperty` and null-prototype objects.
- Correct multi-target transport formatter validation to use the configured level mappings.
- Prevent browser serializers from mutating caller-owned log objects.
- Add regression tests for all fixes.

## Tests

- `npm run lint`
- `npm run test-types`
- Core and transport tests
- Browser and browser transmit tests
- Jest tests
- Eight-million-line stress test

All targeted tests passed.