### PR TITLE
fix message key escaping

### DIFF
--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -24,6 +24,7 @@ const stringifiersSym = Symbol('pino.stringifiers')
 const endSym = Symbol('pino.end')
 const formatOptsSym = Symbol('pino.formatOpts')
 const messageKeySym = Symbol('pino.messageKey')
+const messageKeyStrSym = Symbol('pino.messageKeyStr')
 const errorKeySym = Symbol('pino.errorKey')
 const nestedKeySym = Symbol('pino.nestedKey')
 const nestedKeyStrSym = Symbol('pino.nestedKeyStr')
@@ -62,6 +63,7 @@ module.exports = {
   endSym,
   formatOptsSym,
   messageKeySym,
+  messageKeyStrSym,
   errorKeySym,
   nestedKeySym,
   wildcardFirstSym,

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -21,6 +21,7 @@ const {
   nestedKeySym,
   formattersSym,
   messageKeySym,
+  messageKeyStrSym,
   errorKeySym,
   nestedKeyStrSym,
   msgPrefixSym
@@ -201,6 +202,7 @@ function _asJson (obj, msg, num, time) {
 
   let msgStr = ''
   if (msg !== undefined) {
+    const strMessageKey = this[messageKeyStrSym]
     value = serializers[messageKey] ? serializers[messageKey](msg) : msg
     const stringifier = stringifiers[messageKey] || wildcardStringifier
 
@@ -214,15 +216,15 @@ function _asJson (obj, msg, num, time) {
       // this case explicitly falls through to the next one
       case 'boolean':
         if (stringifier) value = stringifier(value)
-        msgStr = ',"' + messageKey + '":' + value
+        msgStr = ',' + strMessageKey + ':' + value
         break
       case 'string':
         value = (stringifier || asString)(value)
-        msgStr = ',"' + messageKey + '":' + value
+        msgStr = ',' + strMessageKey + ':' + value
         break
       default:
         value = (stringifier || stringify)(value, stringifySafe)
-        msgStr = ',"' + messageKey + '":' + value
+        msgStr = ',' + strMessageKey + ':' + value
     }
   }
 

--- a/pino.js
+++ b/pino.js
@@ -34,6 +34,7 @@ const {
   endSym,
   formatOptsSym,
   messageKeySym,
+  messageKeyStrSym,
   errorKeySym,
   nestedKeySym,
   mixinSym,
@@ -210,6 +211,7 @@ function pino (...args) {
     [endSym]: end,
     [formatOptsSym]: formatOpts,
     [messageKeySym]: messageKey,
+    [messageKeyStrSym]: JSON.stringify(messageKey),
     [errorKeySym]: errorKey,
     [nestedKeySym]: nestedKey,
     // protect against injection

--- a/test/escaping.test.js
+++ b/test/escaping.test.js
@@ -53,6 +53,16 @@ test('correctly escape child binding keys', async () => {
   })
 })
 
+test('correctly escape messageKey', async () => {
+  const stream = sink()
+  const key = 'x"}\n{"level":60,"msg":"forged"}\n{"swallow'
+  const instance = pino({ messageKey: key }, stream)
+
+  instance.info('hello')
+  const result = await once(stream, 'data')
+  assert.equal(result[key], 'hello')
+})
+
 const toEscape = [
   '\u0000', // NUL  Null character
   '\u0001', // SOH  Start of Heading


### PR DESCRIPTION
## Summary

Escape custom `messageKey` values to ensure emitted log records remain valid JSON.

## Changes

- Precompute the escaped message key for each logger instance.
- Prevent malformed output and log injection when `messageKey` contains quotes or control characters.
- Add a regression test covering malicious key content.

## Tests

- `npm run lint`
- `node --test test/escaping.test.js`