### PR TITLE
docs: document the APIs that are unavailable in the browser

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1093,6 +1093,9 @@ If there is a need to wait for the logs to be flushed, a callback should be used
 **Note:** `flush()` does not work when using `pino-pretty`. See
 [Flush Limitations with `pino-pretty`](/docs/asynchronous.md) for more details.
 
+**Note:** in the browser this method is a no-op and `cb` is never invoked. See
+[Node.js-only APIs](/docs/browser.md#nodejs-only-apis).
+
 * See [`destination` parameter](#destination)
 * See [Asynchronous Logging ⇗](./asynchronous.md)
 
@@ -1190,6 +1193,10 @@ register its own serializer upon instantiation the serializers of the parent wil
 
 The logger instance is also an [`EventEmitter ⇗`](https://nodejs.org/dist/latest/docs/api/events.html#events_class_eventemitter)
 
+**Note:** the `EventEmitter` methods are no-ops in the browser, so this event
+never fires there. See
+[Node.js-only APIs](/docs/browser.md#nodejs-only-apis).
+
 A listener function can be attached to a logger via the `level-change` event
 
 The listener is passed five arguments:
@@ -1245,6 +1252,8 @@ Exposes the cumulative `msgPrefix` of the logger.
 Create a Pino Destination instance: a stream-like object with
 significantly more throughput than a standard Node.js stream.
 
+**Note:** this is not available in the browser build. See [Node.js-only APIs](/docs/browser.md#nodejs-only-apis).
+
 ```js
 const pino = require('pino')
 const logger = pino(pino.destination('./my-file'))
@@ -1278,6 +1287,8 @@ A `pino.destination` instance can also be used to reopen closed files
 
 Create a stream that routes logs to a worker thread that
 wraps around a [Pino Transport](/docs/transports.md).
+
+**Note:** this is not available in the browser build. See [Node.js-only APIs](/docs/browser.md#nodejs-only-apis).
 
 ```js
 const pino = require('pino')
@@ -1398,6 +1409,8 @@ Notes:
 
 Create a stream composed by multiple destination streams and returns an
 object implementing the [MultiStreamRes](#multistreamres) interface.
+
+**Note:** this is not available in the browser build. See [Node.js-only APIs](/docs/browser.md#nodejs-only-apis).
 
 ```js
 var fs = require('node:fs')

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -7,6 +7,69 @@ This can be useful with isomorphic/universal JavaScript code.
 By default, in the browser,
 `pino` uses corresponding [Log4j](https://en.wikipedia.org/wiki/Log4j) `console` methods (`console.error`, `console.warn`, `console.info`, `console.debug`, `console.trace`) and uses `console.error` for any `fatal` level logs.
 
+<a id="nodejs-only-apis"></a>
+## Node.js-only APIs
+
+The browser build (`browser.js`, selected through the `browser` field in
+`package.json`) does not implement the parts of the API that depend on the file
+system or on worker threads. Accessing them in the browser throws a
+`TypeError`, because the export is simply absent:
+
+```js
+const pino = require('pino')
+pino.destination('./my-file') // TypeError: pino.destination is not a function
+```
+
+The following statics are available in Node.js only:
+
+| Static | Why it is Node.js only |
+| --- | --- |
+| [`pino.destination()`](/docs/api.md#pino-destination) | Returns a [`SonicBoom`](https://github.com/pinojs/sonic-boom) instance writing to a file descriptor. |
+| [`pino.transport()`](/docs/api.md#pino-transport) | Runs a [transport](/docs/transports.md) on a worker thread. |
+| [`pino.multistream()`](/docs/api.md#pino-multistream) | Fans out to multiple destination streams. |
+
+`pino.levels`, `pino.stdSerializers` and `pino.stdTimeFunctions` are available in
+both environments.
+
+### Methods that are no-ops in the browser
+
+These exist on a browser logger, so calling them is safe, but they do nothing:
+
+* [`logger.flush([cb])`](/docs/api.md#flush) — there is no write buffer
+  to flush. Note that a callback passed to it is **not** invoked.
+* Every `EventEmitter` method (`on`, `once`, `emit`, `removeListener`,
+  `listeners`, ...). As a consequence the
+  [`level-change`](/docs/api.md#level-change) event never fires in the
+  browser.
+
+### Writing isomorphic code
+
+Code shared between a server and a browser bundle should not call the Node.js
+only statics unconditionally. Guard the call rather than the environment, so the
+same branch works under any bundler:
+
+```js
+const pino = require('pino')
+
+const logger = pino.destination
+  ? pino(pino.destination('./my-file')) // Node.js
+  : pino({ browser: { asObject: true } }) // browser
+```
+
+Note that the browser build's `pino()` accepts the options object only. A second
+`destination` argument is accepted but ignored, so a logger constructed with one
+still writes to the console rather than failing:
+
+```js
+// in the browser the second argument is ignored, not honoured
+const logger = pino({ level: 'info' }, someDestination)
+logger.info('still goes to the console')
+```
+
+Assigning a no-op shim onto the `pino` export (`pino.destination = () => {}`)
+works too, but it mutates a module object shared with every other importer in the
+bundle; guarding the call site keeps the change local.
+
 ## Options
 
 Pino can be passed a `browser` object in the options object,


### PR DESCRIPTION
Fixes #2032.

`pino.destination()`, `pino.transport()` and `pino.multistream()` are not part of the browser build, so calling them in the browser throws:

```
TypeError: pino.destination is not a function
```

Neither `docs/browser.md` nor the API reference mentioned this, so the failure reads as a bundler problem rather than an intentional limit. That was the substance of #2032, where you replied:

> I think having a no-op would be problematic, but this certainly needs documenting. Would you like to open a PR?

The reporter never opened one, so here it is. Documentation only — no source changes, and no no-op shim, per your comment.

## What this adds

A **Node.js-only APIs** section in `docs/browser.md` covering:

- the three statics that are absent from the browser build, and why;
- that `pino.levels`, `pino.stdSerializers` and `pino.stdTimeFunctions` *are* available in both;
- two behaviours that were also undocumented — `logger.flush()` is a no-op whose callback is never invoked, and the `EventEmitter` methods are no-ops, so `level-change` never fires in the browser;
- guidance for isomorphic code, including that the browser `pino()` takes the options object only and silently ignores a second `destination` argument.

Plus five cross-references in `docs/api.md`, on `pino.destination()`, `pino.transport()`, `pino.multistream()`, `logger.flush([cb])` and `Event: 'level-change'`.

## Verification

Every claim was checked by running `browser.js` against `pino.js` rather than read off the source:

| Claim | Result |
| --- | --- |
| `destination` / `transport` / `multistream` absent in browser, present in Node | confirmed |
| `levels` / `stdSerializers` / `stdTimeFunctions` present in both | confirmed |
| browser `pino.destination()` throws `TypeError` | confirmed |
| browser `flush()` exists, callback never invoked (sync or after a tick) | confirmed |
| `level-change` never fires in browser | confirmed |
| `level-change` does fire in Node | confirmed (control) |
| browser `pino()` arity is 1, second argument ignored | confirmed |

That last one corrected a draft of this PR: I had assumed the workaround in #2032 (`pino.destination = () => undefined`) would leave the logger silently discarding lines. It doesn't — the browser build ignores the second argument and logging continues to the console. The text now documents the real behaviour.

`npm run lint` passes.

## Deliberately out of scope

`pino.symbols`, `pino.version` and `logger.bindings()` are also missing from the browser build, but #2508 and #2504 are changing that. Documenting them as absent would be stale on merge, so they are left alone.

Happy to adjust the wording, drop the isomorphic-code guidance if you would rather the docs stay purely descriptive, or split the `api.md` notes into a separate PR.
